### PR TITLE
Added in the option to select system locale if --advance is given

### DIFF
--- a/examples/guided.py
+++ b/examples/guided.py
@@ -51,6 +51,17 @@ def ask_user_questions():
 		selected_region = archinstall.arguments['mirror-region']
 		archinstall.arguments['mirror-region'] = {selected_region: archinstall.list_mirrors()[selected_region]}
 
+	if not archinstall.arguments.get('sys-language', None) and archinstall.arguments.get('advanced', False):
+		archinstall.arguments['sys-language'] = input("Enter a valid locale (language) for your OS, (Default: en_US): ").strip()
+		archinstall.arguments['sys-encoding'] = input("Enter a valid system default encoding for your OS, (Default: utf-8): ").strip()
+
+		if not archinstall.arguments['sys-language']:
+			archinstall.arguments['sys-language'] = 'en_US'
+		if not archinstall.arguments['sys-encoding']:
+			archinstall.arguments['sys-encoding'] = 'utf-8'
+
+		archinstall.log("Keep in mind that if you want multiple locales, post configuration is required.", fg="yellow")
+
 	# Ask which harddrive/block-device we will install to
 	if archinstall.arguments.get('harddrive', None):
 		archinstall.arguments['harddrive'] = archinstall.BlockDevice(archinstall.arguments['harddrive'])
@@ -328,6 +339,7 @@ def perform_installation(mountpoint):
 		if archinstall.arguments.get('mirror-region', None):
 			archinstall.use_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors for the live medium
 		if installation.minimal_installation():
+			installation.set_locale(archinstall.arguments['sys-language'], archinstall.arguments['sys-encoding'].upper())
 			installation.set_hostname(archinstall.arguments['hostname'])
 			if archinstall.arguments['mirror-region'].get("mirrors", None) is not None:
 				installation.set_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors in the installation medium


### PR DESCRIPTION
If guided gets --advanced, it will allow for setting of system language as it does potentially cause issues in the installation if not configured properly.

It's also a bit experimental, and possibly we'll need to add `en_US.UTF-8` as a backup locale, since most applications are written against it.

But this fixes 227