### PR TITLE
Fix misspellings

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -25,7 +25,7 @@ class BlockDevice():
 		self.path = path
 		self.info = info
 		self.part_cache = OrderedDict()
-		# TODO: Currently disk encryption is a BIT missleading.
+		# TODO: Currently disk encryption is a BIT misleading.
 		#       It's actually partition-encryption, but for future-proofing this
 		#       I'm placing the encryption password on a BlockDevice level.
 		self.encryption_passwoed = None
@@ -284,10 +284,10 @@ class Partition():
 		handle = luks2(self, None, None)
 		return handle.encrypt(self, *args, **kwargs)
 
-	def format(self, filesystem=None, path=None, allow_formatting=None, log_formating=True):
+	def format(self, filesystem=None, path=None, allow_formatting=None, log_formatting=True):
 		"""
 		Format can be given an overriding path, for instance /dev/null to test
-		the formating functionality and in essence the support for the given filesystem.
+		the formatting functionality and in essence the support for the given filesystem.
 		"""
 		if filesystem is None:
 			filesystem = self.filesystem
@@ -305,7 +305,7 @@ class Partition():
 		if not allow_formatting:
 			raise PermissionError(f"{self} is not formatable either because instance is locked ({self.allow_formatting}) or a blocking flag was given ({allow_formatting})")
 
-		if log_formating:
+		if log_formatting:
 			log(f'Formatting {path} -> {filesystem}', level=LOG_LEVELS.Info)
 
 		if filesystem == 'btrfs':
@@ -400,7 +400,7 @@ class Partition():
 		 2. UnknownFilesystemFormat that indicates that we don't support the given filesystem type
 		"""
 		try:
-			self.format(self.filesystem, '/dev/null', log_formating=False, allow_formatting=True)
+			self.format(self.filesystem, '/dev/null', log_formatting=False, allow_formatting=True)
 		except SysCallError:
 			pass # We supported it, but /dev/null is not formatable as expected so the mkfs call exited with an error code
 		except UnknownFilesystemFormat as err:

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -28,7 +28,7 @@ class BlockDevice():
 		# TODO: Currently disk encryption is a BIT misleading.
 		#       It's actually partition-encryption, but for future-proofing this
 		#       I'm placing the encryption password on a BlockDevice level.
-		self.encryption_passwoed = None
+		self.encryption_password = None
 
 	def __repr__(self, *args, **kwargs):
 		return f"BlockDevice({self.device})"

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -73,7 +73,7 @@ class Installer():
 		return self
 
 	def __exit__(self, *args, **kwargs):
-		# b''.join(sys_command(f'sync')) # No need to, since the underlaying fs() object will call sync.
+		# b''.join(sys_command(f'sync')) # No need to, since the underlying fs() object will call sync.
 		# TODO: https://stackoverflow.com/questions/28157929/how-to-safely-handle-an-exception-inside-a-context-manager
 
 		if len(args) >= 2 and args[1]:
@@ -268,7 +268,7 @@ class Installer():
 		return True
 
 	def minimal_installation(self):
-		## Add nessecary packages if encrypting the drive
+		## Add necessary packages if encrypting the drive
 		## (encrypted partitions default to btrfs for now, so we need btrfs-progs)
 		## TODO: Perhaps this should be living in the function which dictates
 		##       the partitioning. Leaving here for now.
@@ -401,7 +401,7 @@ class Installer():
 		# The tricky thing with doing the import archinstall.session instead is that
 		# profiles might be run from a different chroot, and there's no way we can
 		# guarantee file-path safety when accessing the installer object that way.
-		# Doing the __builtins__ replacement, ensures that the global vriable "installation"
+		# Doing the __builtins__ replacement, ensures that the global variable "installation"
 		# is always kept up to date. It's considered a nasty hack - but it's a safe way
 		# of ensuring 100% accuracy of archinstall session variables.
 		__builtins__['installation'] = self

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -56,7 +56,7 @@ def wirelessScan(interface):
 
 	storage['_WIFI'][interface]['scanning'] = True
 
-# TOOD: Full WiFi experience might get evolved in the future, pausing for now 2021-01-25
+# TODO: Full WiFi experience might get evolved in the future, pausing for now 2021-01-25
 def getWirelessNetworks(interface):
 	# TODO: Make this oneliner pritter to check if the interface is scanning or not.
 	if not '_WIFI' in storage or interface not in storage['_WIFI'] or storage['_WIFI'][interface].get('scanning', False) is False:

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from .storage import storage
 
 # TODO: use logging's built in levels instead.
-#       Altough logging is threaded and I wish to avoid that.
+#       Although logging is threaded and I wish to avoid that.
 #       It's more Pythonistic or w/e you want to call it.
 class LOG_LEVELS:
 	Critical = 0b001

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -112,11 +112,11 @@ class Script():
 
 			if f"{self.profile}" in self.examples:
 				return self.localize_path(self.examples[self.profile]['path'])
-			# TODO: Redundant, the below block shouldnt be needed as profiles are stripped of their .py, but just in case for now:
+			# TODO: Redundant, the below block shouldn't be needed as profiles are stripped of their .py, but just in case for now:
 			elif f"{self.profile}.py" in self.examples:
 				return self.localize_path(self.examples[f"{self.profile}.py"]['path'])
 
-			# Path was not found in any known examples, check if it's an abolute path
+			# Path was not found in any known examples, check if it's an absolute path
 			if os.path.isfile(self.profile):
 				return self.profile
 
@@ -156,7 +156,7 @@ class Profile(Script):
 
 	def install(self):
 		# Before installing, revert any temporary changes to the namespace.
-		# This ensures that the namespace during installation is the original initation namespace.
+		# This ensures that the namespace during installation is the original initiation namespace.
 		# (For instance awesome instead of aweosme.py or app-awesome.py)
 		self.namespace = self.original_namespace
 		return self.execute()
@@ -194,11 +194,11 @@ class Application(Profile):
 
 			if f"{self.profile}" in self.examples:
 				return self.localize_path(self.examples[self.profile]['path'])
-			# TODO: Redundant, the below block shouldnt be needed as profiles are stripped of their .py, but just in case for now:
+			# TODO: Redundant, the below block shouldn't be needed as profiles are stripped of their .py, but just in case for now:
 			elif f"{self.profile}.py" in self.examples:
 				return self.localize_path(self.examples[f"{self.profile}.py"]['path'])
 
-			# Path was not found in any known examples, check if it's an abolute path
+			# Path was not found in any known examples, check if it's an absolute path
 			if os.path.isfile(self.profile):
 				return os.path.basename(self.profile)
 
@@ -210,7 +210,7 @@ class Application(Profile):
 
 	def install(self):
 		# Before installing, revert any temporary changes to the namespace.
-		# This ensures that the namespace during installation is the original initation namespace.
+		# This ensures that the namespace during installation is the original initiation namespace.
 		# (For instance awesome instead of aweosme.py or app-awesome.py)
 		self.namespace = self.original_namespace
 		return self.execute()

--- a/archinstall/lib/storage.py
+++ b/archinstall/lib/storage.py
@@ -15,7 +15,7 @@ storage = {
 		#os.path.abspath(f'{os.path.dirname(__file__)}/../examples')
 	],
 	'UPSTREAM_URL' : 'https://raw.githubusercontent.com/Torxed/archinstall/master/profiles',
-	'PROFILE_DB' : None, # Used in cases when listing profiles is desired, not mandatory for direct profile grabing.
+	'PROFILE_DB' : None, # Used in cases when listing profiles is desired, not mandatory for direct profile grabbing.
 	'LOG_PATH' : '/var/log/archinstall',
 	'LOG_FILE' : 'install.log',
 	'MOUNT_POINT' : '/mnt'

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -151,7 +151,7 @@ def ask_for_main_filesystem_format():
 def generic_select(options, input_text="Select one of the above by index or absolute value: ", sort=True):
 	"""
 	A generic select function that does not output anything
