### PR TITLE
Torxed launchwarning

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -17,7 +17,8 @@ from .lib.hardware import *
 __version__ = "2.1.3"
 
 if hasUEFI() is False:
-	log("Archinstall currently only support UEFI booted machines. MBR & Grub is coming in version 2.2.0!")
+	log("Archinstall currently only support UEFI booted machines. MBR & Grub is coming in version 2.2.0!", fg="red", LOG_LEVELS.Error)
+	exit(1)
 
 ## Basic version of arg.parse() supporting:
 ##  --key=value

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -16,6 +16,9 @@ from .lib.hardware import *
 
 __version__ = "2.1.3"
 
+if hasUEFI() is False:
+	log("Archinstall currently only support UEFI booted machines. MBR & Grub is coming in version 2.2.0!")
+
 ## Basic version of arg.parse() supporting:
 ##  --key=value
 ##  --boolean


### PR DESCRIPTION
If UEFI is not detected on launch, the script will log and error and exit.
This will be removed once Grub and MBR is supported in master (v2.2.0)