### PR TITLE
Change position of linter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 <!-- <div align="center"> -->
 <img src="https://github.com/archlinux/archinstall/raw/master/docs/logo.png" alt="drawing" width="200"/>
 
-[![Lint Python and Find Syntax Errors](https://github.com/archlinux/archinstall/actions/workflows/lint-python.yaml/badge.svg)](https://github.com/archlinux/archinstall/actions/workflows/lint-python.yaml)
-
 <!-- </div> -->
 # Arch Installer
+[![Lint Python and Find Syntax Errors](https://github.com/archlinux/archinstall/actions/workflows/lint-python.yaml/badge.svg)](https://github.com/archlinux/archinstall/actions/workflows/lint-python.yaml)
 
 Just another guided/automated [Arch Linux](https://wiki.archlinux.org/index.php/Arch_Linux) installer with a twist.
 The installer also doubles as a python library to install Arch Linux and manage services, packages and other things inside the installed system *(Usually from a live medium)*.


### PR DESCRIPTION
Not the most important and cool change, but usually any badges are placed under the main heading rather than under the project logo *(it also looks more nicer)*

![image](https://user-images.githubusercontent.com/36604233/119035347-24f3a380-b9b8-11eb-8893-909a23aac0bb.png)