### PR TITLE
Remove PermissionError since it shadows the built-in of the same name

### DIFF
--- a/archinstall/lib/exceptions.py
+++ b/archinstall/lib/exceptions.py
@@ -29,10 +29,6 @@ class HardwareIncompatibilityError(BaseException):
 	pass
 
 
-class PermissionError(BaseException):
-	pass
-
-
 class UserError(BaseException):
 	pass
 


### PR DESCRIPTION
Closes #464