### PR TITLE
rename package name

### DIFF
--- a/profiles/awesome.py
+++ b/profiles/awesome.py
@@ -6,7 +6,7 @@ is_top_level_profile = False
 
 # New way of defining packages for a profile, which is iterable and can be used out side
 # of the profile to get a list of "what packages will be installed".
-__packages__ = ['nemo', 'gpicview-gtk3', 'main', 'alacritty']
+__packages__ = ['nemo', 'gpicview', 'main', 'alacritty']
 
 def _prep_function(*args, **kwargs):
 	"""


### PR DESCRIPTION
The `gpicview-gtk3` package was renamed for just  `gpicview`.

![image](https://user-images.githubusercontent.com/9499562/118359044-eee99600-b557-11eb-8126-d8ef6fb149e6.png)

https://archlinux.org/packages/community/x86_64/gpicview/

this is causing an error when i try install the arch linux through of `archinstall`