-	other than the options and their indexs. As an example:
+	other than the options and their indexes. As an example:
 
 	generic_select(["first", "second", "third option"])
 	1: first

--- a/docs/installing/guided.rst
+++ b/docs/installing/guided.rst
@@ -66,7 +66,7 @@ Default is :code:`auto detect best mirror`
 
 As an example:
 
- * :code:`Sweden` *(wich a capital :code:`S`)* will only use mirrors from Sweden.
+ * :code:`Sweden` *(with a capital :code:`S`)* will only use mirrors from Sweden.
 
 Selection of drive
 ------------------

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -58,7 +58,7 @@ def ask_user_questions():
 	if archinstall.arguments['harddrive'].has_partitions():
 		archinstall.log(f"{archinstall.arguments['harddrive']} contains the following partitions:", fg='yellow')
 
-		# We curate a list pf supported paritions
+		# We curate a list pf supported partitions
 		# and print those that we don't support.
 		partition_mountpoints = {}
 		for partition in archinstall.arguments['harddrive']:
@@ -69,7 +69,7 @@ def ask_user_questions():
 			except archinstall.UnknownFilesystemFormat as err:
 				archinstall.log(f" {partition} (Filesystem not supported)", fg='red')
 
-		# We then ask what to do with the paritions.
+		# We then ask what to do with the partitions.
 		if (option := archinstall.ask_for_disk_layout()) == 'abort':
 			archinstall.log(f"Safely aborting the installation. No changes to the disk or system has been made.")
 			exit(1)
@@ -89,7 +89,7 @@ def ask_user_questions():
 				mountpoint = input(f"Enter a mount-point for {partition}: ").strip(' ')
 				if len(mountpoint):
 
