### PR TITLE
Rework input handling in generic_select function and fix language selection by name

### DIFF
--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -266,7 +266,7 @@ def select_disk(dict_o_disks):
 	if len(drives) >= 1:
 		for index, drive in enumerate(drives):
 			print(f"{index}: {drive} ({dict_o_disks[drive]['size'], dict_o_disks[drive].device, dict_o_disks[drive]['label']})")
-		drive = input('Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ')
+		drive = generic_select('Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ', False)
 		if drive.strip() == '/mnt':
 			return None
 		elif drive.isdigit():
@@ -302,7 +302,7 @@ def select_profile(options):
 		print(' -- The above list is a set of pre-programmed profiles. --')
 		print(' -- They might make it easier to install things like desktop environments. --')
 		print(' -- (Leave blank and hit enter to skip this step and continue) --')
-		selected_profile = input('Enter a pre-programmed profile name if you want to install one: ')
+		selected_profile = generic_select('Enter a pre-programmed profile name if you want to install one: ', False)
 
 		if len(selected_profile.strip()) <= 0:
 			return None

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -160,7 +160,7 @@ def ask_to_configure_network():
 	if nic and nic != 'Copy ISO network configuration to installation':
 		if nic == 'Use NetworkManager to control and manage your internet connection':
 			return {'nic': nic,'NetworkManager':True}
-		mode = generic_select(['DHCP (auto detect)', 'IP (static)'], f"Select which mode to configure for {nic}: ")
+		mode = generic_select(['DHCP (auto detect)', 'IP (static)'], f"Select which mode to configure for {nic}: ", False)
 		if mode == 'IP (static)':
 			while 1:
 				ip = input(f"Enter the IP and subnet for {nic} (example: 192.168.0.5/24): ").strip()
@@ -195,7 +195,7 @@ def ask_for_disk_layout():
 		'abort' : 'Abort the installation.'
 	}
 
-	value = generic_select(options.values(), "Found partitions on the selected drive, (select by number) what you want to do: ")
+	value = generic_select(options.values(), "Found partitions on the selected drive, (select by number) what you want to do: ", False)
 	return next((key for key, val in options.items() if val == value), None)
 
 def ask_for_main_filesystem_format():
@@ -206,7 +206,7 @@ def ask_for_main_filesystem_format():
 		'f2fs' : 'f2fs'
 	}
 
-	value = generic_select(options.values(), "Select which filesystem your main partition should use (by number or name): ")
+	value = generic_select(options.values(), "Select which filesystem your main partition should use (by number or name): ", False)
 	return next((key for key, val in options.items() if val == value), None)
 
 def generic_select(options, input_text="Select one of the above by index or absolute value: ", allow_empty_input=True, sort=True):

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -297,10 +297,10 @@ def select_profile(options):
 	profiles = sorted(list(options))
 
 	if len(profiles) >= 1:
-		selected_profile = generic_select(profiles, 'Enter a pre-programmed profile name if you want to install one: ')
-		print(' -- The above list is a set of pre-programmed profiles. --')
+		print(' -- The below list is a set of pre-programmed profiles. --')
 		print(' -- They might make it easier to install things like desktop environments. --')
-		print(' -- (Leave blank and hit enter to skip this step and continue) --')
+		selected_profile = generic_select(profiles, 'Enter a pre-programmed profile name if you want to install one (leave blank to skip): ')
+
 
 		if len(selected_profile.strip()) <= 0:
 			return None

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -297,10 +297,10 @@ def select_profile(options):
 	profiles = sorted(list(options))
 
 	if len(profiles) >= 1:
+		selected_profile = generic_select(profiles, 'Enter a pre-programmed profile name if you want to install one: ')
 		print(' -- The above list is a set of pre-programmed profiles. --')
 		print(' -- They might make it easier to install things like desktop environments. --')
 		print(' -- (Leave blank and hit enter to skip this step and continue) --')
-		selected_profile = generic_select(profiles, 'Enter a pre-programmed profile name if you want to install one: ', False)
 
 		if len(selected_profile.strip()) <= 0:
 			return None

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -266,7 +266,7 @@ def select_disk(dict_o_disks):
 	if len(drives) >= 1:
 		for index, drive in enumerate(drives):
 			print(f"{index}: {drive} ({dict_o_disks[drive]['size'], dict_o_disks[drive].device, dict_o_disks[drive]['label']})")
-		drive = generic_select(drives, 'Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ', False)
+		drive = generic_select([], 'Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ', False)
 		if drive.strip() == '/mnt':
 			return None
 		elif drive.isdigit():
@@ -296,9 +296,6 @@ def select_profile(options):
 	profiles = sorted(list(options))
 
 	if len(profiles) >= 1:
