### PR TITLE
Fix selecting language layout by name

### DIFF
--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -358,8 +358,7 @@ def select_language(options, show_only_country_codes=True):
 		# all possible language layouts, and we might want to write
 		# for instance sv-latin1 (if we know that exists) without having to
 		# go through the search step.
-		elif selected_language in options:
-			selected_language = options[options.index(selected_language)]
+		elif selected_language in languages:
 			return selected_language
 		else:
 			raise RequirementError("Selected language does not exist.")


### PR DESCRIPTION
# Describe your PR

This change fixes issue when selecting keyboard layout by name gave a selection error

# Testing

Tested in VirtualBox 6.1 by typing all available keyboard layouts by name
