### PR TITLE
Have the configuration file request identify itself as coming from ArchInstall

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -51,7 +51,7 @@ def initialize_arguments():
 				with open(args.config) as file:
 					config = json.load(file)
 			else:  # Attempt to load the configuration from the URL.
-				with urllib.request.urlopen(args.config) as response:
+				with urllib.request.urlopen(urllib.request.Request(args.config, headers={'User-Agent': 'ArchInstall'})) as response:
 					config = json.loads(response.read())
 		except Exception as e:
 			print(e)


### PR DESCRIPTION
This is necessary to allow proper filtering of these requests server-side, and some services block urllib requests (known issue with Cloudflare). This doesn't break checks for servers that do not care about the user agent.