### PR TITLE
Only ask for audio server selection on a desktop profile (depends on #219)

### DIFF
--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -177,6 +177,7 @@ class Profile(Script):
 					if hasattr(imported, '_prep_function'):
 						return True
 		return False
+
 	def has_post_install(self):
 		with open(self.path, 'r') as source:
 			source_data = source.read()
@@ -192,6 +193,11 @@ class Profile(Script):
 				with self.load_instructions(namespace=f"{self.namespace}.py") as imported:
 					if hasattr(imported, '_post_install'):
 						return True
+
+	def is_top_level_profile(self):
+		with open(self.path, 'r') as source:
+			source_data = source.read()
+			return 'top_level_profile = True' in source_data
 
 	@property
 	def packages(self) -> list:

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -107,7 +107,7 @@ def ask_for_a_timezone():
 def ask_for_audio_selection():
 	audio = "pulseaudio" # Default for most desktop environments
 	pipewire_choice = input("Would you like to install pipewire instead of pulseaudio as the default audio server? [Y/n] ").lower()
-	if pipewire_choice == "y":
+	if pipewire_choice in ("y", ""):
 		audio = "pipewire"
 
 	return audio

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -341,7 +341,7 @@ def perform_installation(device, boot_partition, language, mirrors):
 				installation.enable_service('systemd-networkd')
 				installation.enable_service('systemd-resolved')
 
-			if 	archinstall.arguments['audio'] != 'none':
+			if 	archinstall.arguments.get('audio', None) != None:
 				installation.log(f"The {archinstall.arguments.get('audio', None)} audio server will be used.", level=archinstall.LOG_LEVELS.Info)
 				if archinstall.arguments.get('audio', None) == 'pipewire':
 					print('Installing pipewire ...')

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -182,9 +182,16 @@ def ask_user_questions():
 				)
 				exit(1)
 
-	# Ask about audio server selection (this right now just asks for pipewire and defaults to pulseaudio otherwise)
+	# Ask about audio server selection if one is not already set
 	if not archinstall.arguments.get('audio', None):
-		archinstall.arguments['audio'] = archinstall.ask_for_audio_selection()
+		
+		# only ask for audio server selection on a desktop profile 
+		if str(archinstall.arguments['profile']) == 'Profile(desktop)':
+			archinstall.arguments['audio'] = archinstall.ask_for_audio_selection()
+		else:
+			# packages installed by a profile may depend on audio and something may get installed anyways, not much we can do about that.
+			# we will not try to remove packages post-installation to not have audio, as that may cause multiple issues
+			archinstall.arguments['audio'] = 'none'
 
 	# Additional packages (with some light weight error handling for invalid package names)
 	if not archinstall.arguments.get('packages', None):
@@ -334,13 +341,14 @@ def perform_installation(device, boot_partition, language, mirrors):
 				installation.enable_service('systemd-networkd')
 				installation.enable_service('systemd-resolved')
 
-			installation.log(f"The {archinstall.arguments.get('audio', None)} audio server will be used.", level=archinstall.LOG_LEVELS.Info)
-			if archinstall.arguments.get('audio', None) == 'pipewire':
-				print('Installing pipewire ...')
-				installation.add_additional_packages(["pipewire", "pipewire-alsa", "pipewire-docs", "pipewire-jack", "pipewire-media-session", "pipewire-pulse", "gst-plugin-pipewire", "libpulse"])
-			elif archinstall.arguments.get('audio', None) == 'pulseaudio':
-				print('Installing pulseaudio ...')
-				installation.add_additional_packages("pulseaudio")
+			if 	archinstall.arguments['audio'] != 'none':
+				installation.log(f"The {archinstall.arguments.get('audio', None)} audio server will be used.", level=archinstall.LOG_LEVELS.Info)
+				if archinstall.arguments.get('audio', None) == 'pipewire':
+					print('Installing pipewire ...')
+					installation.add_additional_packages(["pipewire", "pipewire-alsa", "pipewire-docs", "pipewire-jack", "pipewire-media-session", "pipewire-pulse", "gst-plugin-pipewire", "libpulse"])
+				elif archinstall.arguments.get('audio', None) == 'pulseaudio':
+					print('Installing pulseaudio ...')
+					installation.add_additional_packages("pulseaudio")
 			
 			if archinstall.arguments.get('packages', None) and archinstall.arguments.get('packages', None)[0] != '':
 				installation.add_additional_packages(archinstall.arguments.get('packages', None))

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -1,6 +1,7 @@
 import getpass, time, json, sys, signal, os
 import archinstall
 from archinstall.lib.hardware import hasUEFI
