### PR TITLE
Fixes #292: Removed dupe formatter

### DIFF
--- a/examples/guided.py
+++ b/examples/guided.py
@@ -292,8 +292,8 @@ def perform_installation_steps():
 					unlocked_device.format(fs.find_partition('/').filesystem)
 					unlocked_device.mount('/mnt')
 			else:
-				fs.find_partition('/').format(fs.find_partition('/').filesystem)
 				fs.find_partition('/').mount('/mnt')
+			
 			if hasUEFI():
 				fs.find_partition('/boot').mount('/mnt/boot')
 	


### PR DESCRIPTION
There should be no reason to call `.format()` here, since the steps above take care of all formatting.