### PR TITLE
Implement MATE desktop environment

### DIFF
--- a/profiles/applications/mate.py
+++ b/profiles/applications/mate.py
@@ -1,0 +1,3 @@
+import archinstall
+
+installation.add_additional_packages("mate mate-extra lightdm lightdm-gtk-greeter") 

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -16,7 +16,7 @@ def _prep_function(*args, **kwargs):
 	for more input before any other installer steps start.
 	"""
 
-	supported_desktops = ['gnome', 'kde', 'awesome', 'sway', 'cinnamon', 'xfce4', 'lxqt', 'i3', 'budgie']
+	supported_desktops = ['gnome', 'kde', 'awesome', 'sway', 'cinnamon', 'xfce4', 'lxqt', 'i3', 'budgie', 'mate']
 	desktop = archinstall.generic_select(supported_desktops, 'Select your desired desktop environment: ')
 	
 	# Temporarily store the selected desktop profile

--- a/profiles/mate.py
+++ b/profiles/mate.py
@@ -1,0 +1,34 @@
+# A desktop environment using "MATE"
+
+import archinstall
+
+is_top_level_profile = False
+
+def _prep_function(*args, **kwargs):
+	"""
+	Magic function called by the importing installer
+	before continuing any further. It also avoids executing any
+	other code in this stage. So it's a safe way to ask the user
+	for more input before any other installer steps start.
+	"""
+
+	# MATE requires a functional xorg installation.
+	profile = archinstall.Profile(None, 'xorg')
+	with profile.load_instructions(namespace='xorg.py') as imported:
+		if hasattr(imported, '_prep_function'):
+			return imported._prep_function()
+		else:
+			print('Deprecated (??): xorg profile has no _prep_function() anymore')
+
+# Ensures that this code only gets executed if executed
+# through importlib.util.spec_from_file_location("mate", "/somewhere/mate.py")
+# or through conventional import mate
+if __name__ == 'mate':
+	# Install dependency profiles
+	installation.install_profile('xorg')
+
+	# Install the application mate from the template under /applications/
+	mate = archinstall.Application(installation, 'mate')
+	mate.install()
+
+	installation.enable_service('lightdm') # Light Display Manager


### PR DESCRIPTION
![VirtualBox_arch_11_04_2021_10_16_10](https://user-images.githubusercontent.com/277927/114307763-00e69d80-9aaf-11eb-8da8-b81296beb7f8.png)

From MATE homepage:

The MATE Desktop Environment is the continuation of GNOME 2. It provides an intuitive and attractive desktop environment using traditional metaphors for Linux and other Unix-like operating systems. MATE is under active development to add support for new technologies while preserving a traditional desktop experience.

mate-extra is fine here IMO since the install is basically unusable without it and it is really, really minimal for an extra package, unlike the GNOME and KDE ones.