### PR TITLE
Fix newline issue on fstab writes

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -147,7 +147,7 @@ class Installer():
 		self.log(f"Updating {self.mountpoint}/etc/fstab", level=LOG_LEVELS.Info)
 		
 		fstab = sys_command(f'/usr/bin/genfstab {flags} {self.mountpoint}').trace_log
-		with open(f"{self.mountpoint}/etc/fstab", 'ab') as fstab_fh:
+		with open(f"{self.mountpoint}/etc/fstab", 'ab',newline='\n') as fstab_fh:
 			fstab_fh.write(fstab)
 
 		if not os.path.isfile(f'{self.mountpoint}/etc/fstab'):


### PR DESCRIPTION


## Description

Forced the newline char fstab writes as Python appears to be selecting the incorrect newlines.

## Bugs and Issues

https://github.com/archlinux/archinstall/issues/214

## How Has This Been Tested?

No testing. But simple change so it should be good to go.


- [* ] My code follows the style guidelines of this project
- [* ] I have performed a self-review of my own code to the best of my abilities
- [* ] I have commented my code, particularly in hard-to-understand areas
- [* ] I have made corresponding changes to the documentation where possible/if applicable
