### PR TITLE
Desktop Environment Cleanup and Switch to Packages Definitions

### DIFF
--- a/profiles/applications/alacritty.py
+++ b/profiles/applications/alacritty.py
@@ -1,3 +1,0 @@
-import archinstall
-
-installation.add_additional_packages("alacritty")

--- a/profiles/applications/budgie.py
+++ b/profiles/applications/budgie.py
@@ -1,4 +1,0 @@
-import archinstall
-
-# "It is recommended also to install the gnome group, which contains applications required for the standard GNOME experience." - Arch Wiki 
-installation.add_additional_packages("budgie-desktop lightdm lightdm-gtk-greeter gnome")

--- a/profiles/applications/cinnamon.py
+++ b/profiles/applications/cinnamon.py
@@ -1,3 +1,0 @@
-import archinstall
-
-installation.add_additional_packages("cinnamon system-config-printer gnome-keyring gnome-terminal blueberry metacity lightdm lightdm-gtk-greeter")

--- a/profiles/applications/deepin.py
+++ b/profiles/applications/deepin.py
@@ -1,5 +1,0 @@
-import archinstall
-
-packages = "deepin deepin-terminal deepin-editor"
-
-installation.add_additional_packages(packages)

--- a/profiles/applications/gnome.py
+++ b/profiles/applications/gnome.py
@@ -1,4 +1,0 @@
-import archinstall
-
-installation.add_additional_packages("gnome gnome-tweaks gdm")
-# Note: gdm should be part of the gnome group, but adding it here for clarity

--- a/profiles/applications/i3-gaps.py
+++ b/profiles/applications/i3-gaps.py
@@ -1,2 +1,0 @@
-import archinstall
-installation.add_additional_packages("i3-gaps")

--- a/profiles/applications/i3-wm.py
+++ b/profiles/applications/i3-wm.py
@@ -1,2 +1,0 @@
-import archinstall
-installation.add_additional_packages("i3-wm")

--- a/profiles/applications/kde.py
+++ b/profiles/applications/kde.py
@@ -1,5 +1,0 @@
-import archinstall
-packages = "plasma-meta konsole kate dolphin sddm plasma-wayland-session"
-if "nvidia" in _gfx_driver_packages:
-	packages = packages + " egl-wayland"
-installation.add_additional_packages(packages)

--- a/profiles/applications/kde.py
+++ b/profiles/applications/kde.py
@@ -1,0 +1,5 @@
+import archinstall
+packages = "plasma-meta konsole kate dolphin sddm plasma-wayland-session"
+if "nvidia" in _gfx_driver_packages:
+	packages = packages + " egl-wayland"
+installation.add_additional_packages(packages)

--- a/profiles/applications/kde.py
+++ b/profiles/applications/kde.py
@@ -1,6 +1,0 @@
-import archinstall
-
-# Other packages for KDE are installed in the main profile now.
-
-if "nvidia" in _gfx_driver_packages:
-	installation.add_additional_packages("egl-wayland")

--- a/profiles/applications/kde.py
+++ b/profiles/applications/kde.py
@@ -1,6 +1,6 @@
 import archinstall
 
-packages = "plasma-meta konsole kate dolphin sddm plasma-wayland-session"
+packages = "" # Other packages for KDE are installed in the main profile now.
 
 if "nvidia" in _gfx_driver_packages:
 	packages = packages + " egl-wayland"

--- a/profiles/applications/kde.py
+++ b/profiles/applications/kde.py
@@ -1,5 +1,8 @@
 import archinstall
+
 packages = "plasma-meta konsole kate dolphin sddm plasma-wayland-session"
+
 if "nvidia" in _gfx_driver_packages:
 	packages = packages + " egl-wayland"
+
 installation.add_additional_packages(packages)

--- a/profiles/applications/kde.py
+++ b/profiles/applications/kde.py
@@ -1,8 +1,6 @@
 import archinstall
 
-packages = "" # Other packages for KDE are installed in the main profile now.
+# Other packages for KDE are installed in the main profile now.
 
 if "nvidia" in _gfx_driver_packages:
-	packages = packages + " egl-wayland"
-
-installation.add_additional_packages(packages)
+	installation.add_additional_packages("egl-wayland")

--- a/profiles/applications/lxqt.py
+++ b/profiles/applications/lxqt.py
@@ -1,3 +1,0 @@
-import archinstall
-
-installation.add_additional_packages("lxqt breeze-icons oxygen-icons xdg-utils ttf-freefont leafpad slock sddm")

--- a/profiles/applications/mate.py
+++ b/profiles/applications/mate.py
@@ -1,3 +1,0 @@
-import archinstall
-
-installation.add_additional_packages("mate mate-extra lightdm lightdm-gtk-greeter") 

--- a/profiles/applications/sway.py
+++ b/profiles/applications/sway.py
@@ -1,3 +1,0 @@
-import archinstall
-__packages__ = "sway swaylock swayidle waybar dmenu light grim slurp pavucontrol alacritty"
-installation.add_additional_packages(__packages__)

