### PR TITLE
draft: Cherry-Pick i3 Profiles and Make Common i3 Package

### DIFF
--- a/profiles/applications/i3-gaps.py
+++ b/profiles/applications/i3-gaps.py
@@ -1,0 +1,2 @@
+import archinstall
+installation.add_additional_packages("i3lock i3status i3blocks i3-gaps")

--- a/profiles/applications/i3-gaps.py
+++ b/profiles/applications/i3-gaps.py
@@ -1,2 +1,2 @@
 import archinstall
-installation.add_additional_packages("i3lock i3status i3blocks i3-gaps")
+installation.add_additional_packages("i3-gaps")

--- a/profiles/applications/i3-wm.py
+++ b/profiles/applications/i3-wm.py
@@ -1,2 +1,2 @@
 import archinstall
-installation.add_additional_packages("i3lock i3status i3blocks i3-wm")
+installation.add_additional_packages("i3-wm")

--- a/profiles/applications/i3-wm.py
+++ b/profiles/applications/i3-wm.py
@@ -1,0 +1,2 @@
+import archinstall
+installation.add_additional_packages("i3lock i3status i3blocks i3-wm")

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -16,7 +16,7 @@ def _prep_function(*args, **kwargs):
 	for more input before any other installer steps start.
 	"""
 
-	supported_desktops = ['gnome', 'kde', 'awesome', 'sway', 'cinnamon', 'xfce4', 'lxqt']
+	supported_desktops = ['gnome', 'kde', 'awesome', 'sway', 'cinnamon', 'xfce4', 'lxqt', 'i3']
 	desktop = archinstall.generic_select(supported_desktops, 'Select your desired desktop environment: ')
 	
 	# Temporarily store the selected desktop profile

--- a/profiles/i3-gaps.py
+++ b/profiles/i3-gaps.py
@@ -9,14 +9,7 @@ def _prep_function(*args, **kwargs):
 	other code in this stage. So it's a safe way to ask the user
 	for more input before any other installer steps start.
 	"""
-
-	# i3 requires a functioning Xorg installation.
-	profile = archinstall.Profile(None, 'xorg')
-	with profile.load_instructions(namespace='xorg.py') as imported:
-		if hasattr(imported, '_prep_function'):
-			return imported._prep_function()
-		else:
-			print('Deprecated (??): xorg profile has no _prep_function() anymore')
+	return True
 
 if __name__ == 'i3-gaps':
     # install the i3 group now

--- a/profiles/i3-gaps.py
+++ b/profiles/i3-gaps.py
@@ -1,0 +1,28 @@
+import archinstall
+
+def _prep_function(*args, **kwargs):
+	"""
+	Magic function called by the importing installer
+	before continuing any further. It also avoids executing any
+	other code in this stage. So it's a safe way to ask the user
+	for more input before any other installer steps start.
+	"""
+
+	# KDE requires a functioning Xorg installation.
+	profile = archinstall.Profile(None, 'xorg')
+	with profile.load_instructions(namespace='xorg.py') as imported:
+		if hasattr(imported, '_prep_function'):
+			return imported._prep_function()
+		else:
+			print('Deprecated (??): xorg profile has no _prep_function() anymore')
+
+if __name__ == 'i3-wm':
+	# Install dependency profiles
+    installation.install_profile('xorg')
+    # gaps is installed by deafult so we are overriding it here
+    installation.add_additional_packages("lightdm-gtk-greeter lightdm")
+    # install the i3 group now
+    i3 = archinstall.Application(installation, 'i3-gaps')
+    i3.install()
+    # Auto start lightdm for all users
+    installation.enable_service('lightdm')

