### PR TITLE
propagate options when mounting a partition

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -384,7 +384,10 @@ class Partition():
 			pathlib.Path(target).mkdir(parents=True, exist_ok=True)
 
 			try:
-				sys_command(f'/usr/bin/mount {self.path} {target}')
+				if options:
+					sys_command(f'/usr/bin/mount -o {options} {self.path} {target}')
+				else:
+					sys_command(f'/usr/bin/mount {self.path} {target}')
 			except SysCallError as err:
 				raise err
 


### PR DESCRIPTION
Hi! 

I noticed options are never used when mounting a partition so this PR fixes this. This is a bit related to #153. 