### PR TITLE
Remove gnome-todo and gnome-sound-recorder from default installation

### DIFF
--- a/profiles/applications/gnome.py
+++ b/profiles/applications/gnome.py
@@ -1,4 +1,4 @@
 import archinstall
 
-installation.add_additional_packages("gnome gnome-tweaks gnome-todo gnome-sound-recorder gdm")
+installation.add_additional_packages("gnome gnome-tweaks gdm")
 # Note: gdm should be part of the gnome group, but adding it here for clarity


### PR DESCRIPTION
# Pull Request Template

Make sure you've checked out the [contribution guideline](https://github.com/archlinux/archinstall/blob/master/CONTRIBUTING.md).<br>
Most of the guidelines are not enforced, but is heavily encouraged.

## Description

gnome todo and gnome sound recorder should not be in default installation, honoring the Arch Linux philosophy. These packages are not even pre installed on other major linux distributions. gnome-tweaks is the only package (that is not part of the gnome group https://archlinux.org/groups/x86_64/gnome/) what 90 percent gnome users still use and that should be in default installation and it is.

## How Has This Been Tested?

Doesn't require any specific tests as these are not required packages for default installation.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where possible/if applicable
