### PR TITLE
Remove lightdm-gtk-greeter-settings

### DIFF
--- a/profiles/applications/budgie.py
+++ b/profiles/applications/budgie.py
@@ -1,4 +1,4 @@
 import archinstall
 
 # "It is recommended also to install the gnome group, which contains applications required for the standard GNOME experience." - Arch Wiki 
-installation.add_additional_packages("budgie-desktop lightdm lightdm-gtk-greeter lightdm-gtk-greeter-settings gnome")
+installation.add_additional_packages("budgie-desktop lightdm lightdm-gtk-greeter gnome")

--- a/profiles/applications/cinnamon.py
+++ b/profiles/applications/cinnamon.py
@@ -1,3 +1,3 @@
 import archinstall
 
-installation.add_additional_packages("cinnamon system-config-printer gnome-keyring gnome-terminal blueberry metacity lightdm lightdm-gtk-greeter lightdm-gtk-greeter-settings") 
+installation.add_additional_packages("cinnamon system-config-printer gnome-keyring gnome-terminal blueberry metacity lightdm lightdm-gtk-greeter") 

--- a/profiles/applications/xfce4.py
+++ b/profiles/applications/xfce4.py
@@ -1,3 +1,3 @@
 import archinstall
 
-installation.add_additional_packages("xfce4 xfce4-goodies lightdm lightdm-gtk-greeter lightdm-gtk-greeter-settings") 
+installation.add_additional_packages("xfce4 xfce4-goodies lightdm lightdm-gtk-greeter") 


### PR DESCRIPTION
lightdm-gtk-greeter-settings is just a GUI to configure the lightdm GTK greeter. I don't think it's needed out of the box.