### PR TITLE
Add cockpit application profile

### DIFF
--- a/profiles/applications/cockpit.py
+++ b/profiles/applications/cockpit.py
@@ -1,0 +1,9 @@
+import archinstall
+
+# Define the package list in order for lib to source
+# which packages will be installed by this profile
+__packages__ = ["cockpit", "udisks2", "packagekit"]
+
+installation.add_additional_packages(__packages__)
+
+installation.enable_service('cockpit.socket')


### PR DESCRIPTION
This adds Cockpit (https://cockpit-project.org/running.html#archlinux) as an application package option.