### PR TITLE
Implement is_desktop_profile helper function

### DIFF
--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -23,9 +23,19 @@ def grab_url_data(path):
 	return response.read()
 
 
-def is_desktop_profile(profile_name) -> bool:
-	if str(profile_name) == 'Profile(desktop)':
+def is_desktop_profile(profile) -> bool:
+	if str(profile) == 'Profile(desktop)':
 		return True
+
+	desktop_profile = Profile(None, "desktop")
+	with open(desktop_profile.path, 'r') as source:
+		source_data = source.read()
+
+		if '__name__' in source_data and '__supported__' in source_data:
+			with desktop_profile.load_instructions(namespace=f"{desktop_profile.namespace}.py") as imported:
+				if hasattr(imported, '__supported__'):
+					desktop_profiles = imported.__supported__
+					return str(profile) in [f"Profile({s})" for s in desktop_profiles]
 
 
 def list_profiles(filter_irrelevant_macs=True, subpath='', filter_top_level_profiles=False):

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -23,6 +23,11 @@ def grab_url_data(path):
 	return response.read()
 
 
+def is_desktop_profile(profile_name) -> bool:
+	if str(profile_name) == 'Profile(desktop)':
+		return True
+
+
 def list_profiles(filter_irrelevant_macs=True, subpath='', filter_top_level_profiles=False):
 	# TODO: Grab from github page as well, not just local static files
 	if filter_irrelevant_macs:

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -37,6 +37,8 @@ def is_desktop_profile(profile) -> bool:
 					desktop_profiles = imported.__supported__
 					return str(profile) in [f"Profile({s})" for s in desktop_profiles]
 
+	return False
+
 
 def list_profiles(filter_irrelevant_macs=True, subpath='', filter_top_level_profiles=False):
 	# TODO: Grab from github page as well, not just local static files

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -373,9 +373,9 @@ def ask_for_bootloader() -> str:
 
 
 def ask_for_audio_selection(desktop=True):
-	audio = "pipewire"  # Default for most desktop environments
+	audio = 'pipewire' if desktop else 'none'
 	choices = ['pipewire', 'pulseaudio'] if desktop else ['pipewire', 'pulseaudio', 'none']
-	selection = generic_select(choices, 'Choose an audio server or leave blank to use pipewire: ', options_output=False)
+	selection = generic_select(choices, f'Choose an audio server or leave blank to use {audio}: ', options_output=True)
 	if selection != "":
 		audio = selection
 

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -372,7 +372,7 @@ def ask_for_bootloader() -> str:
 	return bootloader
 
 
-def ask_for_audio_selection():
+def ask_for_audio_selection(desktop = True):
 	audio = "pulseaudio"  # Default for most desktop environments
 	pipewire_choice = input("Would you like to install pipewire instead of pulseaudio as the default audio server? [Y/n] ").lower()
 	if pipewire_choice in ("y", ""):
@@ -703,7 +703,7 @@ def select_driver(options=AVAILABLE_GFX_DRIVERS):
 
 	if drivers:
 		if has_amd_graphics():
-			print('For the best compatibility with your AMD hardware, you may want to use either the all open-source or AMD / ATI options.') 
+			print('For the best compatibility with your AMD hardware, you may want to use either the all open-source or AMD / ATI options.')
 		if has_intel_graphics():
 			print('For the best compatibility with your Intel hardware, you may want to use either the all open-source or Intel options.')
 		if has_nvidia_graphics():

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -372,11 +372,12 @@ def ask_for_bootloader() -> str:
 	return bootloader
 
 
-def ask_for_audio_selection(desktop = True):
-	audio = "pulseaudio"  # Default for most desktop environments
-	pipewire_choice = input("Would you like to install pipewire instead of pulseaudio as the default audio server? [Y/n] ").lower()
-	if pipewire_choice in ("y", ""):
-		audio = "pipewire"
+def ask_for_audio_selection(desktop=True):
+	audio = "pipewire"  # Default for most desktop environments
+	choices = ['pipewire', 'pulseaudio'] if desktop else ['pipewire', 'pulseaudio', 'none']
+	selection = generic_select(choices, 'Choose an audio server or leave blank to use pipewire: ', options_output=False)
+	if selection != "":
+		audio = selection
 
 	return audio
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -213,7 +213,7 @@ def ask_user_questions():
 	# Ask about audio server selection if one is not already set
 	if not archinstall.arguments.get('audio', None):
 		# The argument to ask_for_audio_selection lets the library know if it's a desktop profile