--- a/profiles/applications/xfce4.py
+++ b/profiles/applications/xfce4.py
@@ -1,3 +1,0 @@
-import archinstall
-__packages__ = "xfce4 xfce4-goodies lightdm lightdm-gtk-greeter"
-installation.add_additional_packages(__packages__)

--- a/profiles/awesome.py
+++ b/profiles/awesome.py
@@ -6,7 +6,7 @@ is_top_level_profile = False
 
 # New way of defining packages for a profile, which is iterable and can be used out side
 # of the profile to get a list of "what packages will be installed".
-__packages__ = ['nemo', 'gpicview-gtk3', 'scrot']
+__packages__ = ['nemo', 'gpicview-gtk3', 'scrot', 'alacritty']
 
 def _prep_function(*args, **kwargs):
 	"""
@@ -34,9 +34,6 @@ if __name__ == 'awesome':
 	awesome.install()
 
 	installation.add_additional_packages(__packages__)
-
-	alacritty = archinstall.Application(installation, 'alacritty')
-	alacritty.install()
 
 	# TODO: Copy a full configuration to ~/.config/awesome/rc.lua instead.
 	with open(f'{installation.target}/etc/xdg/awesome/rc.lua', 'r') as fh:

--- a/profiles/budgie.py
+++ b/profiles/budgie.py
@@ -4,6 +4,9 @@ import archinstall
 
 is_top_level_profile = False
 
+# "It is recommended also to install the gnome group, which contains applications required for the standard GNOME experience." - Arch Wiki 
+__packages__ = ["budgie-desktop", "lightdm", "lightdm-gtk-greeter", "gnome"]
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer
@@ -27,8 +30,7 @@ if __name__ == 'budgie':
 	# Install dependency profiles
 	installation.install_profile('xorg')
 
-	# Install the application budgie from the template under /applications/
-	budgie = archinstall.Application(installation, 'budgie')
-	budgie.install()
+	# Install the Budgie packages
+	installation.add_additional_packages(__packages__)
 
 	installation.enable_service('lightdm') # Light Display Manager

--- a/profiles/cinnamon.py
+++ b/profiles/cinnamon.py
@@ -4,6 +4,8 @@ import archinstall
 
 is_top_level_profile = False
 
+__packages__ = ["cinnamon", "system-config-printer", "gnome-keyring", "gnome-terminal", "blueberry", "metacity", "lightdm", "lightdm-gtk-greeter"]
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/cinnamon.py
+++ b/profiles/cinnamon.py
@@ -27,8 +27,7 @@ if __name__ == 'cinnamon':
 	# Install dependency profiles
 	installation.install_profile('xorg')
 
-	# Install the application cinnamon from the template under /applications/
-	cinnamon = archinstall.Application(installation, 'cinnamon')
-	cinnamon.install()
+	# Install the Cinnamon packages
+	installation.add_additional_packages(__packages__)
 
 	installation.enable_service('lightdm') # Light Display Manager

--- a/profiles/deepin.py
+++ b/profiles/deepin.py
@@ -4,6 +4,7 @@ import archinstall, os
 
 is_top_level_profile = False
 
+__packages__ = ["deepin", "deepin-terminal", "deepin-editor"]
 
 def _prep_function(*args, **kwargs):
 	"""

--- a/profiles/deepin.py
+++ b/profiles/deepin.py
@@ -29,9 +29,8 @@ if __name__ == 'deepin':
 	# Install dependency profiles
 	installation.install_profile('xorg')
 
-	# Install the application deepin from the template under /applications/
-	deepin = archinstall.Application(installation, 'deepin')
-	deepin.install()
+	# Install the Deepin packages
+	installation.add_additional_packages(__packages__)
 
 	# Enable autostart of Deepin for all users
 	installation.enable_service('lightdm')

--- a/profiles/gnome.py
+++ b/profiles/gnome.py
@@ -4,6 +4,9 @@ import archinstall
 
 is_top_level_profile = False
 
+# Note: GDM should be part of the gnome group, but adding it here for clarity
+__packages__ = ["gnome". "gnome-tweaks", "gdm"]
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/gnome.py
+++ b/profiles/gnome.py
@@ -28,9 +28,8 @@ if __name__ == 'gnome':
 	# Install dependency profiles
 	installation.install_profile('xorg')
 
-	# Install the application gnome from the template under /applications/
-	gnome = archinstall.Application(installation, 'gnome')
-	gnome.install()
+	# Install the GNOME packages
+	installation.add_additional_packages(__packages__)
 
 	installation.enable_service('gdm') # Gnome Display Manager
 	# We could also start it via xinitrc since we do have Xorg,

--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -60,5 +60,4 @@ if __name__ == 'i3':
 	installation.enable_service('lightdm')
 
 	# install the i3 group now
-	i3 = archinstall.Application(installation, archinstall.storage['_i3_configuration'])
-	i3.install()
+	installation.add_additional_packages(installation, archinstall.storage['_i3_configuration'])

