### PR TITLE
Move to flit as build tool

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,11 +21,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel flit
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        FLIT_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        FLIT_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        flit publish

--- a/.pypirc
+++ b/.pypirc
@@ -1,0 +1,6 @@
+[distutils]
+index-servers =
+   pypi
+
+[pypi]
+repository = https://upload.pypi.org/legacy/

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -1,3 +1,4 @@
+"""Arch Linux installer - guided, templates etc."""
 from .lib.general import *
 from .lib.disk import *
 from .lib.user_interaction import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ Documentation = "https://archinstall.readthedocs.io/"
 archinstall = "archinstall:run_as_a_module"
 
 [tool.flit.sdist]
-include = ["doc/"]
-exclude = ["doc/*.html"]
+include = ["docs/"]
+exclude = ["docs/*.html", "docs/_static","docs/*.png","docs/*.psd"]
 
 [tool.flit.metadata.requires-extra]
 doc = ["sphinx"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,30 @@
 [build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
+
+[tool.flit.metadata]
+module = "archinstall"
+author = "Anton Hvornum"
+author-email = "anton@hvornum.se"
+home-page = "https://archlinux.org"
+classifiers = [ "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+"Programming Language :: Python :: 3.8",
+"Programming Language :: Python :: 3.9",
+"License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+"Operating System :: POSIX :: Linux",
+]
+description-file = "README.md"
+requires-python=">=3.8"
+[tool.flit.metadata.urls]
+Source = "https://github.com/archlinux/archinstall"
+Documentation = "https://archinstall.readthedocs.io/"
+
+[tool.flit.scripts]
+archinstall = "archinstall:run_as_a_module"
+
+[tool.flit.sdist]
+include = ["doc/"]
+exclude = ["doc/*.html"]
+
+[tool.flit.metadata.requires-extra]
+doc = ["sphinx"]


### PR DESCRIPTION
🚨 PR Guidelines:

# New features *(v2.2.0)*

This changes our build tools to flit. I've currently left out setup.py for the archinstall-git package. Ideally this should be dropped as flit generates its own setup.py file for sdist builds. 

# Testing

I've been able to build and install a version made from `python -m flit build`

*These PR guidelines will change after 2021-05-01, which is when `v2.1.4` gets onto the new ISO*
