### PR TITLE
created load_config() to load configuration

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -64,7 +64,7 @@ def initialize_arguments():
 			config[key] = val
 	config["script"] = args.script
 	if args.dry_run is not None:
-		config["dry_run"] = args.dry_run
+		config["dry-run"] = args.dry_run
 	return config
 
 

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -710,7 +710,8 @@ def select_driver(options=AVAILABLE_GFX_DRIVERS):
 		if has_nvidia_graphics():
 			print('For the best compatibility with your Nvidia hardware, you may want to use the Nvidia proprietary driver.')
 
-		arguments['gfx_driver'] = generic_select(drivers, input_text="Select your graphics card driver: ")
+		if not arguments.get('gfx_driver', None):
+			arguments['gfx_driver'] = generic_select(drivers, input_text="Select a graphics driver or leave blank to install all open-source drivers: ")
 		
 		if arguments.get('gfx_driver', None) is None:
 			arguments['gfx_driver'] = "All open-source (default)"

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -280,7 +280,7 @@ def perform_installation_steps():
 		config_file.write(user_configuration)
 	print()
 
-	if archinstall.arguments.get('dry_run'):
+	if archinstall.arguments.get('dry-run'):
 		exit(0)
 
 	if not archinstall.arguments.get('silent'):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -8,6 +8,7 @@ from archinstall.lib.general import run_custom_user_commands
 from archinstall.lib.hardware import *
 from archinstall.lib.networking import check_mirror_reachable
 from archinstall.lib.profiles import Profile, is_desktop_profile
+from archinstall.lib.profiles.server import available_servers
 
 if archinstall.arguments.get('help'):
 	print("See `man archinstall` for help.")
@@ -50,7 +51,9 @@ def load_config():
 		archinstall.arguments['sys-encoding'] = archinstall.arguments.get('sys-encoding', 'utf-8')
 	if archinstall.arguments.get('gfx_driver', None) is not None:
 		archinstall.storage['gfx_driver_packages'] = AVAILABLE_GFX_DRIVERS.get(archinstall.arguments.get('gfx_driver', None), None)
-
+	if archinstall.arguments.get('servers', None) is not None:
+		archinstall.storage['_selected_servers'] = archinstall.arguments.get('servers', None)
+	
 def ask_user_questions():
 	"""
 		First, we'll ask the user for a bunch of user input.

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -37,6 +37,7 @@ def load_config():
 			archinstall.arguments['profile'] = archinstall.Profile(None, archinstall.arguments.get('profile', None)['path'])
 		else:
 			archinstall.arguments['profile'] = archinstall.Profile(None, archinstall.arguments.get('profile', None))
+	archinstall.storage['_desktop_profile'] = archinstall.arguments.get('desktop-environment', None)
 	if archinstall.arguments.get('mirror-region', None) is not None:
 		if type(archinstall.arguments.get('mirror-region', None)) is dict:
 			archinstall.arguments['mirror-region'] = archinstall.arguments.get('mirror-region', None)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -8,7 +8,6 @@ from archinstall.lib.general import run_custom_user_commands
 from archinstall.lib.hardware import *
 from archinstall.lib.networking import check_mirror_reachable
 from archinstall.lib.profiles import Profile, is_desktop_profile
-from archinstall.lib.profiles.server import available_servers
 
 if archinstall.arguments.get('help'):
 	print("See `man archinstall` for help.")

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -26,6 +26,29 @@ archinstall.log(f"Graphics devices detected: {archinstall.graphics_devices().key
 # For support reasons, we'll log the disk layout pre installation to match against post-installation layout
 archinstall.log(f"Disk states before installing: {archinstall.disk_layouts()}", level=logging.DEBUG)
 
+def load_config():
+	if archinstall.arguments.get('harddrive', None) is not None:
+		archinstall.arguments['harddrive'] = archinstall.BlockDevice(path=archinstall.arguments['harddrive']['path'])
+		# Temporarily disabling keep_partitions if config file is loaded
+		archinstall.arguments['harddrive'].keep_partitions = False
+		# Temporary workaround to make Desktop Environments work
+	if archinstall.arguments.get('profile', None) is not None:
+		if type(archinstall.arguments.get('profile', None)) is dict:
+			archinstall.arguments['profile'] = archinstall.Profile(None, archinstall.arguments.get('profile', None)['path'])
+		else:
+			archinstall.arguments['profile'] = archinstall.Profile(None, archinstall.arguments.get('profile', None))
+	if archinstall.arguments.get('mirror-region', None) is not None:
+		if type(archinstall.arguments.get('mirror-region', None)) is dict:
+			archinstall.arguments['mirror-region'] = archinstall.arguments.get('mirror-region', None)
+		else:
+			selected_region = archinstall.arguments.get('mirror-region', None)
+			archinstall.arguments['mirror-region'] = {selected_region: archinstall.list_mirrors()[selected_region]}
+	if archinstall.arguments.get('sys-language', None) is not None:
+		archinstall.arguments['sys-language'] = archinstall.arguments.get('sys-language', 'en_US')
+	if archinstall.arguments.get('sys-encoding', None) is not None:
+		archinstall.arguments['sys-encoding'] = archinstall.arguments.get('sys-encoding', 'utf-8')
+	if archinstall.arguments.get('gfx_driver', None) is not None:
+		archinstall.storage['gfx_driver_packages'] = AVAILABLE_GFX_DRIVERS.get(archinstall.arguments.get('gfx_driver', None), None)
 
 def ask_user_questions():
 	"""
