### PR TITLE
Add nginx application profile

### DIFF
--- a/profiles/applications/nginx.py
+++ b/profiles/applications/nginx.py
@@ -1,0 +1,9 @@
+import archinstall
+
+# Define the package list in order for lib to source
+# which packages will be installed by this profile
+__packages__ = ["nginx"]
+
+installation.add_additional_packages(__packages__)
+
+installation.enable_service('nginx')


### PR DESCRIPTION
Similar to Torxed's postgresql profile, this is the start of an nginx application profile - not exposed via guided installation, but for library usage.