### PR TITLE
Add pavucontrol to XFCE profile

### DIFF
--- a/profiles/xfce4.py
+++ b/profiles/xfce4.py
@@ -7,6 +7,7 @@ is_top_level_profile = False
 __packages__ = [
 	"xfce4",
 	"xfce4-goodies",
+	"pavucontrol",
 	"lightdm",
 	"lightdm-gtk-greeter",
 ]


### PR DESCRIPTION
Adjusting volume doesn't work correctly without this - audio mixer shortcut is broken.