### PR TITLE
Show size in partition string representation

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -199,9 +199,9 @@ class Partition():
 			mount_repr = f", rel_mountpoint={self.target_mountpoint}"
 
 		if self._encrypted:
-			return f'Partition(path={self.path}, real_device={self.real_device}, fs={self.filesystem}{mount_repr})'
+			return f'Partition(path={self.path}, size={self.size}, real_device={self.real_device}, fs={self.filesystem}{mount_repr})'
 		else:
-			return f'Partition(path={self.path}, fs={self.filesystem}{mount_repr})'
+			return f'Partition(path={self.path}, size={self.size}, fs={self.filesystem}{mount_repr})'
 
 	@property
 	def uuid(self) -> str:


### PR DESCRIPTION
This might be useful for users to know that they are installing to the right partitions.

Before:

![Screenshot from 2021-04-10 11-09-41](https://user-images.githubusercontent.com/277927/114274672-a0dbf280-99ed-11eb-91cd-b343e2456f47.png)

After:

![Screenshot from 2021-04-10 11-09-57](https://user-images.githubusercontent.com/277927/114274681-ab968780-99ed-11eb-9a3b-70a30582beba.png)
