### PR TITLE
Move some packages from awesome to desktop generic profile and add wireless/SMART tools 

### DIFF
--- a/profiles/awesome.py
+++ b/profiles/awesome.py
@@ -6,7 +6,7 @@ is_top_level_profile = False
 
 # New way of defining packages for a profile, which is iterable and can be used out side
 # of the profile to get a list of "what packages will be installed".
-__packages__ = ['nano', 'nemo', 'gpicview-gtk3', 'openssh', 'sshfs', 'htop', 'scrot', 'wget']
+__packages__ = ['nemo', 'gpicview-gtk3', 'scrot']
 
 def _prep_function(*args, **kwargs):
 	"""
@@ -33,13 +33,7 @@ if __name__ == 'awesome':
 	awesome = archinstall.Application(installation, 'awesome')
 	awesome.install()
 
-	# Then setup and configure the desktop environment: awesome
-	editor = "nano"
-	filebrowser = "nemo gpicview-gtk3"
-	utils = "openssh sshfs htop scrot wget"
-
-
-	installation.add_additional_packages(f"{utils} {filebrowser} {editor}")
+	installation.add_additional_packages(__packages__)
 
 	alacritty = archinstall.Application(installation, 'alacritty')
 	alacritty.install()

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -4,6 +4,10 @@ import archinstall, os
 
 is_top_level_profile = True
 
+# New way of defining packages for a profile, which is iterable and can be used out side
+# of the profile to get a list of "what packages will be installed".
+__packages__ = ['nano', 'openssh', 'htop', 'wget', 'iwd', 'wireless_tools', 'wpa_supplicant', 'smartmontools']
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer
@@ -14,7 +18,7 @@ def _prep_function(*args, **kwargs):
 
 	supported_desktops = ['gnome', 'kde', 'awesome']
 	desktop = archinstall.generic_select(supported_desktops, 'Select your desired desktop environment: ')
-
+	
 	# Temporarily store the selected desktop profile
 	# in a session-safe location, since this module will get reloaded
 	# the next time it gets executed.
@@ -41,7 +45,11 @@ if __name__ == 'desktop':
 	There are plenty of desktop-turn-key-solutions based on Arch Linux,
 	this is therefore just a helper to get started
 	"""
+	
+	# Install common packages for all desktop environments
+	installation.add_additional_packages(__packages__)
 
 	# TODO: Remove magic variable 'installation' and place it
 	#       in archinstall.storage or archinstall.session/archinstall.installation
 	installation.install_profile(archinstall.storage['_desktop_profile'])
+


### PR DESCRIPTION
This moves some common packages from Awesome to desktop.

https://gitlab.archlinux.org/archlinux/archiso/-/blob/master/configs/releng/packages.x86_64 lists packages that come out of the box in the arch iso. One situation we want to avoid is laptop users not able to connect to wifi after installation, so I'm adding wifi config utilities to avoid these users having to do a reinstallation.

This also pulls in smartmontools to close #98.