### PR TITLE
Add additional hardware debugging functions

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -107,6 +107,43 @@ def cpu_vendor() -> Optional[str]:
 	return None
 
 
+def cpu_model() -> Optional[str]:
+	cpu_info_raw = SysCommand("lscpu -J")
+	cpu_info = json.loads(b"".join(cpu_info_raw).decode('UTF-8'))['lscpu']
+
+	for info in cpu_info:
+		if info.get('field', None) == "Model name:":
+			return info.get('data', None)
+	return None
+
+
+def sys_vendor() -> Optional[str]:
+	with open(f"/sys/devices/virtual/dmi/id/sys_vendor") as vendor:
+		return vendor.read()
+
+
+def product_name() -> Optional[str]:
+	with open(f"/sys/devices/virtual/dmi/id/product_name") as product:
+		return product.read()
+
+
+def mem_info():
+	# This implementation is from https://stackoverflow.com/a/28161352
+	return dict((i.split()[0].rstrip(':'), int(i.split()[1])) for i in open('/proc/meminfo').readlines())
+
+
+def mem_available() -> Optional[str]:
+	return mem_info()['MemAvailable']
+
+
+def mem_free() -> Optional[str]:
+	return mem_info()['MemFree']
+
+
+def mem_total() -> Optional[str]:
+	return mem_info()['MemTotal']
+
+
 def is_vm() -> bool:
 	try:
 		# systemd-detect-virt issues a non-zero exit code if it is not on a virtual machine

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -119,12 +119,12 @@ def cpu_model() -> Optional[str]:
 
 def sys_vendor() -> Optional[str]:
 	with open(f"/sys/devices/virtual/dmi/id/sys_vendor") as vendor:
-		return vendor.read()
+		return vendor.read().strip()
 
 
 def product_name() -> Optional[str]:
 	with open(f"/sys/devices/virtual/dmi/id/product_name") as product:
-		return product.read()
+		return product.read().strip()
 
 
 def mem_info():
@@ -142,6 +142,10 @@ def mem_free() -> Optional[str]:
 
 def mem_total() -> Optional[str]:
 	return mem_info()['MemTotal']
+
+
+def virtualization() -> Optional[str]:
+	return str(SysCommand("systemd-detect-virt")).strip('\r\n')
 
 
 def is_vm() -> bool:

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -81,20 +81,20 @@ def graphics_devices() -> dict:
 	for line in SysCommand("lspci"):
 		if b' VGA ' in line or b' 3D ' in line:
 			_, identifier = line.split(b': ', 1)
-			cards[identifier.strip().lower().decode('UTF-8')] = line
+			cards[identifier.strip().decode('UTF-8')] = line
 	return cards
 
 
 def has_nvidia_graphics() -> bool:
-	return any('nvidia' in x for x in graphics_devices())
+	return any('nvidia' in x.lower() for x in graphics_devices())
 
 
 def has_amd_graphics() -> bool:
-	return any('amd' in x for x in graphics_devices())
+	return any('amd' in x.lower() for x in graphics_devices())
 
 
 def has_intel_graphics() -> bool:
-	return any('intel' in x for x in graphics_devices())
+	return any('intel' in x.lower() for x in graphics_devices())
 
 
 def cpu_vendor() -> Optional[str]:

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -79,7 +79,7 @@ def has_uefi() -> bool:
 def graphics_devices() -> dict:
 	cards = {}
 	for line in SysCommand("lspci"):