-					# Get a valid & supported filesystem for the parition:
+					# Get a valid & supported filesystem for the partition:
 					while 1:
 						new_filesystem = input(f"Enter a valid filesystem for {partition} (leave blank for {partition.filesystem}): ").strip(' ')
 						if len(new_filesystem) <= 0:
@@ -120,7 +120,7 @@ def ask_user_questions():
 								 # But that means our .format() function supported it.
 						break
 
-					# When we've selected all three criterias,
+					# When we've selected all three criteria,
 					# We can safely mark the partition for formatting and where to mount it.
 					# TODO: allow_formatting might be redundant since target_mountpoint should only be
 					#       set if we actually want to format it anyway.
@@ -170,7 +170,7 @@ def ask_user_questions():
 	else:
 		archinstall.arguments['profile'] = archinstall.list_profiles()[archinstall.arguments['profile']]
 
-	# Check the potentially selected profiles preperations to get early checks if some additional questions are needed.
+	# Check the potentially selected profiles preparations to get early checks if some additional questions are needed.
 	if archinstall.arguments['profile'] and archinstall.arguments['profile'].has_prep_function():
 		with archinstall.arguments['profile'].load_instructions(namespace=f"{archinstall.arguments['profile'].namespace}.py") as imported:
 			if not imported._prep_function():

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -13,8 +13,8 @@ def _prep_function(*args, **kwargs):
 	supported_desktops = ['gnome', 'kde', 'awesome']
 	desktop = archinstall.generic_select(supported_desktops, 'Select your desired desktop environment: ')
 
-	# Temporarly store the selected desktop profile
-	# in a session-safe location, since this module will get re-loaded
+	# Temporarily store the selected desktop profile
+	# in a session-safe location, since this module will get reloaded
 	# the next time it gets executed.
 	archinstall.storage['_desktop_profile'] = desktop
 
@@ -29,7 +29,7 @@ def _prep_function(*args, **kwargs):
 if __name__ == 'desktop':
 	"""
 	This "profile" is a meta-profile.
-	There are no specific desktop-steps, it simply routes
+	There are no desktop-specific steps, it simply routes
 	the installer to whichever desktop environment/window manager was chosen.
 
 	Maybe in the future, a network manager or similar things *could* be added here.
@@ -37,7 +37,7 @@ if __name__ == 'desktop':
 	it trying to be a turn-key desktop distribution.
 
 	There are plenty of desktop-turn-key-solutions based on Arch Linux,
-	this is therefor just a helper to get started
+	this is therefore just a helper to get started
 	"""
 
 	# TODO: Remove magic variable 'installation' and place it

--- a/profiles/kde-wayland.py
+++ b/profiles/kde-wayland.py
@@ -1,4 +1,4 @@
-# A desktop environement using "KDE".
+# A desktop environment using "KDE".
 import archinstall, os
 
 # TODO: Remove hard dependency of bash (due to .bash_profile)

--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -1,4 +1,4 @@
-# A desktop environement using "KDE".
+# A desktop environment using "KDE".
 
 import archinstall, os
 


### PR DESCRIPTION
## Description

Fix misspellings reported by `codespell`.

Most fixed words are comments, with exception of `archinstall/lib/disk.py`'s `format` method which had `log_formating` keyword argument – fixed, including all calls to it.

## Bugs and Issues

```
$ codespell -ef . --skip *.pyc,.git,*.png,*.psd
./profiles/kde-wayland.py:1: environement ==> environment
./profiles/desktop.py:16: Temporarly ==> Temporarily, temporary
./profiles/desktop.py:40: therefor ==> therefore
./profiles/kde.py:1: environement ==> environment
./docs/installing/guided.rst:69: wich ==> which
./examples/guided.py:92: parition ==> partition
./examples/guided.py:123: criterias ==> criteria
./examples/guided.py:173: preperations ==> preparations
./archinstall/lib/user_interaction.py:154: indexs ==> indexes, indices
./archinstall/lib/storage.py:18: grabing ==> grabbing
./archinstall/lib/disk.py:28: missleading ==> misleading
./archinstall/lib/disk.py:290: formating ==> formatting
./archinstall/lib/profiles.py:115: shouldnt ==> shouldn't
./archinstall/lib/profiles.py:119: abolute ==> absolute
./archinstall/lib/profiles.py:159: initation ==> initiation
./archinstall/lib/profiles.py:197: shouldnt ==> shouldn't
./archinstall/lib/profiles.py:201: abolute ==> absolute
./archinstall/lib/profiles.py:213: initation ==> initiation
./archinstall/lib/output.py:9: Altough ==> Although
./archinstall/lib/installer.py:76: underlaying ==> underlying
./archinstall/lib/installer.py:271: nessecary ==> necessary
./archinstall/lib/installer.py:404: vriable ==> variable
./archinstall/lib/networking.py:59: TOOD ==> TODO
```

## How Has This Been Tested?

N/D

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation where possible/if applicable
