### PR TITLE
Fix docs warnings

### DIFF
--- a/docs/archinstall/general.rst
+++ b/docs/archinstall/general.rst
@@ -22,7 +22,7 @@ Locale related
 
 .. autofunction:: archinstall.search_keyboard_layout
 
-.. autofunction:: archinstall.set_keyboard_layout
+.. autofunction:: archinstall.set_keyboard_language
 
 Services
 ========
@@ -34,7 +34,7 @@ Mirrors
 
 .. autofunction:: archinstall.filter_mirrors_by_region
 
-.. autofunction:: archinstall.add_custom_mirror
+.. autofunction:: archinstall.add_custom_mirrors
 
 .. autofunction:: archinstall.insert_mirrors
 

--- a/docs/examples/binary.rst
+++ b/docs/examples/binary.rst
@@ -1,4 +1,4 @@
-.. _examples.python:
+.. _examples.binary:
 
 Binary executable
 =================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,12 +43,15 @@ Some of the features of Archinstall are:
 
    examples/python
    examples/binary
+..
    examples/scripting
 
-.. toctree::
+..
+   .. toctree::
    :maxdepth: 3
    :caption: Programming Guide
 
+..
    programming_guide/requirements
    programming_guide/basic_concept
 

--- a/docs/installing/binary.rst
+++ b/docs/installing/binary.rst
@@ -1,10 +1,10 @@
-.. _installing.binary
+.. _installing.binary:
 
 Binary executable
 =================
 
 Archinstall can be compiled into a standalone executable.
-For Arch Linux based systems, there's a package for this called `archinstall <https://archlinux.life/>`_.
+For Arch Linux based systems, there's a package for this called `archinstall <https://archlinux.org/packages/extra/any/archinstall/>`_.
 
 .. warning::
     This is not required if you're running archinstall on a pre-built ISO. The installation is only required if you're creating your own scripted installations.
@@ -37,7 +37,7 @@ Which should produce a `archinstall-X.x.z-1.pkg.tar.zst` that can be installed u
 
 .. note::
 
-    For a complete guide on the build process, please consult the wiki on `PKGBUILD <https://wiki.archlinux.org/index.php/PKGBUILD>`_.
+    For a complete guide on the build process, please consult the `PKGBUILD on ArchWiki <https://wiki.archlinux.org/index.php/PKGBUILD>`_.
 
 Manual compilation
 ------------------


### PR DESCRIPTION
## Description

Fixes warnings reported by Sphinx when building the documentation, and also make sure `archinstall.set_keyboard_language` and `archinstall.add_custom_mirrors` are properly displayed in resulting documentation.

Some notes:
- on `docs/index.rst`, I commented nonexistent doc files to disable them. Maybe should be removed instead?
- on `installing/binary.rst`, the "PKGBUILD" has two links, so I adapted the writting to avoid conflict.
- also on `installing/binary.rst`, https://archlinux.life doesn't exist, so I pointed to Arch Linux's binary package.

## Bugs and Issues

The following issues are displayed on build time:

```
WARNING: autodoc: failed to import function 'set_keyboard_layout' from module 'archinstall'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/util/inspect.py", line 393, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'archinstall' has no attribute 'set_keyboard_layout'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/ext/autodoc/importer.py", line 111, in import_object
    obj = attrgetter(obj, mangled_name)
  File "/usr/lib/python3.9/site-packages/sphinx/ext/autodoc/__init__.py", line 320, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/usr/lib/python3.9/site-packages/sphinx/ext/autodoc/__init__.py", line 2604, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/usr/lib/python3.9/site-packages/sphinx/util/inspect.py", line 409, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: set_keyboard_layout

WARNING: autodoc: failed to import function 'add_custom_mirror' from module 'archinstall'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/util/inspect.py", line 393, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'archinstall' has no attribute 'add_custom_mirror'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/ext/autodoc/importer.py", line 111, in import_object
    obj = attrgetter(obj, mangled_name)
  File "/usr/lib/python3.9/site-packages/sphinx/ext/autodoc/__init__.py", line 320, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/usr/lib/python3.9/site-packages/sphinx/ext/autodoc/__init__.py", line 2604, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/usr/lib/python3.9/site-packages/sphinx/util/inspect.py", line 409, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: add_custom_mirror

/home/rafael/repos/archinstall/docs/examples/python.rst:4: WARNING: duplicate label examples.python, other instance in /home/rafael/repos/archinstall/docs/examples/binary.rst
/home/rafael/repos/archinstall/docs/index.rst:40: WARNING: toctree contains reference to nonexisting document 'examples/scripting'
/home/rafael/repos/archinstall/docs/index.rst:48: WARNING: toctree contains reference to nonexisting document 'programming_guide/requirements'
/home/rafael/repos/archinstall/docs/index.rst:48: WARNING: toctree contains reference to nonexisting document 'programming_guide/basic_concept'
/home/rafael/repos/archinstall/docs/installing/binary.rst:1: WARNING: malformed hyperlink target.
/home/rafael/repos/archinstall/docs/installing/binary.rst:4: WARNING: Duplicate explicit target name: "pkgbuild".
```

## How Has This Been Tested?

On `docs` directory, I ran `rm  -rf _build` and `make html` until not issue is reported.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where possible/if applicable
