### PR TITLE
Unlink existing ucodes when strapping them in.

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -98,11 +98,12 @@ def has_intel_graphics() -> bool:
 
 
 def cpu_vendor() -> Optional[str]:
-	cpu_info = json.loads(subprocess.check_output("lscpu -J", shell=True).decode('utf-8'))['lscpu']
+	cpu_info_raw = SysCommand("lscpu -J")
+	cpu_info = json.loads(b"".join(cpu_info_raw).decode('UTF-8'))['lscpu']
+
 	for info in cpu_info:
-		if info.get('field', None):
-			if info.get('field', None) == "Vendor ID:":
-				return info.get('data', None)
+		if info.get('field', None) == "Vendor ID:":
+			return info.get('data', None)
 	return None
 
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -339,7 +339,7 @@ class Installer:
 				if (ucode := pathlib.Path(f"{self.target}/boot/intel-ucode.img")).exists():
 					ucode.unlink()
 			else:
-				self.log("Unknown cpu vendor not installing ucode", level=logging.INFO)
+				self.log(f"Unknown CPU vendor '{vendor}' detected. Archinstall won't install any ucode.", level=logging.DEBUG)
 
 		self.pacstrap(self.base_packages)
 		self.helper_flags['base-strapped'] = True


### PR DESCRIPTION
This should hopefully address #459.

It will unlink any existing ucode before calling `pacstrap`.
Attempted to create `--overwrite` to `pacstrap` in hope it would propegate to `pacman`, but it's not that transparent.