### PR TITLE
add dmenu dependency to i3 profile

### DIFF
--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -6,7 +6,7 @@ is_top_level_profile = False
 
 # New way of defining packages for a profile, which is iterable and can be used out side
 # of the profile to get a list of "what packages will be installed".
-__packages__ = ['i3lock', 'i3status', 'i3blocks', 'xterm', 'lightdm-gtk-greeter', 'lightdm']
+__packages__ = ['i3lock', 'i3status', 'i3blocks', 'xterm', 'lightdm-gtk-greeter', 'lightdm', 'dmenu']
 
 def _prep_function(*args, **kwargs):
 	"""


### PR DESCRIPTION
`dmenu` is configured as the default launcher (🐧-SPACE key)
in the default i3 configuration.

The same dependency exists for the same reason in the `sway` profile