### PR TITLE
Fixed a typo in the last PR https://github.com/archlinux/archinstall/pull/378

### DIFF
--- a/profiles/gnome.py
+++ b/profiles/gnome.py
@@ -5,7 +5,7 @@ import archinstall
 is_top_level_profile = False
 
 # Note: GDM should be part of the gnome group, but adding it here for clarity
-__packages__ = ["gnome". "gnome-tweaks", "gdm"]
+__packages__ = ["gnome", "gnome-tweaks", "gdm"]
 
 def _prep_function(*args, **kwargs):
 	"""


### PR DESCRIPTION

replaced a `.` with a `,` in gnome.py profile.

🚨 PR Guidelines:

# Describe your PR

Fixed a small typo in gnome.py profile. Replacing `.` with a `,` in packages.

# Testing

No Testing required