-		archinstall.ask_for_audio_selection(is_desktop_profile(archinstall.arguments['profile']))
+		archinstall.arguments['audio'] = archinstall.ask_for_audio_selection(is_desktop_profile(archinstall.arguments['profile']))
 
 	# Ask for preferred kernel:
 	if not archinstall.arguments.get("kernels", None):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -7,7 +7,7 @@ import archinstall
 from archinstall.lib.general import run_custom_user_commands
 from archinstall.lib.hardware import *
 from archinstall.lib.networking import check_mirror_reachable
-from archinstall.lib.profiles import Profile
+from archinstall.lib.profiles import Profile, is_desktop_profile
 
 if archinstall.arguments.get('help'):
 	print("See `man archinstall` for help.")
@@ -212,13 +212,8 @@ def ask_user_questions():
 
 	# Ask about audio server selection if one is not already set
 	if not archinstall.arguments.get('audio', None):
-		# only ask for audio server selection on a desktop profile
-		if str(archinstall.arguments['profile']) == 'Profile(desktop)':
-			archinstall.arguments['audio'] = archinstall.ask_for_audio_selection()
-		else:
-			# packages installed by a profile may depend on audio and something may get installed anyways, not much we can do about that.
-			# we will not try to remove packages post-installation to not have audio, as that may cause multiple issues
-			archinstall.arguments['audio'] = None
+		# The argument to ask_for_audio_selection lets the library know if it's a desktop profile
+		archinstall.ask_for_audio_selection(is_desktop_profile(archinstall.arguments['profile']))
 
 	# Ask for preferred kernel:
 	if not archinstall.arguments.get("kernels", None):
@@ -270,10 +265,10 @@ def perform_installation_steps():
 	with open("/var/log/archinstall/user_configuration.json", "w") as config_file:
 		config_file.write(user_configuration)
 	print()
-	
+
 	if archinstall.arguments.get('dry_run'):
 		exit(0)
-	
+
 	if not archinstall.arguments.get('silent'):
 		input('Press Enter to continue.')
 

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -21,6 +21,21 @@ __packages__ = [
 	'xdg-utils',
 ]
 
+__supported__ = [
+	'gnome',
+	'kde',
+	'awesome',
+	'sway',
+	'cinnamon',
+	'xfce4',
+	'lxqt',
+	'i3',
+	'budgie',
+	'mate',
+	'deepin',
+	'enlightenment',
+]
+
 
 def _prep_function(*args, **kwargs):
 	"""
@@ -30,22 +45,7 @@ def _prep_function(*args, **kwargs):
 	for more input before any other installer steps start.
 	"""
 
-	supported_desktops = [
-		'gnome',
-		'kde',
-		'awesome',
-		'sway',
-		'cinnamon',
-		'xfce4',
-		'lxqt',
-		'i3',
-		'budgie',
-		'mate',
-		'deepin',
-		'enlightenment',
-	]
-
-	desktop = archinstall.generic_select(supported_desktops, 'Select your desired desktop environment: ', allow_empty_input=False, sort=True)
+	desktop = archinstall.generic_select(__supported__, 'Select your desired desktop environment: ', allow_empty_input=False, sort=True)
 
 	# Temporarily store the selected desktop profile
 	# in a session-safe location, since this module will get reloaded


### PR DESCRIPTION
This is tested and it works. This pull request makes a change in how we ask for audio selections. If the user chooses desktop or they choose a profile within desktop by typing that profile name directly, they would be prompted to choose between pipewire and pulseaudio. If they choose a profile that is not a desktop profile they will additionally be allowed to choose none which will be the default for that profile. None is not available for desktop profiles because of dependencies and it would not work correctly. I moved all the supported desktop profiles in the desktop file to a global variable that is being read in to determine whether or not a profile is a desktop or not.