### PR TITLE
Allow multiple services to be enabled at once

### DIFF
--- a/archinstall/lib/exceptions.py
+++ b/archinstall/lib/exceptions.py
@@ -19,3 +19,5 @@ class PermissionError(BaseException):
 	pass
 class UserError(BaseException):
 	pass
+class ServiceException(BaseException):
+	pass

--- a/docs/archinstall/general.rst
+++ b/docs/archinstall/general.rst
@@ -88,3 +88,13 @@ Exceptions
 .. autofunction:: archinstall.ProfileError
 
 .. autofunction:: archinstall.SysCallError
+
+.. autofunction:: archinstall.ProfileNotFound
+
+.. autofunction:: archinstall.HardwareIncompatibilityError
+
+.. autofunction:: archinstall.PermissionError
+
+.. autofunction:: archinstall.UserError
+
+.. autofunction:: archinstall.ServiceException


### PR DESCRIPTION
# Pull Request Template

## Description

Closes https://github.com/archlinux/archinstall/issues/111

This allows multiple services to be passed into the `enable_service` helper function


## Bugs and Issues

https://github.com/archlinux/archinstall/issues/111

## How Has This Been Tested?

Made sure installer completes without issue

**Test Configuration**:
* Hardware: Virtualbox
* Specific steps: Installed and confirmed nothing has broken

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where possible/if applicable
