### PR TITLE
Initial port of GitHub Actions to GitLab CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,83 @@
+# This file contains GitLab CI/CD configuration for the ArchInstall project.
+# It defines several jobs that get run when a new commit is made, and is comparable to the GitHub workflows.
+# All jons will be run in the official archlinux container image, so we will declare that here.
+# There is an expectation that a runner exists that has the --privileged flag enabled for the build ISO job to run correctly.
+# These jobs should leverage the same tag as that runner. If necessary, change the tag from 'docker' to the one it uses.
+
+image: archlinux:latest
+
+stages:
+  - lint
+  - test
+  - build
+  - publish
+
+mypy:
+  stage: lint
+  tags:
+    - docker
+  script:
+    - pacman --noconfirm -Syu python mypy
+    - mypy . --ignore-missing-imports || exit 0
+
+flake8:
+  stage: lint
+  tags:
+    - docker
+  script:
+    - pacman --noconfirm -Syu python python-pip
+    - python -m pip install --upgrade pip
+    - pip install flake8
+    - flake8 . --count --select=E9,F63,F7 --show-source --statistics
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+# We currently do not have unit tests implemented but this stage is written in anticipation of their future usage.
+# When a stage name is preceeded with a '.' it's treated as "disabled" by GitLab and is not executed, so it's fine for it to be declared.
+.pytest:
+  stage: test
+  tags:
+    - docker
+  script:
+    - pacman --noconfirm -Syu python python-pip
+    - python -m pip install --upgrade pip
+    - pip install pytest
+    - pytest
+
+# This stage might fail with exit code 137 on a shared runner. This is probably due to the CPU/memory consumption needed to run the build.
+build_iso:
+  stage: build
+  tags:
+    - docker
+  script:
+    - pwd
+    - find .
+    - cat /etc/os-release
+    - mkdir -p /tmp/archlive/airootfs/root/archinstall-git; cp -r . /tmp/archlive/airootfs/root/archinstall-git
+    - echo "pip uninstall archinstall -y; cd archinstall-git; python setup.py install" > /tmp/archlive/airootfs/root/.zprofile
+    - echo "echo \"This is an unofficial ISO for development and testing of archinstall. No support will be provided.\"" >> /tmp/archlive/airootfs/root/.zprofile
+    - echo "echo \"This ISO was built from Git SHA $CI_COMMIT_SHA\"" >> /tmp/archlive/airootfs/root/.zprofile
+    - echo "echo \"Type archinstall to launch the installer.\"" >> /tmp/archlive/airootfs/root/.zprofile
+    - cat /tmp/archlive/airootfs/root/.zprofile
+    - pacman -Sy; pacman --noconfirm -S git archiso
+    - cp -r /usr/share/archiso/configs/releng/* /tmp/archlive
+    - echo -e "git\npython\npython-pip\npython-setuptools" >> /tmp/archlive/packages.x86_64
+    - find /tmp/archlive
+    - cd /tmp/archlive; mkarchiso -v -w work/ -o out/ ./
+  artifacts:
+    name: "Arch Live ISO"
+    paths:
+      - /tmp/archlive/out/*.iso
+    expire_in: 1 week
+
+## The following CI/CD variables need to be set to the PyPi username and password in the GitLab project's settings for this stage to work.
+# * FLIT_USERNAME
+# * FLIT_PASSWORD
+publish_pypi:
+  stage: publish
+  tags:
+    - docker
+  script:
+    - pacman -Sy; pacman --noconfirm -S python python-pip
+    - python -m pip install --upgrade pip
+    - pip install setuptools wheel flit
+    - flit


### PR DESCRIPTION
This is an attempt to port all of our GitHub workspaces to GitLab CI/CD. This makes a couple of assumptions, including the presence of a privileged docker runner tagged 'docker'. This also expects the CI/CD variables needed for flit to publish would be declared in the project's CI/CD variables.

Privileged Docker execution is allowed on the GitLab.com runners, as Docker-in-Docker uses this functionality. https://docs.gitlab.com/ee/user/gitlab_com/#linux-shared-runners

Note that the build_iso will fail on GitLab.com's shared runners due to memory constraints, exiting with code 137 which indicates excessive CPU/memory consumption.

The pytest stage is disabled because running pytest is a waste of compute time and unnecessarily fails due to lack of test cases, so we can skip this one until we actually have unit tests.