+from archinstall.lib.profiles import Profile
 
 """
 This signal-handler chain (and global variable)
@@ -167,7 +168,7 @@ def ask_user_questions():
 
 	# Ask for archinstall-specific profiles (such as desktop environments etc)
 	if not archinstall.arguments.get('profile', None):
-		archinstall.arguments['profile'] = archinstall.select_profile(archinstall.list_profiles())
+		archinstall.arguments['profile'] = archinstall.select_profile(filter(lambda profile: (Profile(None, profile).is_top_level_profile()), archinstall.list_profiles()))
 	else:
 		archinstall.arguments['profile'] = archinstall.list_profiles()[archinstall.arguments['profile']]
 

--- a/profiles/awesome.py
+++ b/profiles/awesome.py
@@ -2,6 +2,8 @@
 
 import archinstall
 
+is_top_level_profile = False
+
 # New way of defining packages for a profile, which is iterable and can be used out side
 # of the profile to get a list of "what packages will be installed".
 __packages__ = ['nano', 'nemo', 'gpicview-gtk3', 'openssh', 'sshfs', 'htop', 'scrot', 'wget']

--- a/profiles/cinnamon.py
+++ b/profiles/cinnamon.py
@@ -1,6 +1,8 @@
 # A desktop environment using "Cinnamon"
 import archinstall
 
+is_top_level_profile = False
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -2,6 +2,8 @@
 
 import archinstall, os
 
+is_top_level_profile = True
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer
@@ -10,7 +12,7 @@ def _prep_function(*args, **kwargs):
 	for more input before any other installer steps start.
 	"""
 
-	supported_desktops = ['gnome', 'kde', 'awesome', 'xfce4', 'cinnamon']
+	supported_desktops = ['gnome', 'kde', 'awesome', 'xfce4', 'cinnamon', 'i3-gaps', 'i3-wm']
 	desktop = archinstall.generic_select(supported_desktops, 'Select your desired desktop environment: ')
 
 	# Temporarily store the selected desktop profile

--- a/profiles/gnome.py
+++ b/profiles/gnome.py
@@ -2,6 +2,8 @@
 
 import archinstall
 
+is_top_level_profile = False
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/i3-gaps.py
+++ b/profiles/i3-gaps.py
@@ -1,5 +1,7 @@
 import archinstall, subprocess
 
+is_top_level_profile = False
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/i3-wm.py
+++ b/profiles/i3-wm.py
@@ -1,5 +1,7 @@
 import archinstall, subprocess
 
+is_top_level_profile = False
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -2,6 +2,8 @@
 
 import archinstall, os
 
+is_top_level_profile = False
+
 # TODO: Remove hard dependency of bash (due to .bash_profile)
 
 def _prep_function(*args, **kwargs):

--- a/profiles/minimal.py
+++ b/profiles/minimal.py
@@ -1,0 +1,20 @@
+# Used to do a minimal install
+
+import archinstall, os
+
+is_top_level_profile = True
+
+def _prep_function(*args, **kwargs):
+	"""
+	Magic function called by the importing installer
+	before continuing any further. For minimal install,
+	we don't need to do anything special here, but it
+	needs to exist and return True.
+	"""
+	return True # Do nothing and just return True
+
+if __name__ == 'minimal':
+	"""
+	This "profile" is a meta-profile.
+	It is used for a custom minimal installation, without any desktop-specific packages.
+	"""

--- a/profiles/xfce4.py
+++ b/profiles/xfce4.py
@@ -1,6 +1,8 @@
 
 # A desktop environment using "Xfce4"
 
+is_top_level_profile = False
+
 import archinstall
 
 def _prep_function(*args, **kwargs):

--- a/profiles/xorg.py
+++ b/profiles/xorg.py
@@ -2,6 +2,8 @@
 
 import archinstall, os
 
+is_top_level_profile = True
+
 AVAILABLE_DRIVERS = {
 	# Sub-dicts are layer-2 options to be selected
 	# and lists are a list of packages to be installed


### PR DESCRIPTION
This has a dependency on #219 already being merged. This makes it so that only desktop profiles are prompted for an audio server selection. We do this by having all the desktop environments under the top-level desktop profile and if (and only if) this is selected, we will ask the user which sound server they prefer (currently pipewire or pulseaudio, but may be expanded later).

🚨 PR Guidelines:

# New features *(v2.2.0)*

Merge new features in to `torxed-v2.2.0`.<br>
This branch is designated for potential breaking changes, added complexity and new functionality.

# Bug fixes *(v2.1.4)*

Merge against `master` for bug fixes and anything that improves stability and quality of life.<br>
This excludes:
 * New functionality
 * Added complexity
 * Breaking changes

Any changes to `master` automatically gets pulled in to `torxed-v2.2.0` to avoid merge hell.

# Describe your PR

If the changes has been discussed in an Issue, please tag it so we can backtrace from the Issue later on.<br>
If the PR is larger than ~20 lines, please describe it here unless described in an issue.

# Testing

Any new feature or stability improvement should be tested if possible.
Please follow the test instructions at the bottom of the README.

*These PR guidelines will change after 2021-05-01, which is when `v2.1.4` gets onto the new ISO*
