### PR TITLE
Avoid some word wrapping on smaller consoles like VirtualBox.

### DIFF
--- a/.github/workflows/iso-build.yaml
+++ b/.github/workflows/iso-build.yaml
@@ -29,7 +29,7 @@ jobs:
     - run: cat /etc/os-release
     - run: mkdir -p /tmp/archlive/airootfs/root/archinstall-git; cp -r . /tmp/archlive/airootfs/root/archinstall-git
     - run: echo "pip uninstall archinstall -y; cd archinstall-git; python setup.py install" > /tmp/archlive/airootfs/root/.zprofile
-    - run: echo "echo \"This is an unofficial ISO for the development and testing of archinstall. No support will be provided.\"" >> /tmp/archlive/airootfs/root/.zprofile
+    - run: echo "echo \"This is an unofficial ISO for development and testing of archinstall. No support will be provided.\"" >> /tmp/archlive/airootfs/root/.zprofile
     - run: echo "echo \"This ISO was built from Git SHA $GITHUB_SHA\"" >> /tmp/archlive/airootfs/root/.zprofile
     - run: echo "echo \"Type archinstall to launch the installer.\"" >> /tmp/archlive/airootfs/root/.zprofile
     - run: cat /tmp/archlive/airootfs/root/.zprofile


### PR DESCRIPTION
Not really needed, but this bothered me more than it should have. 

![VirtualBox_Arch BIOS_28_04_2021_08_58_12](https://user-images.githubusercontent.com/277927/116407712-0c043200-a800-11eb-9710-366604ca9b30.png)
