### PR TITLE
OOB in generic_selection

### DIFF
--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -184,7 +184,7 @@ def generic_select(options, input_text="Select one of the above by index or abso
 		return None
 	elif selected_option.isdigit():
 		selected_option = int(selected_option)
-		if selected_option >= len(options):
+		if selected_option > len(options):
 			raise RequirementError(f'Selected option "{selected_option}" is out of range')
 		selected_option = options[selected_option]
 	elif selected_option in options:


### PR DESCRIPTION
Out of bounds check in generic_selection is using >= on list. Lists are zero based. If you put in a value that equals the number of items in the list you get an out of bounds error. 

Removed the equals part of the test as last item in list/dictionary items is len(list)-1 not len(list)

Tested in VM and small netbook.
