### PR TITLE
Proposal: Split Nvidia so that there are two options for it

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -48,10 +48,12 @@ AVAILABLE_GFX_DRIVERS = {
 		"intel-media-driver",
 		"vulkan-intel",
 	],
-	"Nvidia": {
-		"open-source": ["mesa", "xf86-video-nouveau", "libva-mesa-driver"],
-		"proprietary": ["nvidia"],
-	},
+	"Nvidia (open-source)": [
+		"mesa",
+		"xf86-video-nouveau",
+		"libva-mesa-driver"
+	],
+	"Nvidia (proprietary)": ["nvidia"],
 	"VMware / VirtualBox (open-source)": ["mesa", "xf86-video-vmware"],
 }
 


### PR DESCRIPTION
This makes selecting an Nvidia driver simpler and makes it apparent that we support both open-source and proprietary from the initial selection. This will also allow a specific Nvidia driver to be chosen via a configuration file.