--- a/profiles/i3-gaps.py
+++ b/profiles/i3-gaps.py
@@ -21,8 +21,13 @@ def _post_install(*args, **kwargs):
 	Another magic function called after the system 
 	has been installed. 
 	"""
-	print("the installation of i3 does not conatain any configuerations for the wm. in this shell you take your time should add your configuerations")			
-	subprocess.check_call("arch-chroot /mnt",shell=True)
+	installation.log("the installation of i3 does not conatain any configuerations for the wm. In this shell you should take your time to add your desiired configueration. Exit the shell once you are done to continue the installation.", fg="yellow")
+	try:
+		subprocess.check_call("arch-chroot /mnt",shell=True)
+	except subprocess.CallProcessError:
+		return False
+	
+	return True
 
 if __name__ == 'i3-wm':
 	# Install dependency profiles

--- a/profiles/i3-gaps.py
+++ b/profiles/i3-gaps.py
@@ -18,19 +18,6 @@ def _prep_function(*args, **kwargs):
 		else:
 			print('Deprecated (??): xorg profile has no _prep_function() anymore')
 
-def _post_install(*args, **kwargs):
-	"""
-	Another magic function called after the system 
-	has been installed. 
-	"""
-	installation.log("the installation of i3 does not conatain any configuerations for the wm. In this shell you should take your time to add your desiired configueration. Exit the shell once you are done to continue the installation.", fg="yellow")
-	try:
-		subprocess.check_call("arch-chroot /mnt",shell=True)
-	except subprocess.CallProcessError:
-		return False
-	
-	return True
-
 if __name__ == 'i3-gaps':
     # install the i3 group now
     i3 = archinstall.Application(installation, 'i3-gaps')

--- a/profiles/i3-gaps.py
+++ b/profiles/i3-gaps.py
@@ -8,7 +8,7 @@ def _prep_function(*args, **kwargs):
 	for more input before any other installer steps start.
 	"""
 
-	# KDE requires a functioning Xorg installation.
+	# i3 requires a functioning Xorg installation.
 	profile = archinstall.Profile(None, 'xorg')
 	with profile.load_instructions(namespace='xorg.py') as imported:
 		if hasattr(imported, '_prep_function'):

--- a/profiles/i3-gaps.py
+++ b/profiles/i3-gaps.py
@@ -1,4 +1,4 @@
-import archinstall
+import archinstall, subprocess
 
 def _prep_function(*args, **kwargs):
 	"""
@@ -15,6 +15,14 @@ def _prep_function(*args, **kwargs):
 			return imported._prep_function()
 		else:
 			print('Deprecated (??): xorg profile has no _prep_function() anymore')
+
+def _post_install(*args, **kwargs):
+	"""
+	Another magic function called after the system 
+	has been installed. 
+	"""
+	print("the installation of i3 does not conatain any configuerations for the wm. in this shell you take your time should add your configuerations")			
+	subprocess.check_call("arch-chroot /mnt",shell=True)
 
 if __name__ == 'i3-wm':
 	# Install dependency profiles

--- a/profiles/i3-gaps.py
+++ b/profiles/i3-gaps.py
@@ -1,5 +1,7 @@
 import archinstall, subprocess
 
+is_top_level_profile = False
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/i3-gaps.py
+++ b/profiles/i3-gaps.py
@@ -31,13 +31,7 @@ def _post_install(*args, **kwargs):
 	
 	return True
 
-if __name__ == 'i3-wm':
-	# Install dependency profiles
-    installation.install_profile('xorg')
-    # gaps is installed by deafult so we are overriding it here
-    installation.add_additional_packages("lightdm-gtk-greeter lightdm")
+if __name__ == 'i3-gaps':
     # install the i3 group now
     i3 = archinstall.Application(installation, 'i3-gaps')
     i3.install()
-    # Auto start lightdm for all users
-    installation.enable_service('lightdm')

--- a/profiles/i3-wm.py
+++ b/profiles/i3-wm.py
@@ -8,7 +8,7 @@ def _prep_function(*args, **kwargs):
 	for more input before any other installer steps start.
 	"""
 
-	# KDE requires a functioning Xorg installation.
+	# i3 requires a functioning Xorg installation.
 	profile = archinstall.Profile(None, 'xorg')
 	with profile.load_instructions(namespace='xorg.py') as imported:
 		if hasattr(imported, '_prep_function'):

--- a/profiles/i3-wm.py
+++ b/profiles/i3-wm.py
@@ -18,19 +18,6 @@ def _prep_function(*args, **kwargs):
 		else:
 			print('Deprecated (??): xorg profile has no _prep_function() anymore')
 
-def _post_install(*args, **kwargs):
-	"""
-	Another magic function called after the system 
-	has been installed. 
-	"""
-	installation.log("the installation of i3 does not conatain any configuerations for the wm. In this shell you should take your time to add your desiired configueration. Exit the shell once you are done to continue the installation.", fg="yellow")
-	try:
-		subprocess.check_call("arch-chroot /mnt",shell=True)
-	except subprocess.CallProcessError:
-		return False
-	
-	return True
-
 if __name__ == 'i3-wm':
     # install the i3 group now
     i3 = archinstall.Application(installation, 'i3-wm')

