### PR TITLE
Only print requires root messages if effective user id is not root

### DIFF
--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -32,7 +32,8 @@ def check_mirror_reachable():
 	if (exit_code := SysCommand("pacman -Sy").exit_code) == 0:
 		return True
 	elif exit_code == 256:
-		log("check_mirror_reachable() uses 'pacman -Sy' which requires root.", level=logging.ERROR, fg="red")
+		if os.geteuid() != 0:
+			log("check_mirror_reachable() uses 'pacman -Sy' which requires root.", level=logging.ERROR, fg="red")
 
 	return False
 


### PR DESCRIPTION
This error message seems to confuse people. https://www.reddit.com/r/archlinux/comments/nvz86f/check_mirror_reachable_uses_pacman_sy_which/