### PR TITLE
While somewhat nice to have, archlinux-wallpaper isn't needed in a minimall install

### DIFF
--- a/profiles/applications/lxqt.py
+++ b/profiles/applications/lxqt.py
@@ -1,3 +1,3 @@
 import archinstall
 
-installation.add_additional_packages("lxqt breeze-icons oxygen-icons xdg-utils ttf-freefont leafpad slock archlinux-wallpaper sddm")
+installation.add_additional_packages("lxqt breeze-icons oxygen-icons xdg-utils ttf-freefont leafpad slock sddm")


### PR DESCRIPTION
Simple commit to remove this from default packages on lxqt to save some time/space