### PR TITLE
i3-sensible-terminal can't find a terminal on new install

### DIFF
--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -6,7 +6,7 @@ is_top_level_profile = False
 
 # New way of defining packages for a profile, which is iterable and can be used out side
 # of the profile to get a list of "what packages will be installed".
-__packages__ = ['i3lock', 'i3status', 'i3blocks']
+__packages__ = ['i3lock', 'i3status', 'i3blocks', 'xterm']
 
 def _prep_function(*args, **kwargs):
 	"""


### PR DESCRIPTION
Before:

![VirtualBox_arch_09_04_2021_22_06_43](https://user-images.githubusercontent.com/277927/114254840-e95cc700-997f-11eb-823e-d989327ca708.png)

After:

![VirtualBox_arch_09_04_2021_22_19_21](https://user-images.githubusercontent.com/277927/114255169-adc2fc80-9981-11eb-946e-9dde1f3e3eff.png)


Add a terminal emulator support by https://man.archlinux.org/man/i3-sensible-terminal.1

I tried alacritty and urxvt and they didn't work. xterm's working though. And it's a super small package.
