### PR TITLE
Fix incorrect behavior for empty sudo username

### DIFF
--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -61,8 +61,6 @@ def ask_for_superuser_account(prompt='Create a required super-user with sudo pri
 	while 1:
 		new_user = input(prompt).strip(' ')
 
-		if not check_for_correct_username(new_user):
-			continue
 		if not new_user and forced:
 			# TODO: make this text more generic?
 			#       It's only used to create the first sudo user when root is disabled in guided.py
@@ -70,6 +68,8 @@ def ask_for_superuser_account(prompt='Create a required super-user with sudo pri
 			continue
 		elif not new_user and not forced:
 			raise UserError("No superuser was created.")
+		elif not check_for_correct_username(new_user):
+			continue
 
 		password = get_password(prompt=f'Password for user {new_user}: ')
 		return {new_user: {"!password" : password}}


### PR DESCRIPTION
## Description

Fixes a bug from the PR #170, where statements for empty sudo username could be skipped because of new check *(As regex matching gives `False` on empty string)*

> Sorry to bother you with these changes again, as, unfortunately, I noticed this bug only after the previous pull request was closed. For now, I hope this is the last flaw in these changes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation where possible/if applicable