@@ -54,9 +77,6 @@ def ask_user_questions():
 				break
 			except archinstall.RequirementError as e:
 				archinstall.log(e, fg="red")
-	else:
-		selected_region = archinstall.arguments['mirror-region']
-		archinstall.arguments['mirror-region'] = {selected_region: archinstall.list_mirrors()[selected_region]}
 
 	if not archinstall.arguments.get('sys-language', None) and archinstall.arguments.get('advanced', False):
 		archinstall.arguments['sys-language'] = input("Enter a valid locale (language) for your OS, (Default: en_US): ").strip()
@@ -69,9 +89,7 @@ def ask_user_questions():
 		archinstall.arguments['sys-encoding'] = 'utf-8'
 
 	# Ask which harddrive/block-device we will install to
-	if archinstall.arguments.get('harddrive', None):
-		archinstall.arguments['harddrive'] = archinstall.BlockDevice(archinstall.arguments['harddrive'])
-	else:
+	if not archinstall.arguments.get('harddrive', None):
 		archinstall.arguments['harddrive'] = archinstall.select_disk(archinstall.all_disks())
 		if archinstall.arguments['harddrive'] is None:
 			archinstall.arguments['target-mount'] = archinstall.storage.get('MOUNT_POINT', '/mnt')
@@ -188,20 +206,15 @@ def ask_user_questions():
 		archinstall.arguments['!root-password'] = archinstall.get_password(prompt='Enter root password (Recommendation: leave blank to leave root disabled): ')
 
 	# Ask for additional users (super-user if root pw was not set)
-	archinstall.arguments['users'] = {}
-	archinstall.arguments['superusers'] = {}
-	if not archinstall.arguments.get('!root-password', None):
+	if not archinstall.arguments.get('!root-password', None) and not archinstall.arguments.get('superusers', None):
 		archinstall.arguments['superusers'] = archinstall.ask_for_superuser_account('Create a required super-user with sudo privileges: ', forced=True)
-
-	users, superusers = archinstall.ask_for_additional_users('Enter a username to create a additional user (leave blank to skip & continue): ')
-	archinstall.arguments['users'] = users
-	archinstall.arguments['superusers'] = {**archinstall.arguments['superusers'], **superusers}
+		users, superusers = archinstall.ask_for_additional_users('Enter a username to create a additional user (leave blank to skip & continue): ')
+		archinstall.arguments['users'] = users
+		archinstall.arguments['superusers'] = {**archinstall.arguments['superusers'], **superusers}
 
 	# Ask for archinstall-specific profiles (such as desktop environments etc)
 	if not archinstall.arguments.get('profile', None):
 		archinstall.arguments['profile'] = archinstall.select_profile()
-	else:
-		archinstall.arguments['profile'] = Profile(installer=None, path=archinstall.arguments['profile'])
 
 	# Check the potentially selected profiles preparations to get early checks if some additional questions are needed.
 	if archinstall.arguments['profile'] and archinstall.arguments['profile'].has_prep_function():
@@ -437,33 +450,8 @@ if not check_mirror_reachable():
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
+load_config()
 if not archinstall.arguments.get('silent'):
 	ask_user_questions()
