### PR TITLE
Fixes dual-boot and /boot getting wiped accidentally

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -321,9 +321,6 @@ class Partition():
 		if log_formatting:
 			log(f'Formatting {path} -> {filesystem}', level=logging.INFO)
 
-		if path == '/dev/sda1' and filesystem == 'vfat':
-			raise ValueError("Debugging breakpoint!")
-
 		if filesystem == 'btrfs':
 			o = b''.join(sys_command(f'/usr/bin/mkfs.btrfs -f {path}'))
 			if b'UUID' not in o:

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -321,6 +321,9 @@ class Partition():
 		if log_formatting:
 			log(f'Formatting {path} -> {filesystem}', level=logging.INFO)
 
+		if path == '/dev/sda1' and filesystem == 'vfat':
+			raise ValueError("Debugging breakpoint!")
+
 		if filesystem == 'btrfs':
 			o = b''.join(sys_command(f'/usr/bin/mkfs.btrfs -f {path}'))
 			if b'UUID' not in o:

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -283,8 +283,6 @@ def perform_installation_steps():
 						partition.format()
 				else:
 					archinstall.log(f"Did not format {partition} because .safe_to_format() returned False or .allow_formatting was False.", level=logging.DEBUG)
-			if hasUEFI():
-				fs.find_partition('/boot').format('vfat')# we don't have a boot partition in bios mode
 
 			if archinstall.arguments.get('!encryption-password', None):
 				# First encrypt and unlock, then format the desired partition inside the encrypted part.


### PR DESCRIPTION
Currently, as mentioned in #434 - Dual-boot is broken unless *"Use `/mnt` as is"* option is being used.
Any other formatting option will wipe the `/boot` partition and any boot loaders with it.

This was discovered in #381 and mentioned in #266.