--- a/profiles/i3-wm.py
+++ b/profiles/i3-wm.py
@@ -9,14 +9,7 @@ def _prep_function(*args, **kwargs):
 	other code in this stage. So it's a safe way to ask the user
 	for more input before any other installer steps start.
 	"""
-
-	# i3 requires a functioning Xorg installation.
-	profile = archinstall.Profile(None, 'xorg')
-	with profile.load_instructions(namespace='xorg.py') as imported:
-		if hasattr(imported, '_prep_function'):
-			return imported._prep_function()
-		else:
-			print('Deprecated (??): xorg profile has no _prep_function() anymore')
+	return True
 
 if __name__ == 'i3-wm':
     # install the i3 group now

--- a/profiles/i3-wm.py
+++ b/profiles/i3-wm.py
@@ -20,8 +20,13 @@ def _post_install(*args, **kwargs):
 	Another magic function called after the system 
 	has been installed. 
 	"""
-	print("the installation of i3-gaps does not conatain any configuerations for the wm. in this shell you should take your time to add your configuerations")			
-	subprocess.check_call("arch-chroot /mnt",shell=True)
+	installation.log("the installation of i3 does not conatain any configuerations for the wm. In this shell you should take your time to add your desiired configueration. Exit the shell once you are done to continue the installation.", fg="yellow")
+	try:
+		subprocess.check_call("arch-chroot /mnt",shell=True)
+	except subprocess.CallProcessError:
+		return False
+	
+	return True
 
 if __name__ == 'i3-wm':
     # Install dependency profiles

--- a/profiles/i3-wm.py
+++ b/profiles/i3-wm.py
@@ -1,5 +1,7 @@
 import archinstall, subprocess
 
+is_top_level_profile = False
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/i3-wm.py
+++ b/profiles/i3-wm.py
@@ -17,6 +17,7 @@ def _prep_function(*args, **kwargs):
 			return imported._prep_function()
 		else:
 			print('Deprecated (??): xorg profile has no _prep_function() anymore')
+
 def _post_install(*args, **kwargs):
 	"""
 	Another magic function called after the system 
@@ -31,12 +32,6 @@ def _post_install(*args, **kwargs):
 	return True
 
 if __name__ == 'i3-wm':
-    # Install dependency profiles
-    installation.install_profile('xorg')
-    # we are installing lightdm to auto start i3
-    installation.add_additional_packages("lightdm-gtk-greeter lightdm")
     # install the i3 group now
     i3 = archinstall.Application(installation, 'i3-wm')
     i3.install()
-    # Auto start lightdm for all users
-    installation.enable_service('lightdm')

--- a/profiles/i3-wm.py
+++ b/profiles/i3-wm.py
@@ -1,4 +1,4 @@
-import archinstall
+import archinstall, subprocess
 
 def _prep_function(*args, **kwargs):
 	"""
@@ -15,6 +15,13 @@ def _prep_function(*args, **kwargs):
 			return imported._prep_function()
 		else:
 			print('Deprecated (??): xorg profile has no _prep_function() anymore')
+def _post_install(*args, **kwargs):
+	"""
+	Another magic function called after the system 
+	has been installed. 
+	"""
+	print("the installation of i3-gaps does not conatain any configuerations for the wm. in this shell you should take your time to add your configuerations")			
+	subprocess.check_call("arch-chroot /mnt",shell=True)
 
 if __name__ == 'i3-wm':
     # Install dependency profiles

--- a/profiles/i3-wm.py
+++ b/profiles/i3-wm.py
@@ -1,0 +1,28 @@
+import archinstall
+
+def _prep_function(*args, **kwargs):
+	"""
+	Magic function called by the importing installer
+	before continuing any further. It also avoids executing any
+	other code in this stage. So it's a safe way to ask the user
+	for more input before any other installer steps start.
+	"""
+
+	# KDE requires a functioning Xorg installation.
+	profile = archinstall.Profile(None, 'xorg')
+	with profile.load_instructions(namespace='xorg.py') as imported:
+		if hasattr(imported, '_prep_function'):
+			return imported._prep_function()
+		else:
+			print('Deprecated (??): xorg profile has no _prep_function() anymore')
+
+if __name__ == 'i3-wm':
+    # Install dependency profiles
+    installation.install_profile('xorg')
+    # we are installing lightdm to auto start i3
+    installation.add_additional_packages("lightdm-gtk-greeter lightdm")
+    # install the i3 group now
+    i3 = archinstall.Application(installation, 'i3-wm')
+    i3.install()
+    # Auto start lightdm for all users
+    installation.enable_service('lightdm')

