### PR TITLE
GitHub Actions: Build Arch Live ISO With Each Commit Included

### DIFF
--- a/.github/workflows/iso-build.yaml
+++ b/.github/workflows/iso-build.yaml
@@ -1,0 +1,27 @@
+# This workflow will build an Arch Linux ISO file with the commit on it
+
+name: Build Arch ISO with ArchInstall Commit
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v2
+    - run: pwd
+    - run: find .
+    - run: cat /etc/os-release
+    - run: mkdir -p /tmp/archlive/airootfs/root/archinstall-git; cp -r . /tmp/archlive/airootfs/root/archinstall-git
+    - run: pacman -Sy; pacman --noconfirm -S git archiso
+    - run: cp -r /usr/share/archiso/configs/releng/* /tmp/archlive
+    - run: echo -e "git\npython\npython-pip\npython-setuptools" >> /tmp/archlive/packages.x86_64 
+    - run: find /tmp/archlive
+    - run: cd /tmp/archlive;  mkarchiso -v -w work/ -o out/ ./
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Arch Live ISO
+        path: /tmp/archlive/out/*.iso

--- a/.github/workflows/iso-build.yaml
+++ b/.github/workflows/iso-build.yaml
@@ -16,6 +16,7 @@ jobs:
     - run: find .
     - run: cat /etc/os-release
     - run: mkdir -p /tmp/archlive/airootfs/root/archinstall-git; cp -r . /tmp/archlive/airootfs/root/archinstall-git
+    - run: echo "pip uninstall archinstall -y; cd archinstall-git; python setup.py install; echo 'Type python -m archinstall to launch archinstall'" > /tmp/archlive/airootfs/root/.zprofile
     - run: pacman -Sy; pacman --noconfirm -S git archiso
     - run: cp -r /usr/share/archiso/configs/releng/* /tmp/archlive
     - run: echo -e "git\npython\npython-pip\npython-setuptools" >> /tmp/archlive/packages.x86_64 

--- a/.github/workflows/iso-build.yaml
+++ b/.github/workflows/iso-build.yaml
@@ -2,7 +2,7 @@
 
 name: Build Arch ISO with ArchInstall Commit
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
![Screenshot from 2021-04-10 17-49-08](https://user-images.githubusercontent.com/277927/114285435-2a5ae700-9a25-11eb-8390-c50be989f8f0.png)

![VirtualBox_arch_10_04_2021_20_02_01](https://user-images.githubusercontent.com/277927/114288375-423e6500-9a3d-11eb-9281-0576bfda2496.png)



So this is a really neat CI/CD feature I'm testing out - we can have GitHub automatically build us ISOs to test to avoid having to replace ArchInstall on a vanilla Arch image. I want to get it to automatically launch as well - I think this will prove to be incredibly useful when done.

This will enable the following workflow when reviewing a change/pull request:

* Download ISO
* Start up VM or Write to USB
* The specific ArchInstall commit will be automatically installed and you can run it with python -m archinstall