### PR TITLE
Remove nano from base packages

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -34,7 +34,7 @@ class Installer():
 	:type hostname: str, optional
 
 	"""
-	def __init__(self, partition, boot_partition, *, base_packages='base base-devel linux linux-firmware efibootmgr nano', profile=None, mountpoint='/mnt', hostname='ArchInstalled', logdir=None, logfile=None):
+	def __init__(self, partition, boot_partition, *, base_packages='base base-devel linux linux-firmware efibootmgr', profile=None, mountpoint='/mnt', hostname='ArchInstalled', logdir=None, logfile=None):
 		self.profile = profile
 		self.hostname = hostname
 		self.mountpoint = mountpoint


### PR DESCRIPTION
nano feels really out of place in base packages and it's installed in desktop anyways so it's redundant on everything but xorg/minimal top-level installs (but users could just do pacman -S nano).

🚨 PR Guidelines:

# New features *(v2.2.0)*

Merge new features in to `torxed-v2.2.0`.<br>
This branch is designated for potential breaking changes, added complexity and new functionality.

# Bug fixes *(v2.1.4)*

Merge against `master` for bug fixes and anything that improves stability and quality of life.<br>
This excludes:
 * New functionality
 * Added complexity
 * Breaking changes

Any changes to `master` automatically gets pulled in to `torxed-v2.2.0` to avoid merge hell.

# Describe your PR

If the changes has been discussed in an Issue, please tag it so we can backtrace from the Issue later on.<br>
If the PR is larger than ~20 lines, please describe it here unless described in an issue.

# Testing

Any new feature or stability improvement should be tested if possible.
Please follow the test instructions at the bottom of the README.

*These PR guidelines will change after 2021-05-01, which is when `v2.1.4` gets onto the new ISO*
