### PR TITLE
Implement chroot prompt after successful installation

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1,4 +1,4 @@
-import os, stat, time, shutil, pathlib
+import os, stat, time, shutil, pathlib, subprocess
 
 from .exceptions import *
 from .disk import *
@@ -81,6 +81,13 @@ class Installer():
 		if not (missing_steps := self.post_install_check()):
 			self.log('Installation completed without any errors. You may now reboot.', bg='black', fg='green', level=LOG_LEVELS.Info)
 			self.sync_log_to_install_medium()
+			self.log("For post-installation tips, see https://wiki.archlinux.org/index.php/Installation_guide#Post-installation", fg="yellow")
+			choice = input("Would you like to chroot into the newly created installation and perform post-installation configuration? [Y/n] ")
+			if choice.lower() in ("y", ""):
+				try:
+					subprocess.check_call(f"arch-chroot {self.target}", shell=True)
+				except:
+					pass
 			return True
 		else:
 			self.log('Some required steps were not successfully installed/configured before leaving the installer:', bg='black', fg='red', level=LOG_LEVELS.Warning)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -81,13 +81,7 @@ class Installer():
 		if not (missing_steps := self.post_install_check()):
 			self.log('Installation completed without any errors. You may now reboot.', bg='black', fg='green', level=LOG_LEVELS.Info)
 			self.sync_log_to_install_medium()
-			self.log("For post-installation tips, see https://wiki.archlinux.org/index.php/Installation_guide#Post-installation", fg="yellow")
-			choice = input("Would you like to chroot into the newly created installation and perform post-installation configuration? [Y/n] ")
-			if choice.lower() in ("y", ""):
-				try:
-					subprocess.check_call(f"arch-chroot {self.target}", shell=True)
-				except:
-					pass
+
 			return True
 		else:
 			self.log('Some required steps were not successfully installed/configured before leaving the installer:', bg='black', fg='red', level=LOG_LEVELS.Warning)
@@ -196,6 +190,9 @@ class Installer():
 
 	def arch_chroot(self, cmd, *args, **kwargs):
 		return self.run_command(cmd)
+
+	def drop_to_shell(self):
+		subprocess.check_call(f"/usr/bin/arch-chroot {self.target}", shell=True)
 
 	def configure_nic(self, nic, dhcp=True, ip=None, gateway=None, dns=None, *args, **kwargs):
 		if dhcp:

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -327,3 +327,11 @@ def perform_installation(mountpoint):
 
 ask_user_questions()
 perform_installation_steps()
+
+installation.log("For post-installation tips, see https://wiki.archlinux.org/index.php/Installation_guide#Post-installation", fg="yellow")
+choice = input("Would you like to chroot into the newly created installation and perform post-installation configuration? [Y/n] ")
+if choice.lower() in ("y", ""):
+	try:
+		installation.drop_to_shell()
+	except:
+		pass


### PR DESCRIPTION
This allows users to chroot into a newly installed system so they can perform further configuration and customization. 

Closes #225 