### PR TITLE
Change ordering of example profiles

### DIFF
--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -579,7 +579,7 @@ def select_profile():
 
 		print(' -- The above list is a set of pre-programmed profiles. --')
 		print(' -- They might make it easier to install things like desktop environments. --')
-		print(' -- The desktop profile will let you select a DE/WM profile, e.g sway,kde plasma and gnome --')
+		print(' -- The desktop profile will let you select a DE/WM profile, e.g gnome, kde, sway --')
 		print(' -- (Leave blank and hit enter to skip this step and continue) --')
 
 		selected_profile = generic_select(actual_profiles_raw, 'Enter a pre-programmed profile name if you want to install one: ', options_output=False)


### PR DESCRIPTION
I  think that it is better alphabetically, and gnome for better or worse is the default on most distros. gnome/kde are also what 90% of people are likely to use. I know sway or tiling window managers in general are more confusing to new users too. I don't know how I feel about them being first.