### PR TITLE
BC: Replaced the magic __builtin__ global variable for installation

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -452,14 +452,7 @@ class Installer():
 		return self.pacstrap(*packages)
 
 	def install_profile(self, profile):
-		# TODO: Replace this with a import archinstall.session instead in the profiles.
-		# The tricky thing with doing the import archinstall.session instead is that
-		# profiles might be run from a different chroot, and there's no way we can
-		# guarantee file-path safety when accessing the installer object that way.
-		# Doing the __builtins__ replacement, ensures that the global variable "installation"
-		# is always kept up to date. It's considered a nasty hack - but it's a safe way
-		# of ensuring 100% accuracy of archinstall session variables.
-		__builtins__['installation'] = self
+		storage['installation_session'] = self
 
 		if type(profile) == str:
 			profile = Profile(self, profile)

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -36,7 +36,7 @@ def list_profiles(filter_irrelevant_macs=True, subpath='', filter_top_level_prof
 					description = ''
 					with open(os.path.join(root, file), 'r') as fh:
 						first_line = fh.readline()
-						if first_line[0] == '#':
+						if len(first_line) and first_line[0] == '#':
 							description = first_line[1:].strip()
 
 					cache[file[:-3]] = {'path' : os.path.join(root, file), 'description' : description, 'tailored' : tailored}

--- a/profiles/52-54-00-12-34-56.py
+++ b/profiles/52-54-00-12-34-56.py
@@ -5,7 +5,7 @@ import urllib.request
 __packages__ = ['nano', 'wget', 'git']
 
 if __name__ == '52-54-00-12-34-56':
-	awesome = archinstall.Application(installation, 'postgresql')
+	awesome = archinstall.Application(archinstall.storage['installation_session'], 'postgresql')
 	awesome.install()
 	
 """

--- a/profiles/applications/awesome.py
+++ b/profiles/applications/awesome.py
@@ -2,11 +2,11 @@ import archinstall
 
 __packages__ = ["awesome", "xorg-xrandr", "xterm", "feh", "slock", "terminus-font", "gnu-free-fonts", "ttf-liberation", "xsel"]
 
-installation.install_profile('xorg')
+archinstall.storage['installation_session'].install_profile('xorg')
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-with open(f'{installation.target}/etc/X11/xinit/xinitrc', 'r') as xinitrc:
+with open(f"{archinstall.storage['installation_session'].target}/etc/X11/xinit/xinitrc", 'r') as xinitrc:
 	xinitrc_data = xinitrc.read()
 
 for line in xinitrc_data.split('\n'):
@@ -20,5 +20,5 @@ for line in xinitrc_data.split('\n'):
 xinitrc_data += '\n'
 xinitrc_data += 'exec awesome\n'
 
-with open(f'{installation.target}/etc/X11/xinit/xinitrc', 'w') as xinitrc:
+with open(f"{archinstall.storage['installation_session'].target}/etc/X11/xinit/xinitrc", 'w') as xinitrc:
 	xinitrc.write(xinitrc_data)

--- a/profiles/applications/cockpit.py
+++ b/profiles/applications/cockpit.py
@@ -4,6 +4,6 @@ import archinstall
 # which packages will be installed by this profile
 __packages__ = ["cockpit", "udisks2", "packagekit"]
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-installation.enable_service('cockpit.socket')
+archinstall.storage['installation_session'].enable_service('cockpit.socket')

--- a/profiles/applications/docker.py
+++ b/profiles/applications/docker.py
@@ -4,6 +4,6 @@ import archinstall
 # which packages will be installed by this profile
 __packages__ = ["docker"]
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-installation.enable_service('docker')
+archinstall.storage['installation_session'].enable_service('docker')

--- a/profiles/applications/httpd.py
+++ b/profiles/applications/httpd.py
@@ -4,6 +4,6 @@ import archinstall
 # which packages will be installed by this profile
 __packages__ = ["apache"]
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-installation.enable_service('httpd')
+archinstall.storage['installation_session'].enable_service('httpd')

--- a/profiles/applications/lighttpd.py
+++ b/profiles/applications/lighttpd.py
@@ -4,6 +4,6 @@ import archinstall
 # which packages will be installed by this profile
 __packages__ = ["lighttpd"]
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-installation.enable_service('lighttpd')
+archinstall.storage['installation_session'].enable_service('lighttpd')

--- a/profiles/applications/mariadb.py
+++ b/profiles/applications/mariadb.py
@@ -4,8 +4,8 @@ import archinstall
 # which packages will be installed by this profile
 __packages__ = ["mariadb"]
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-installation.arch_chroot("mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql")
+archinstall.storage['installation_session'].arch_chroot("mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql")
 
-installation.enable_service('mariadb')
+archinstall.storage['installation_session'].enable_service('mariadb')

--- a/profiles/applications/nginx.py
+++ b/profiles/applications/nginx.py
@@ -4,6 +4,6 @@ import archinstall
 # which packages will be installed by this profile
 __packages__ = ["nginx"]
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-installation.enable_service('nginx')
+archinstall.storage['installation_session'].enable_service('nginx')

--- a/profiles/applications/postgresql.py
+++ b/profiles/applications/postgresql.py
@@ -4,8 +4,8 @@ import archinstall
 # which packages will be installed by this profile
 __packages__ = ["postgresql"]
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-installation.arch_chroot("initdb -D /var/lib/postgres/data", runas='postgres')
+archinstall.storage['installation_session'].arch_chroot("initdb -D /var/lib/postgres/data", runas='postgres')
 
-installation.enable_service('postgresql')
+archinstall.storage['installation_session'].enable_service('postgresql')

--- a/profiles/applications/sshd.py
+++ b/profiles/applications/sshd.py
@@ -4,6 +4,6 @@ import archinstall
 # which packages will be installed by this profile
 __packages__ = ["openssh"]
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-installation.enable_service('sshd')
+archinstall.storage['installation_session'].enable_service('sshd')

--- a/profiles/applications/tomcat.py
+++ b/profiles/applications/tomcat.py
@@ -7,6 +7,6 @@ import archinstall
 # which packages will be installed by this profile
 __packages__ = ["tomcat10"]
 
-installation.add_additional_packages(__packages__)
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-installation.enable_service('tomcat10')
+archinstall.storage['installation_session'].enable_service('tomcat10')

--- a/profiles/awesome.py
+++ b/profiles/awesome.py
@@ -30,23 +30,23 @@ def _prep_function(*args, **kwargs):
 # or through conventional import awesome
 if __name__ == 'awesome':
 	# Install the application awesome from the template under /applications/
-	awesome = archinstall.Application(installation, 'awesome')
+	awesome = archinstall.Application(archinstall.storage['installation_session'], 'awesome')
 	awesome.install()
 
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
 	# TODO: Copy a full configuration to ~/.config/awesome/rc.lua instead.
-	with open(f'{installation.target}/etc/xdg/awesome/rc.lua', 'r') as fh:
+	with open(f'{archinstall.storage['installation_session'].target}/etc/xdg/awesome/rc.lua', 'r') as fh:
 		awesome_lua = fh.read()
 
 	## Replace xterm with alacritty for a smoother experience.
 	awesome_lua = awesome_lua.replace('"xterm"', '"alacritty"')
 
-	with open(f'{installation.target}/etc/xdg/awesome/rc.lua', 'w') as fh:
+	with open(f'{archinstall.storage['installation_session'].target}/etc/xdg/awesome/rc.lua', 'w') as fh:
 		fh.write(awesome_lua)
 
 	## TODO: Configure the right-click-menu to contain the above packages that were installed. (as a user config)
 	
 	## Remove some interfering nemo settings
-	installation.arch_chroot("gsettings set org.nemo.desktop show-desktop-icons false")
-	installation.arch_chroot("xdg-mime default nemo.desktop inode/directory application/x-gnome-saved-search")
+	archinstall.storage['installation_session'].arch_chroot("gsettings set org.nemo.desktop show-desktop-icons false")
+	archinstall.storage['installation_session'].arch_chroot("xdg-mime default nemo.desktop inode/directory application/x-gnome-saved-search")

--- a/profiles/awesome.py
+++ b/profiles/awesome.py
@@ -36,13 +36,13 @@ if __name__ == 'awesome':
 	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
 	# TODO: Copy a full configuration to ~/.config/awesome/rc.lua instead.
-	with open(f'{archinstall.storage['installation_session'].target}/etc/xdg/awesome/rc.lua', 'r') as fh:
+	with open(f"{archinstall.storage['installation_session'].target}/etc/xdg/awesome/rc.lua", 'r') as fh:
 		awesome_lua = fh.read()
 
 	## Replace xterm with alacritty for a smoother experience.
 	awesome_lua = awesome_lua.replace('"xterm"', '"alacritty"')
 
-	with open(f'{archinstall.storage['installation_session'].target}/etc/xdg/awesome/rc.lua', 'w') as fh:
+	with open(f"{archinstall.storage['installation_session'].target}/etc/xdg/awesome/rc.lua", 'w') as fh:
 		fh.write(awesome_lua)
 
 	## TODO: Configure the right-click-menu to contain the above packages that were installed. (as a user config)

--- a/profiles/budgie.py
+++ b/profiles/budgie.py
@@ -28,9 +28,9 @@ def _prep_function(*args, **kwargs):
 # or through conventional import budgie
 if __name__ == 'budgie':
 	# Install dependency profiles
-	installation.install_profile('xorg')
+	archinstall.storage['installation_session'].install_profile('xorg')
 
 	# Install the Budgie packages
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-	installation.enable_service('lightdm') # Light Display Manager
+	archinstall.storage['installation_session'].enable_service('lightdm') # Light Display Manager

--- a/profiles/cinnamon.py
+++ b/profiles/cinnamon.py
@@ -27,9 +27,9 @@ def _prep_function(*args, **kwargs):
 # or through conventional import cinnamon
 if __name__ == 'cinnamon':
 	# Install dependency profiles
-	installation.install_profile('xorg')
+	archinstall.storage['installation_session'].install_profile('xorg')
 
 	# Install the Cinnamon packages
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-	installation.enable_service('lightdm') # Light Display Manager
+	archinstall.storage['installation_session'].enable_service('lightdm') # Light Display Manager

--- a/profiles/deepin.py
+++ b/profiles/deepin.py
@@ -28,10 +28,10 @@ def _prep_function(*args, **kwargs):
 # or through conventional import deepin
 if __name__ == 'deepin':
 	# Install dependency profiles
-	installation.install_profile('xorg')
+	archinstall.storage['installation_session'].install_profile('xorg')
 
 	# Install the Deepin packages
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
 	# Enable autostart of Deepin for all users
-	installation.enable_service('lightdm')
+	archinstall.storage['installation_session'].enable_service('lightdm')

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -48,9 +48,7 @@ if __name__ == 'desktop':
 	"""
 	
 	# Install common packages for all desktop environments
-	installation.add_additional_packages(__packages__)
-
-	# TODO: Remove magic variable 'installation' and place it
-	#       in archinstall.storage or archinstall.session/archinstall.installation
-	installation.install_profile(archinstall.storage['_desktop_profile'])
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
+	
+	archinstall.storage['installation_session'].install_profile(archinstall.storage['_desktop_profile'])
 

--- a/profiles/gnome.py
+++ b/profiles/gnome.py
@@ -29,11 +29,11 @@ def _prep_function(*args, **kwargs):
 # or through conventional import gnome
 if __name__ == 'gnome':
 	# Install dependency profiles
-	installation.install_profile('xorg')
+	archinstall.storage['installation_session'].install_profile('xorg')
 
 	# Install the GNOME packages
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-	installation.enable_service('gdm') # Gnome Display Manager
+	archinstall.storage['installation_session'].enable_service('gdm') # Gnome Display Manager
 	# We could also start it via xinitrc since we do have Xorg,
 	# but for gnome that's deprecated and wayland is preferred.

--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -48,16 +48,16 @@ if __name__ == 'i3':
 	"""
 	
 	# Install common packages for all i3 configurations
-	installation.add_additional_packages(__packages__[:4])
+	archinstall.storage['installation_session'].add_additional_packages(__packages__[:4])
 
 	# Install dependency profiles
-	installation.install_profile('xorg')
+	archinstall.storage['installation_session'].install_profile('xorg')
 
 	# gaps is installed by deafult so we are overriding it here with lightdm
-	installation.add_additional_packages(__packages__[4:])
+	archinstall.storage['installation_session'].add_additional_packages(__packages__[4:])
 
 	# Auto start lightdm for all users
-	installation.enable_service('lightdm')
+	archinstall.storage['installation_session'].enable_service('lightdm')
 
 	# install the i3 group now
-	installation.add_additional_packages(archinstall.storage['_i3_configuration'])
+	archinstall.storage['installation_session'].add_additional_packages(archinstall.storage['_i3_configuration'])

--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -37,10 +37,10 @@ def _post_install(*args, **kwargs):
 # or through conventional import kde
 if __name__ == 'kde':
 	# Install dependency profiles
-	installation.install_profile('xorg')
+	archinstall.storage['installation_session'].install_profile('xorg')
 
 	# Install the KDE packages
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
 	# Enable autostart of KDE for all users
-	installation.enable_service('sddm')
+	archinstall.storage['installation_session'].enable_service('sddm')

--- a/profiles/lxqt.py
+++ b/profiles/lxqt.py
@@ -28,9 +28,9 @@ def _prep_function(*args, **kwargs):
 # or through conventional import lxqt
 if __name__ == 'lxqt':
 	# Install dependency profiles
-	installation.install_profile('xorg')
+	archinstall.storage['installation_session'].install_profile('xorg')
 
 	# Install the LXQt packages
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-	installation.enable_service('sddm') # SDDM Display Manager
+	archinstall.storage['installation_session'].enable_service('sddm') # SDDM Display Manager

--- a/profiles/mate.py
+++ b/profiles/mate.py
@@ -27,9 +27,9 @@ def _prep_function(*args, **kwargs):
 # or through conventional import mate
 if __name__ == 'mate':
 	# Install dependency profiles
-	installation.install_profile('xorg')
+	archinstall.storage['installation_session'].install_profile('xorg')
 
 	# Install the MATE packages
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-	installation.enable_service('lightdm') # Light Display Manager
+	archinstall.storage['installation_session'].enable_service('lightdm') # Light Display Manager

--- a/profiles/server.py
+++ b/profiles/server.py
@@ -24,7 +24,7 @@ if __name__ == 'server':
 	archinstall.log(archinstall.storage['_selected_servers'], level=logging.DEBUG)
 	for server in archinstall.storage['_selected_servers']:
 		archinstall.log(f'Installing {server} ...', level=logging.INFO)
-		app = archinstall.Application(installation, server)
+		app = archinstall.Application(archinstall.storage['installation_session'], server)
 		app.install()
 
 	archinstall.log('If your selections included multiple servers with the same port, you may have to reconfigure them.', fg="yellow", level=logging.INFO)

--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -44,7 +44,7 @@ if __name__ == "sway":
 			)
 
 	# Install the Sway packages
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
 	# Install the graphics driver packages
-	installation.add_additional_packages(_gfx_driver_packages)
+	archinstall.storage['installation_session'].add_additional_packages(_gfx_driver_packages)

--- a/profiles/xfce4.py
+++ b/profiles/xfce4.py
@@ -28,9 +28,9 @@ def _prep_function(*args, **kwargs):
 # or through conventional import xfce4
 if __name__ == 'xfce4':
 	# Install dependency profiles
-	installation.install_profile('xorg')
+	archinstall.storage['installation_session'].install_profile('xorg')
 
 	# Install the XFCE4 packages
-	installation.add_additional_packages(__packages__)
+	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
-	installation.enable_service('lightdm') # Light Display Manager
+	archinstall.storage['installation_session'].enable_service('lightdm') # Light Display Manager

--- a/profiles/xorg.py
+++ b/profiles/xorg.py
@@ -28,22 +28,12 @@ def _prep_function(*args, **kwargs):
 if __name__ == 'xorg':
 	try:
 		if "nvidia" in _gfx_driver_packages:
-			if "linux-zen" in installation.base_packages or "linux-lts" in installation.base_packages:
-				installation.add_additional_packages("dkms")#I've had kernel regen fail if it wasn't installed before nvidia-dkms
-				installation.add_additional_packages("xorg-server xorg-xinit nvidia-dkms")
+			if "linux-zen" in archinstall.storage['installation_session'].base_packages or "linux-lts" in archinstall.storage['installation_session'].base_packages:
+				archinstall.storage['installation_session'].add_additional_packages("dkms")#I've had kernel regen fail if it wasn't installed before nvidia-dkms
+				archinstall.storage['installation_session'].add_additional_packages("xorg-server xorg-xinit nvidia-dkms")
 			else:
-				installation.add_additional_packages(f"xorg-server xorg-xinit {' '.join(_gfx_driver_packages)}")
+				archinstall.storage['installation_session'].add_additional_packages(f"xorg-server xorg-xinit {' '.join(_gfx_driver_packages)}")
 		else:
-			installation.add_additional_packages(f"xorg-server xorg-xinit {' '.join(_gfx_driver_packages)}")
+			archinstall.storage['installation_session'].add_additional_packages(f"xorg-server xorg-xinit {' '.join(_gfx_driver_packages)}")
 	except:
-		installation.add_additional_packages(f"xorg-server xorg-xinit") # Prep didn't run, so there's no driver to install
-
-	# with open(f'{installation.mountpoint}/etc/X11/xinit/xinitrc', 'a') as X11:
-	# 	X11.write('setxkbmap se\n')
-
-	# with open(f'{installation.mountpoint}/etc/vconsole.conf', 'a') as vconsole:
-	# 	vconsole.write('KEYMAP={keyboard_layout}\n'.format(**arguments))
-	# 	vconsole.write('FONT=lat9w-16\n')
-
-	# awesome = archinstall.Application(installation, 'awesome')
-	# awesome.install()
+		archinstall.storage['installation_session'].add_additional_packages(f"xorg-server xorg-xinit") # Prep didn't run, so there's no driver to install


### PR DESCRIPTION
This will break existing profiles if anyone has created their own profiles.
However, it will be a more reliably and robust change for the future.

This replaces `__builtin__['installation']` with `archinstall.storage['installation_session']`