### PR TITLE
Add Apache HTTPD Application Profile

### DIFF
--- a/profiles/applications/httpd.py
+++ b/profiles/applications/httpd.py
@@ -1,0 +1,9 @@
+import archinstall
+
+# Define the package list in order for lib to source
+# which packages will be installed by this profile
+__packages__ = ["apache"]
+
+installation.add_additional_packages(__packages__)
+
+installation.enable_service('httpd')


### PR DESCRIPTION
Similar to PostgreSQL or Nginx this is intended to improve using ArchInstall as a library and won't be exposed via guided.