### PR TITLE
look for default profiles in correct location

### DIFF
--- a/archinstall/lib/storage.py
+++ b/archinstall/lib/storage.py
@@ -11,7 +11,7 @@ storage = {
 	'PROFILE_PATH': [
 		'./profiles',
 		'~/.config/archinstall/profiles',
-		os.path.join(os.path.dirname(os.path.abspath(__file__)), 'profiles'),
+		os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'profiles'),
 		# os.path.abspath(f'{os.path.dirname(__file__)}/../examples')
 	],
 	'UPSTREAM_URL': 'https://raw.githubusercontent.com/archlinux/archinstall/master/profiles',


### PR DESCRIPTION
The default `profiles` directory is a sibling of the `lib` directory, not of `storage.py` itself.

`archinstall` (installed trough pacman) kept looking for profiles under `/usr/lib/python3.9/site-packages/archinstall/lib/profiles/` while the profiles are actually located under `/usr/lib/python3.9/site-packages/archinstall/profiles/`