### PR TITLE
Fix MBR & GRUB warning change

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -17,7 +17,7 @@ from .lib.hardware import *
 __version__ = "2.1.3"
 
 if hasUEFI() is False:
-	log("Archinstall currently only support UEFI booted machines. MBR & GRUB is coming in version 2.2.0!", fg="red", level=LOG_LEVELS.Error)
+	log("ArchInstall currently only supports machines booted with UEFI. MBR & GRUB support is coming in version 2.2.0!", level=LOG_LEVELS.Error, fg="red")
 	exit(1)
 
 ## Basic version of arg.parse() supporting:


### PR DESCRIPTION
This fixes Torxed's latest PR so that archinstall runs again. 