### PR TITLE
Implement function to set the shell for a user (#291)

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -443,6 +443,12 @@ class Installer():
 
 		o = b''.join(sys_command(f"/usr/bin/arch-chroot {self.target} sh -c \"echo '{user}:{password}' | chpasswd\""))
 		pass
+						  
+	def user_set_shell(self, user, shell):
+		self.log(f'Setting shell for {user} to {shell}', level=LOG_LEVELS.Info)
+
+		o = b''.join(sys_command(f"/usr/bin/arch-chroot {self.target} sh -c \"chsh -s {shell} {user}\""))
+		pass
 
 	def set_keyboard_language(self, language):
 		if len(language.strip()):


### PR DESCRIPTION
I think this closes #291.

This introduces a method to set the shell that can be invoked if archinstall is used as a library, following the convention of examples/minimal.py

This is not used during the guided installation as I don't want to have too many choices and it's easy enough to do via chroot after the install. 