### PR TITLE
Adding --debug and other log enhancements

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -61,6 +61,10 @@ def initialize_arguments():
 
 
 arguments = initialize_arguments()
+storage['arguments'] = arguments
+if arguments.get('debug'):
+	log(f"Warning: --debug mode will write certain credentials to {storage['LOG_PATH']}/{storage['LOG_FILE']}!", fg="red", level=logging.WARNING)
+
 from .lib.plugins import plugins, load_plugin # This initiates the plugin loading ceremony
 
 if arguments.get('plugin', None):

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -265,7 +265,7 @@ class SysCommandWorker:
 		if not self.pid:
 			try:
 				os.execve(self.cmd[0], self.cmd, {**os.environ, **self.environment_vars})
-				if storage.arguments.get('debug'):
+				if storage['arguments'].get('debug'):
 					log(f"Executing: {self.cmd}", level=logging.DEBUG)
 			except FileNotFoundError:
 				log(f"{self.cmd[0]} does not exist.", level=logging.ERROR, fg="red")

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -13,7 +13,7 @@ from typing import Union
 
 from .exceptions import *
 from .output import log
-
+from .storage import storage
 
 def gen_uid(entropy_length=256):
 	return hashlib.sha512(os.urandom(entropy_length)).hexdigest()
@@ -265,6 +265,8 @@ class SysCommandWorker:
 		if not self.pid:
 			try:
 				os.execve(self.cmd[0], self.cmd, {**os.environ, **self.environment_vars})
+				if storage.arguments.get('debug'):
+					log(f"Executing: {self.cmd}", level=logging.DEBUG)
 			except FileNotFoundError:
 				log(f"{self.cmd[0]} does not exist.", level=logging.ERROR, fg="red")
 				self.exit_code = 1


### PR DESCRIPTION
This PR aims to improve logging in areas where we might miss some valuable information.

This PR also introduces the `--debug` which will override any safety mechanisms protecting log messages from accidentally printing credentials. This is to be able to debug certain encryption/sensitive bugs. A warning will be written clearly informing the user that the logs now contain this sensitive information and should only be used for actual debugging situations where a dialogue can be held. This is **not** the default behavior!