### PR TITLE
Add Tomcat application profile

### DIFF
--- a/profiles/applications/tomcat.py
+++ b/profiles/applications/tomcat.py
@@ -1,0 +1,12 @@
+import archinstall
+
+# This is using Tomcat 10 as that is the latest release at the time of implementation.
+# This should probably be updated to use newer releases as they come out.
+
+# Define the package list in order for lib to source
+# which packages will be installed by this profile
+__packages__ = ["tomcat10"]
+
+installation.add_additional_packages(__packages__)
+
+installation.enable_service('tomcat10')


### PR DESCRIPTION
Using Tomcat 10 as that is the latest release.

Similar to PostgreSQL or Nginx this is intended to improve using ArchInstall as a library and won't be exposed via guided.