--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -1,0 +1,55 @@
+# Common package for i3, lets user select which i3 configuration they want.
+
+import archinstall, os
+
+is_top_level_profile = False
+
+# New way of defining packages for a profile, which is iterable and can be used out side
+# of the profile to get a list of "what packages will be installed".
+__packages__ = []
+
+def _prep_function(*args, **kwargs):
+	"""
+	Magic function called by the importing installer
+	before continuing any further. It also avoids executing any
+	other code in this stage. So it's a safe way to ask the user
+	for more input before any other installer steps start.
+	"""
+
+	supported_configurations = ['i3-wm', 'i3-gaps']
+	desktop = archinstall.generic_select(supported_configurations, 'Select your desired configuration: ')
+	
+	# Temporarily store the selected desktop profile
+	# in a session-safe location, since this module will get reloaded
+	# the next time it gets executed.
+	archinstall.storage['_desktop_profile'] = desktop
+
+	profile = archinstall.Profile(None, desktop)
+	# Loading the instructions with a custom namespace, ensures that a __name__ comparison is never triggered.
+	with profile.load_instructions(namespace=f"{desktop}.py") as imported:
+		if hasattr(imported, '_prep_function'):
+			return imported._prep_function()
+		else:
+			print(f"Deprecated (??): {desktop} profile has no _prep_function() anymore")
+
+if __name__ == 'i3':
+	"""
+	This "profile" is a meta-profile.
+	There are no desktop-specific steps, it simply routes
+	the installer to whichever desktop environment/window manager was chosen.
+
+	Maybe in the future, a network manager or similar things *could* be added here.
+	We should honor that Arch Linux does not officially endorse a desktop-setup, nor is
+	it trying to be a turn-key desktop distribution.
+
+	There are plenty of desktop-turn-key-solutions based on Arch Linux,
+	this is therefore just a helper to get started
+	"""
+	
+	# Install common packages for all i3 configurations
+	installation.add_additional_packages(__packages__)
+
+	# TODO: Remove magic variable 'installation' and place it
+	#       in archinstall.storage or archinstall.session/archinstall.installation
+	installation.install_profile(archinstall.storage['_desktop_profile'])
+

--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -18,11 +18,19 @@ def _prep_function(*args, **kwargs):
 
 	supported_configurations = ['i3-wm', 'i3-gaps']
 	desktop = archinstall.generic_select(supported_configurations, 'Select your desired configuration: ')
-	
+
 	# Temporarily store the selected desktop profile
 	# in a session-safe location, since this module will get reloaded
 	# the next time it gets executed.
 	archinstall.storage['_desktop_profile'] = desktop
+
+	# i3 requires a functioning Xorg installation.
+	profile = archinstall.Profile(None, 'xorg')
+	with profile.load_instructions(namespace='xorg.py') as imported:
+		if hasattr(imported, '_prep_function'):
+			return imported._prep_function()
+		else:
+			print('Deprecated (??): xorg profile has no _prep_function() anymore')
 
 	profile = archinstall.Profile(None, desktop)
 	# Loading the instructions with a custom namespace, ensures that a __name__ comparison is never triggered.

--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -6,7 +6,7 @@ is_top_level_profile = False
 
 # New way of defining packages for a profile, which is iterable and can be used out side
 # of the profile to get a list of "what packages will be installed".
-__packages__ = []
+__packages__ = ['i3lock', 'i3status', 'i3blocks']
 
 def _prep_function(*args, **kwargs):
 	"""

--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -49,6 +49,15 @@ if __name__ == 'i3':
 	# Install common packages for all i3 configurations
 	installation.add_additional_packages(__packages__)
 
+	# Install dependency profiles
+	installation.install_profile('xorg')
+
+	# gaps is installed by deafult so we are overriding it here
+	installation.add_additional_packages("lightdm-gtk-greeter lightdm")
+
+	# Auto start lightdm for all users
+	installation.enable_service('lightdm')
+
 	# TODO: Remove magic variable 'installation' and place it
 	#       in archinstall.storage or archinstall.session/archinstall.installation
 	installation.install_profile(archinstall.storage['_desktop_profile'])


### PR DESCRIPTION
This pulls in cherry-picked original i3 commits with authorship and history from 2.2.0.

On top of that, I implemented a common i3 profile that lets you choose a configuration for i3: i3-gaps or i3-wm. This should keep the installation menu from being cluttered.

It's a draft because this is UNTESTED. Use at your own risk, but if you do test it and it works, please let me know. :)