### PR TITLE
Fixing newlines not being placed correctly on SysCommand()

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -333,6 +333,10 @@ class SysCommand:
 			while self.session.ended is None:
 				self.session.poll()
 
+			if self.peak_output:
+				sys.stdout.write('\n')
+				sys.stdout.flush()
+
 		except SysCallError:
 			return False
 


### PR DESCRIPTION
Since SysCommand() wraps SysCommandWorker(), but SysCommand() doesn't use contexts, we have to flush the output manually here to avoid newlines not being before the next output.

This fixes #497 