-		for index, profile in enumerate(profiles):
-			print(f"{index}: {profile}")
-
 		print(' -- The above list is a set of pre-programmed profiles. --')
 		print(' -- They might make it easier to install things like desktop environments. --')
 		print(' -- (Leave blank and hit enter to skip this step and continue) --')

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -209,7 +209,7 @@ def ask_for_main_filesystem_format():
 	value = generic_select(options.values(), "Select which filesystem your main partition should use (by number or name): ")
 	return next((key for key, val in options.items() if val == value), None)
 
-def generic_select(options, input_text="Select one of the above by index or absolute value: ", sort=True):
+def generic_select(options, input_text="Select one of the above by index or absolute value: ", allow_empty_input=True, sort=True):
 	"""
 	A generic select function that does not output anything
 	other than the options and their indexes. As an example:
@@ -227,18 +227,27 @@ def generic_select(options, input_text="Select one of the above by index or abso
 	for index, option in enumerate(options):
 		print(f"{index}: {option}")
 
-	selected_option = input(input_text)
-	if len(selected_option.strip()) <= 0:
-		return None
-	elif selected_option.isdigit():
-		selected_option = int(selected_option)
-		if selected_option > len(options):
-			raise RequirementError(f'Selected option "{selected_option}" is out of range')
-		selected_option = options[selected_option]
-	elif selected_option in options:
-		pass # We gave a correct absolute value
-	else:
-		raise RequirementError(f'Selected option "{selected_option}" does not exist in available options: {options}')
+	while True:
+		try:
+			selected_option = input(input_text)
+			if len(selected_option.strip()) == 0:
+				if allow_empty_input:
+					return None
+				raise RequirementError('Please select an option to continue')
+			elif selected_option.isnumeric():
+				selected_option = int(selected_option)
+				if selected_option >= len(options):
+					raise RequirementError(f'Selected option "{selected_option}" is out of range')
+				selected_option = options[selected_option]
+			elif selected_option in options:
+				break # We gave a correct absolute value
+			else:
+				raise RequirementError(f'Selected option "{selected_option}" does not exist in available options: {options}')
+		except RequirementError:
+			log(f" * You entered the option incorrectly, please try again * ", fg='red')
+			continue
+		else:
+			break
 	
 	return selected_option
 

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -367,7 +367,7 @@ def select_language(options, show_only_country_codes=True):
 		# all possible language layouts, and we might want to write
 		# for instance sv-latin1 (if we know that exists) without having to
 		# go through the search step.
-		elif selected_language in options:
+		elif selected_language in languages:
 			return selected_language
 		else:
 			raise RequirementError("Selected language does not exist.")

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -267,7 +267,7 @@ def select_disk(dict_o_disks):
 	if len(drives) >= 1:
 		for index, drive in enumerate(drives):
 			print(f"{index}: {drive} ({dict_o_disks[drive]['size'], dict_o_disks[drive].device, dict_o_disks[drive]['label']})")
-		drive = generic_select(drives, 'Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ', False)
+		drive = generic_select(drives, 'Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ', False, False)
 		if drive.strip() == '/mnt':
 			return None
 		elif drive.isdigit():

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -368,7 +368,6 @@ def select_language(options, show_only_country_codes=True):
 		# for instance sv-latin1 (if we know that exists) without having to
 		# go through the search step.
 		elif selected_language in options:
-			selected_language = options[options.index(selected_language)]
 			return selected_language
 		else:
 			raise RequirementError("Selected language does not exist.")

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -302,8 +302,8 @@ def select_profile(options):
 		selected_profile = generic_select(profiles, 'Enter a pre-programmed profile name if you want to install one (leave blank to skip): ')
 
 
-		if len(selected_profile.strip()) <= 0:
-			return None
+		if selected_profile is None:
+			return selected_profile
 			
 		if selected_profile.isdigit() and (pos := int(selected_profile)) <= len(profiles)-1:
 			selected_profile = profiles[pos]

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -209,7 +209,7 @@ def ask_for_main_filesystem_format():
 	value = generic_select(options.values(), "Select which filesystem your main partition should use (by number or name): ", False)
 	return next((key for key, val in options.items() if val == value), None)
 
-def generic_select(options, input_text="Select one of the above by index or absolute value: ", allow_empty_input=True, sort=True):
+def generic_select(options, input_text="Select one of the above by index or absolute value: ", allow_empty_input=True, options_output=True, sort=True):
 	"""
 	A generic select function that does not output anything
 	other than the options and their indexes. As an example:
