### PR TITLE
Add a message when running check_mirror_reachable to let users know it's not frozen

### DIFF
--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -29,6 +29,7 @@ def list_interfaces(skip_loopback=True):
 
 
 def check_mirror_reachable():
+	log("Testing connectivity to the Arch Linux mirrors ...", level=logging.INFO)
 	if (exit_code := SysCommand("pacman -Sy").exit_code) == 0:
 		return True
 	elif os.geteuid() != 0:


### PR DESCRIPTION
This might make #567 a bit more tolerable