### PR TITLE
Add Cinnamon (with lightdm) - Torxed v2.2.0

### DIFF
--- a/profiles/applications/cinnamon.py
+++ b/profiles/applications/cinnamon.py
@@ -1,0 +1,4 @@
+import archinstall
+
+installation.add_additional_packages("cinnamon system-config-printer gnome-keyring gnome-terminal blueberry metacity lightdm lightdm-gtk-greeter lightdm-gtk-greeter-settings") 
+# We'll create a cinnamon-minimal later, but for now, we'll avoid issues by giving more than we need.

--- a/profiles/applications/xfce4.py
+++ b/profiles/applications/xfce4.py
@@ -1,3 +1,4 @@
 import archinstall
 
-installation.add_additional_packages("xfce4 xfce4-goodies lightdm") # We'll create a xfce4-minimal later, but for now, we'll avoid issues by giving more than we need.
+installation.add_additional_packages("xfce4 xfce4-goodies lightdm lightdm-gtk-greeter lightdm-gtk-greeter-settings") 
+# We'll create a xfce4-minimal later, but for now, we'll avoid issues by giving more than we need.

--- a/profiles/cinnamon.py
+++ b/profiles/cinnamon.py
@@ -1,0 +1,33 @@
+# A desktop environment using "Cinnamon"
+
+import archinstall
+
+def _prep_function(*args, **kwargs):
+	"""
+	Magic function called by the importing installer
+	before continuing any further. It also avoids executing any
+	other code in this stage. So it's a safe way to ask the user
+	for more input before any other installer steps start.
+	"""
+
+	# Cinnamon optionally supports xorg, we'll install it since it also
+	# includes graphic driver setups (this might change in the future)
+	profile = archinstall.Profile(None, 'xorg')
+	with profile.load_instructions(namespace='xorg.py') as imported:
+		if hasattr(imported, '_prep_function'):
+			return imported._prep_function()
+		else:
+			print('Deprecated (??): xorg profile has no _prep_function() anymore')
+
+# Ensures that this code only gets executed if executed
+# through importlib.util.spec_from_file_location("cinnamon", "/somewhere/cinnamon.py")
+# or through conventional import cinnamon
+if __name__ == 'cinnamon':
+	# Install dependency profiles
+	installation.install_profile('xorg')
+
+	# Install the application cinnamon from the template under /applications/
+	cinnamon = archinstall.Application(installation, 'cinnamon')
+	cinnamon.install()
+
+	installation.enable_service('lightdm') # Light Display Manager

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -10,7 +10,7 @@ def _prep_function(*args, **kwargs):
 	for more input before any other installer steps start.
 	"""
 
-	supported_desktops = ['gnome', 'kde', 'awesome', 'xfce4']
+	supported_desktops = ['gnome', 'kde', 'awesome', 'xfce4', 'cinnamon']
 	desktop = archinstall.generic_select(supported_desktops, 'Select your desired desktop environment: ')
 
 	# Temporarly store the selected desktop profile


### PR DESCRIPTION
## Description

Cinnamon Desktop Environment & LightDM
Add dependency for LightDM (Xfce4) 

### Changes
- Added [profiles/cinnamon](https://github.com/archlinux/archinstall/commit/107c1d6caac6880212ac2b97152864b2916f8cd8)  
- Added [profiles/applications/cinnamon](https://github.com/archlinux/archinstall/commit/771087e75b27cc433e98df986ac52e8f09d41f0a) 
- Modified [supported_desktops](https://github.com/archlinux/archinstall/commit/9576486cfa6155a80a8fca833e27b3016dae7e37) in profiles/desktop.py; added cinnamon.
- Modified [profiles/applications/xfce4](https://github.com/archlinux/archinstall/compare/torxed-v2.2.0...m1ten:torxed-v2.2.0#diff-cf83e5045365a4d4cd22c50eae5829c52b1177917e038e3dae80d9e09e9b5c5b); added lightdm-gtk-greeter

## How Has This Been Tested?

**Test Configuration**:
* Hardware: VirtualBox 6.1
* Specific steps: Ran installer with additional packages `cinnamon` and `lightdm`
> User will need to manually configure lightdm for theme or default DE/WM.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where possible/if applicable *I think*