--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -39,7 +39,10 @@ if __name__ == 'kde':
 	# Install dependency profiles
 	installation.install_profile('xorg')
 
-	# Install the application kde from the template under /applications/
+	# Install the KDE packages
+	installation.add_additional_packages(__packages__)
+
+	# Run KDE application configuration
 	kde = archinstall.Application(installation, 'kde')
 	kde.install()
 

--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -4,6 +4,8 @@ import archinstall, os
 
 is_top_level_profile = False
 
+__packages__ = ["plasma-meta", "konsole", "kate", "dolphin", "sddm", "plasma-wayland-session"]
+
 # TODO: Remove hard dependency of bash (due to .bash_profile)
 
 def _prep_function(*args, **kwargs):

--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -4,7 +4,7 @@ import archinstall, os
 
 is_top_level_profile = False
 
-__packages__ = ["plasma-meta", "konsole", "kate", "dolphin", "sddm", "plasma-wayland-session"]
+__packages__ = ["plasma-meta", "konsole", "kate", "dolphin", "sddm", "plasma-wayland-session", "egl-wayland"]
 
 # TODO: Remove hard dependency of bash (due to .bash_profile)
 
@@ -41,10 +41,6 @@ if __name__ == 'kde':
 
 	# Install the KDE packages
 	installation.add_additional_packages(__packages__)
-
-	# Run KDE application configuration
-	kde = archinstall.Application(installation, 'kde')
-	kde.install()
 
 	# Enable autostart of KDE for all users
 	installation.enable_service('sddm')

--- a/profiles/lxqt.py
+++ b/profiles/lxqt.py
@@ -28,8 +28,7 @@ if __name__ == 'lxqt':
 	# Install dependency profiles
 	installation.install_profile('xorg')
 
-	# Install the application xfce4 from the template under /applications/
-	xfce = archinstall.Application(installation, 'lxqt')
-	xfce.install()
+	# Install the LXQt packages
+	installation.add_additional_packages(__packages__)
 
 	installation.enable_service('sddm') # SDDM Display Manager

--- a/profiles/lxqt.py
+++ b/profiles/lxqt.py
@@ -5,6 +5,8 @@ import archinstall
 
 is_top_level_profile = False
 
+__packages__ = ["lxqt", "breeze-icons", "oxygen-icons", "xdg-utils", "ttf-freefont", "leafpad", "slock", "sddm"]
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/mate.py
+++ b/profiles/mate.py
@@ -27,8 +27,7 @@ if __name__ == 'mate':
 	# Install dependency profiles
 	installation.install_profile('xorg')
 
-	# Install the application mate from the template under /applications/
-	mate = archinstall.Application(installation, 'mate')
-	mate.install()
+	# Install the MATE packages
+	installation.add_additional_packages(__packages__)
 
 	installation.enable_service('lightdm') # Light Display Manager

--- a/profiles/mate.py
+++ b/profiles/mate.py
@@ -4,6 +4,8 @@ import archinstall
 
 is_top_level_profile = False
 
+__packages__ = ["mate", "mate-extra", "lightdm", "lightdm-gtk-greeter"]
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -4,6 +4,8 @@ import archinstall
 
 is_top_level_profile = False
 
+__packages__ = ["sway", "swaylock", "swayidle", "waybar", "dmenu", "light", "grim", "slurp", "pavucontrol", "alacritty"]
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -24,6 +24,5 @@ def _prep_function(*args, **kwargs):
 # through importlib.util.spec_from_file_location("sway", "/somewhere/sway.py")
 # or through conventional import sway
 if __name__ == 'sway':
-	# Install the application sway from the template under /applications/
-	sway = archinstall.Application(installation, 'sway')
-	sway.install()
+	# Install the Sway packages
+	installation.add_additional_packages(__packages__)

--- a/profiles/xfce4.py
+++ b/profiles/xfce4.py
@@ -5,6 +5,8 @@ import archinstall
 
 is_top_level_profile = False
 
+__packages__ = ["xfce4", "xfce4-goodies", "lightdm", "lightdm-gtk-greeter"]
+
 def _prep_function(*args, **kwargs):
 	"""
 	Magic function called by the importing installer

--- a/profiles/xfce4.py
+++ b/profiles/xfce4.py
@@ -28,8 +28,7 @@ if __name__ == 'xfce4':
 	# Install dependency profiles
 	installation.install_profile('xorg')
 
-	# Install the application xfce4 from the template under /applications/
-	xfce = archinstall.Application(installation, 'xfce4')
-	xfce.install()
+	# Install the XFCE4 packages
+	installation.add_additional_packages(__packages__)
 
 	installation.enable_service('lightdm') # Light Display Manager


### PR DESCRIPTION
This removes a lot of unneeded files (basically keeping the application profiles for when we're doing customization or other configuration only) and adds a packages declaration to each desktop environment on the top-level so it can be parsed out to see what packages are installed.