@@ -224,8 +224,9 @@ def generic_select(options, input_text="Select one of the above by index or abso
 	if sort: options = sorted(list(options))
 	if len(options) <= 0: raise RequirementError('generic_select() requires at least one option to operate.')
 
-	for index, option in enumerate(options):
-		print(f"{index}: {option}")
+	if options_output:
+		for index, option in enumerate(options):
+			print(f"{index}: {option}")
 
 	while True:
 		try:
@@ -266,7 +267,7 @@ def select_disk(dict_o_disks):
 	if len(drives) >= 1:
 		for index, drive in enumerate(drives):
 			print(f"{index}: {drive} ({dict_o_disks[drive]['size'], dict_o_disks[drive].device, dict_o_disks[drive]['label']})")
-		drive = generic_select([], 'Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ', False)
+		drive = generic_select(drives, 'Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ', False)
 		if drive.strip() == '/mnt':
 			return None
 		elif drive.isdigit():

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -266,7 +266,7 @@ def select_disk(dict_o_disks):
 	if len(drives) >= 1:
 		for index, drive in enumerate(drives):
 			print(f"{index}: {drive} ({dict_o_disks[drive]['size'], dict_o_disks[drive].device, dict_o_disks[drive]['label']})")
-		drive = generic_select('Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ', False)
+		drive = generic_select(drives, 'Select one of the above disks (by number or full path) or write /mnt to skip partitioning: ', False)
 		if drive.strip() == '/mnt':
 			return None
 		elif drive.isdigit():
@@ -302,7 +302,7 @@ def select_profile(options):
 		print(' -- The above list is a set of pre-programmed profiles. --')
 		print(' -- They might make it easier to install things like desktop environments. --')
 		print(' -- (Leave blank and hit enter to skip this step and continue) --')
-		selected_profile = generic_select('Enter a pre-programmed profile name if you want to install one: ', False)
+		selected_profile = generic_select(profiles, 'Enter a pre-programmed profile name if you want to install one: ', False)
 
 		if len(selected_profile.strip()) <= 0:
 			return None

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -359,4 +359,3 @@ def perform_installation(mountpoint):
 
 ask_user_questions()
 perform_installation_steps()
-

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -17,7 +17,7 @@ def _prep_function(*args, **kwargs):
 	"""
 
 	supported_desktops = ['gnome', 'kde', 'awesome', 'sway', 'cinnamon', 'xfce4', 'lxqt', 'i3', 'budgie', 'mate']
-	desktop = archinstall.generic_select(supported_desktops, 'Select your desired desktop environment: ')
+	desktop = archinstall.generic_select(supported_desktops, 'Select your desired desktop environment: ', False)
 	
 	# Temporarily store the selected desktop profile
 	# in a session-safe location, since this module will get reloaded
@@ -52,4 +52,3 @@ if __name__ == 'desktop':
 	# TODO: Remove magic variable 'installation' and place it
 	#       in archinstall.storage or archinstall.session/archinstall.installation
 	installation.install_profile(archinstall.storage['_desktop_profile'])
-

--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -17,7 +17,7 @@ def _prep_function(*args, **kwargs):
 	"""
 
 	supported_configurations = ['i3-wm', 'i3-gaps']
-	desktop = archinstall.generic_select(supported_configurations, 'Select your desired configuration: ')
+	desktop = archinstall.generic_select(supported_configurations, 'Select your desired configuration: ', False)
 
 	# Temporarily store the selected desktop profile
 	# in a session-safe location, since this module will get reloaded

--- a/profiles/xorg.py
+++ b/profiles/xorg.py
@@ -1,5 +1,6 @@
 # A system with "xorg" installed
 
+from archinstall.lib.user_interaction import generic_select
 import archinstall, os
 
 is_top_level_profile = True
@@ -36,9 +37,6 @@ def select_driver(options):
 		for index, driver in enumerate(drivers):
 			print(f"{index}: {driver}")
 
-		print(' -- The above list are supported graphic card drivers. --')
-		print(' -- You need to select (and read about) which one you need. --')
-
 		lspci = archinstall.sys_command(f'/usr/bin/lspci')
 		for line in lspci.trace_log.split(b'\r\n'):
 			if b' vga ' in line.lower():
@@ -48,6 +46,10 @@ def select_driver(options):
 					print(' ** AMD card detected, suggested driver: AMD / ATI **')
 
 		selected_driver = input('Select your graphics card driver: ')
+		selected_driver = generic_select(drivers, 'Select your graphics card driver: ', False)
+
+		print(' -- The above list are supported graphic card drivers. --')
+		print(' -- You need to select (and read about) which one you need. --')
 		initial_option = selected_driver
 
 		# Disabled search for now, only a few profiles exist anyway


### PR DESCRIPTION
# Describe your PR

Rewrote input handling for all `generic_select` calls. Since now, this function prevents from:
- Accepting empty input from user *(Note about this below)*
- Accepting wrong inputs
- Throwing out `IndexError`

Due to different printing info on drive selection, I added `options_output` parameter to disable print options items.

> Note: Because there are places where the input needed to be skipped, I added `allow_empty_input` parameter to allow skipping. Also, the `sort` parameter was never used, so I moved it to the end

As additional patch, I closed last known issue of v2.1.4-RC1 tag:
- *Entering keyboard layouts directly by name in the first prompt is partially broken*

# Testing

Tested on VirtualBox 6.1 by entering possible choices that throw a `RequirementError`