-else:
-	# Workarounds if config is loaded from a file
-	# The harddrive section should be moved to perform_installation_steps, where it's actually being performed
-	# Blockdevice object should be created in perform_installation_steps
-	# This needs to be done until then
-	archinstall.arguments['harddrive'] = archinstall.BlockDevice(path=archinstall.arguments['harddrive']['path'])
-	# Temporarily disabling keep_partitions if config file is loaded
-	archinstall.arguments['harddrive'].keep_partitions = False
-	# Temporary workaround to make Desktop Environments work
-	if archinstall.arguments.get('profile', None) is not None:
-		if type(archinstall.arguments.get('profile', None)) is dict:
-			archinstall.arguments['profile'] = archinstall.Profile(None, archinstall.arguments.get('profile', None)['path'])
-		else:
-			archinstall.arguments['profile'] = archinstall.Profile(None, archinstall.arguments.get('profile', None))
-	else:
-		archinstall.arguments['profile'] = None
-	if archinstall.arguments.get('mirror-region', None) is not None:
-		if type(archinstall.arguments.get('mirror-region', None)) is dict:
-			archinstall.arguments['mirror-region'] = archinstall.arguments.get('mirror-region', None)
-		else:
-			selected_region = archinstall.arguments.get('mirror-region', None)
-			archinstall.arguments['mirror-region'] = {selected_region: archinstall.list_mirrors()[selected_region]}
-	archinstall.arguments['sys-language'] = archinstall.arguments.get('sys-language', 'en_US')
-	archinstall.arguments['sys-encoding'] = archinstall.arguments.get('sys-encoding', 'utf-8')
-	if archinstall.arguments.get('gfx_driver', None) is not None:
-		archinstall.storage['gfx_driver_packages'] = AVAILABLE_GFX_DRIVERS.get(archinstall.arguments.get('gfx_driver', None), None)
 
 perform_installation_steps()

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -50,9 +50,10 @@ def _prep_function(*args, **kwargs):
 	# Temporarily store the selected desktop profile
 	# in a session-safe location, since this module will get reloaded
 	# the next time it gets executed.
-	if '_desktop_profile' not in archinstall.storage.keys():
+	if not archinstall.storage.get('_desktop_profile', None):
 		archinstall.storage['_desktop_profile'] = desktop
-	archinstall.arguments['desktop-environment'] = desktop
+	if not archinstall.arguments.get('desktop-environment', None):
+		archinstall.arguments['desktop-environment'] = desktop
 	profile = archinstall.Profile(None, desktop)
 	# Loading the instructions with a custom namespace, ensures that a __name__ comparison is never triggered.
 	with profile.load_instructions(namespace=f"{desktop}.py") as imported:

--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -52,10 +52,8 @@ def _prep_function(*args, **kwargs):
 	# the next time it gets executed.
 	if '_desktop_profile' not in archinstall.storage.keys():
 		archinstall.storage['_desktop_profile'] = desktop
-
+	archinstall.arguments['desktop-environment'] = desktop
 	profile = archinstall.Profile(None, desktop)
-	# Set the resolved profile path to the actual desktop environment
-	archinstall.arguments['profile'] = profile
 	# Loading the instructions with a custom namespace, ensures that a __name__ comparison is never triggered.
 	with profile.load_instructions(namespace=f"{desktop}.py") as imported:
 		if hasattr(imported, '_prep_function'):

--- a/profiles/server.py
+++ b/profiles/server.py
@@ -26,8 +26,9 @@ def _prep_function(*args, **kwargs):
 	Magic function called by the importing installer
 	before continuing any further.
 	"""
-	selected_servers = archinstall.generic_multi_select(available_servers, "Choose which servers to install and enable (leave blank for a minimal installation): ")
-	archinstall.storage['_selected_servers'] = selected_servers
+	if not archinstall.storage.get('_selected_servers', None):
+		selected_servers = archinstall.generic_multi_select(available_servers, "Choose which servers to install and enable (leave blank for a minimal installation): ")
+		archinstall.storage['_selected_servers'] = selected_servers
 
 	return True
 


### PR DESCRIPTION
Creating a `load_config()` function that shall only populate the config
Goals
1. Having a `load_config()` function which only loads the config
2. Refactoring `ask_user_questions()` to **only** prompt if config is not loaded, set default values **iff** not entered from config or from prompt, maybe separate setting default values to a separate function
3. Refactor `perform_installation_steps()` and `perform_installation()` to **only** perform installation and not modify anything else

we could have a utility function that loads key from config if present else prompts else returns a default value

Fixes #602, while condition does not work if only one partition was present before formatting
Fixes #606 added new `servers` key