### PR TITLE
Change LXQt back to SDDM per NullRequest's suggestion

### DIFF
--- a/profiles/lxqt.py
+++ b/profiles/lxqt.py
@@ -4,6 +4,9 @@ import archinstall
 
 is_top_level_profile = False
 
+# NOTE: SDDM is the only officially supported greeter for LXQt, so unlike other DEs, lightdm is not used here.
+# LXQt works with lightdm, but since this is not supported, we will not default to this.
+# https://github.com/lxqt/lxqt/issues/795
 __packages__ = [
 	"lxqt",
 	"breeze-icons",
@@ -12,8 +15,7 @@ __packages__ = [
 	"ttf-freefont",
 	"leafpad",
 	"slock",
-	"lightdm",
-	"lightdm-gtk-greeter",
+	"sddm",
 ]
 
 
@@ -45,4 +47,4 @@ if __name__ == 'lxqt':
 	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
 	# Enable autostart of LXQt for all users
-	archinstall.storage['installation_session'].enable_service('lightdm')
+	archinstall.storage['installation_session'].enable_service('sddm')


### PR DESCRIPTION
https://github.com/lxqt/lxqt/issues/795

Apparently, SDDM is the only supported greeter for LXQt, so my change from earlier today was wrong. Sorry about that. It DOES work with both greeters, but let's not deviate from what they support.