### PR TITLE
Add a description to top-level profile listing

### DIFF
--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -228,6 +228,18 @@ class Profile(Script):
 		# since developers like less code - omitting it should assume they want to present it.
 		return True
 
+	def get_profile_description(self):
+		with open(self.path, 'r') as source:
+			source_data = source.read()
+
+			if '__description__' in source_data:
+				with self.load_instructions(namespace=f"{self.namespace}.py") as imported:
+					if hasattr(imported, '__description__'):
+						return imported.__description__
+
+		# Default to this string if the profile does not have a description.
+		return "This profile does not have the __description__ attribute set."
+
 	@property
 	def packages(self) -> Optional[list]:
 		"""

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -575,7 +575,8 @@ def select_profile():
 
 	if len(shown_profiles) >= 1:
 		for index, profile in enumerate(shown_profiles):
-			print(f"{index}: {profile}")
+			description = Profile(None, profile).get_profile_description()
+			print(f"{index}: {profile}: {description}")
 
 		print(' -- The above list is a set of pre-programmed profiles. --')
 		print(' -- They might make it easier to install things like desktop environments. --')

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -580,7 +580,6 @@ def select_profile():
 
 		print(' -- The above list is a set of pre-programmed profiles. --')
 		print(' -- They might make it easier to install things like desktop environments. --')
-		print(' -- The desktop profile will let you select a DE/WM profile, e.g gnome, kde, sway --')
 		print(' -- (Leave blank and hit enter to skip this step and continue) --')
 
 		selected_profile = generic_select(actual_profiles_raw, 'Enter a pre-programmed profile name if you want to install one: ', options_output=False)


### PR DESCRIPTION
Example output using current default profiles:

```
0: desktop: Provides a selection of desktop environments and tiling window managers, e.g. gnome, kde, sway
1: minimal: A very basic installation that allows you to customize Arch Linux as you see fit.
2: server: Provides a selection of various server packages to install and enable, e.g. httpd, nginx, mariadb
3: xorg: Installs a minimal system as well as xorg and graphics drivers.
 -- The above list is a set of pre-programmed profiles. --
 -- They might make it easier to install things like desktop environments. --
 -- (Leave blank and hit enter to skip this step and continue) --
Enter a pre-programmed profile name if you want to install one:
```