-		if b' VGA ' in line:
+		if b' VGA ' in line or b' 3D ' in line:
 			_, identifier = line.split(b': ', 1)
 			cards[identifier.strip().lower().decode('UTF-8')] = line
 	return cards

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -21,7 +21,7 @@ archinstall.log(f"Hardware model detected: {archinstall.sys_vendor()} {archinsta
 archinstall.log(f"Processor model detected: {archinstall.cpu_model()}", level=logging.DEBUG)
 archinstall.log(f"Memory statistics: {archinstall.mem_available()} available out of {archinstall.mem_total()} total installed", level=logging.DEBUG)
 archinstall.log(f"Virtualization detected: {archinstall.virtualization()}; is VM: {archinstall.is_vm()}", level=logging.DEBUG)
-archinstall.log(f"Graphics devices detected: {archinstall.graphics_devices()}", level=logging.DEBUG)
+archinstall.log(f"Graphics devices detected: {archinstall.graphics_devices().keys()}", level=logging.DEBUG)
 
 # For support reasons, we'll log the disk layout pre installation to match against post-installation layout
 archinstall.log(f"Disk states before installing: {archinstall.disk_layouts()}", level=logging.DEBUG)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -21,6 +21,7 @@ archinstall.log(f"Hardware model detected: {archinstall.sys_vendor()} {archinsta
 archinstall.log(f"Processor model detected: {archinstall.cpu_model()}", level=logging.DEBUG)
 archinstall.log(f"Memory statistics: {archinstall.mem_available()} available out of {archinstall.mem_total()} total installed", level=logging.DEBUG)
 archinstall.log(f"Virtualization detected: {archinstall.virtualization()}; is VM: {archinstall.is_vm()}", level=logging.DEBUG)
+archinstall.log(f"Graphics devices detected: {archinstall.graphics_devices()}", level=logging.DEBUG)
 
 # For support reasons, we'll log the disk layout pre installation to match against post-installation layout
 archinstall.log(f"Disk states before installing: {archinstall.disk_layouts()}", level=logging.DEBUG)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -5,7 +5,7 @@ import time
 
 import archinstall
 from archinstall.lib.general import run_custom_user_commands
-from archinstall.lib.hardware import has_uefi, AVAILABLE_GFX_DRIVERS
+from archinstall.lib.hardware import *
 from archinstall.lib.networking import check_mirror_reachable
 from archinstall.lib.profiles import Profile
 
@@ -15,6 +15,12 @@ if archinstall.arguments.get('help'):
 if os.getuid() != 0:
 	print("Archinstall requires root privileges to run. See --help for more.")
 	exit(1)
+
+# Log various information about hardware before starting the installation. This might assist in troubleshooting
+archinstall.log(f"Hardware model detected: {archinstall.sys_vendor()} {archinstall.product_name()}; UEFI mode: {archinstall.has_uefi()}", level=logging.DEBUG)
+archinstall.log(f"Processor model detected: {archinstall.cpu_model()}", level=logging.DEBUG)
+archinstall.log(f"Memory statistics: {archinstall.mem_available()} available out of {archinstall.mem_total()} total installed", level=logging.DEBUG)
+archinstall.log(f"Virtualization detected: {archinstall.virtualization()}; is VM: {archinstall.is_vm()}", level=logging.DEBUG)
 
 # For support reasons, we'll log the disk layout pre installation to match against post-installation layout
 archinstall.log(f"Disk states before installing: {archinstall.disk_layouts()}", level=logging.DEBUG)


### PR DESCRIPTION
This might be helpful for debugging. This also fixes failure to detect a Quadro T1000 on my system. Sample output:

```
Hardware model detected: Dell Inc. Precision 5540; UEFI mode: True
Processor model detected: Intel(R) Xeon(R) E-2276M  CPU @ 2.80GHz
Memory statistics: 23105152 available out of 32497664 total installed
Virtualization detected: none; is VM: False
Graphics devices detected: dict_keys(['Intel Corporation UHD Graphics 630 (Mobile) (rev 02)', 'NVIDIA Corporation TU117GLM [Quadro T1000 Mobile] (rev a1)'])
Disk states before installing: {'blockdevices': [{'name': 'nvme0n1', 'fstype': None, 'fsver': None, 'label': None, 'uuid': None, 'fsavail': None, 'fsuse%': None, 'mountpoint': None, 'type': 'disk', 'size': '953.9G', 'children': [{'name': 'nvme0n1p1', 'fstype': 'vfat', 'fsver': 'FAT32', 'label': None, 'uuid': '94EE-EDD7', 'fsavail': '257M', 'fsuse%': '50%', 'mountpoint': '/boot', 'type': 'part', 'size': '512M'}, {'name': 'nvme0n1p2', 'fstype': 'crypto_LUKS', 'fsver': '2', 'label': None, 'uuid': '1ea54b52-e005-4438-afd9-e690e690bec4', 'fsavail': None, 'fsuse%': None, 'mountpoint': None, 'type': 'part', 'size': '953.4G', 'children': [{'name': 'cryptlvm', 'fstype': 'LVM2_member', 'fsver': 'LVM2 001', 'label': None, 'uuid': 'Tg8LWJ-WU8i-cazt-623Y-39wR-F7UF-dCYFc6', 'fsavail': None, 'fsuse%': None, 'mountpoint': None, 'type': 'crypt', 'size': '953.4G', 'children': [{'name': 'vg0-swap', 'fstype': 'swap', 'fsver': '1', 'label': None, 'uuid': '39b932f3-eaaa-4014-8b64-98a4fe0a8080', 'fsavail': None, 'fsuse%': None, 'mountpoint': '[SWAP]', 'type': 'lvm', 'size': '8G'}, {'name': 'vg0-root', 'fstype': 'ext4', 'fsver': '1.0', 'label': None, 'uuid': '0d258911-48c6-4783-ab78-726dff391d08', 'fsavail': '28.7G', 'fsuse%': '92%', 'mountpoint': '/', 'type': 'lvm', 'size': '945.3G'}]}]}]}]}
```