### PR TITLE
Add MariaDB Application Profile

### DIFF
--- a/profiles/applications/mariadb.py
+++ b/profiles/applications/mariadb.py
@@ -1,0 +1,11 @@
+import archinstall
+
+# Define the package list in order for lib to source
+# which packages will be installed by this profile
+__packages__ = ["mariadb"]
+
+installation.add_additional_packages(__packages__)
+
+installation.arch_chroot("mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql")
+
+installation.enable_service('mariadb')


### PR DESCRIPTION
Similar to PostgreSQL or Nginx this is intended to improve using ArchInstall as a library and won't be exposed via guided.