### PR TITLE
Fix encryption + grub both in UEFI and BIOS systems.

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -347,6 +347,11 @@ class Partition:
 				raise DiskError(f'Could not format {path} with {filesystem} because: {b"".join(handle)}')
 			self.filesystem = 'ext4'
 
+		elif filesystem == 'ext2':
+			if (handle := SysCommand(f'/usr/bin/mkfs.ext2 -F {path}')).exit_code != 0:
+				raise DiskError(f'Could not format {path} with {filesystem} because: {b"".join(handle)}')
+			self.filesystem = 'ext2'
+
 		elif filesystem == 'xfs':
 			if (handle := SysCommand(f'/usr/bin/mkfs.xfs -f {path}')).exit_code != 0:
 				raise DiskError(f'Could not format {path} with {filesystem} because: {b"".join(handle)}')
@@ -518,12 +523,20 @@ class Filesystem:
 			self.blockdevice.partition[0].allow_formatting = True
 			self.blockdevice.partition[1].allow_formatting = True
 		else:
-			# we don't need a seprate boot partition it would be a waste of space
-			self.add_partition('primary', start='1MB', end='100%')
-			self.blockdevice.partition[0].filesystem = root_filesystem_type
-			log(f"Set the root partition {self.blockdevice.partition[0]} to use filesystem {root_filesystem_type}.", level=logging.DEBUG)
-			self.blockdevice.partition[0].target_mountpoint = '/'
+			self.add_partition('primary', start='1MiB', end='513MiB', partition_format='ext2')
+			self.set(0, 'boot on')
+			self.add_partition('primary', start='513MiB', end='100%')
+
+			self.blockdevice.partition[0].filesystem = 'ext2'
+			self.blockdevice.partition[1].filesystem = root_filesystem_type
+
+			log(f"Set the root partition {self.blockdevice.partition[1]} to use filesystem {root_filesystem_type}.", level=logging.DEBUG)
+
+			self.blockdevice.partition[0].target_mountpoint = '/boot'
+			self.blockdevice.partition[1].target_mountpoint = '/'
+
 			self.blockdevice.partition[0].allow_formatting = True
+			self.blockdevice.partition[1].allow_formatting = True
 
 	def add_partition(self, partition_type, start, end, partition_format=None):
 		log(f'Adding partition to {self.blockdevice}', level=logging.INFO)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -322,8 +322,7 @@ def perform_installation_steps():
 			else:
 				fs.find_partition('/').mount(archinstall.storage.get('MOUNT_POINT', '/mnt'))
 
-			if has_uefi():
-				fs.find_partition('/boot').mount(archinstall.storage.get('MOUNT_POINT', '/mnt') + '/boot')
+			fs.find_partition('/boot').mount(archinstall.storage.get('MOUNT_POINT', '/mnt') + '/boot')
 
 	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
 
@@ -352,7 +351,7 @@ def perform_installation(mountpoint):
 				installation.set_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors in the installation medium
 			if archinstall.arguments["bootloader"] == "grub-install" and has_uefi():
 				installation.add_additional_packages("grub")
-			installation.add_bootloader(archinstall.arguments["bootloader"])
+			installation.add_bootloader(archinstall.arguments["harddrive"], archinstall.arguments["bootloader"])
 
 			# If user selected to copy the current ISO network configuration
 			# Perform a copy of the config


### PR DESCRIPTION
We need to have two partitions in BIOS one for boot (grub)
and the other for root (/). The format of the boot partition
is ext2 (so it is added).

If disk is chosen to be encrypted, `then /etc/default/grub` is edited
as the followings: https://wiki.archlinux.org/title/Dm-crypt/Encrypting_an_entire_system#Configuring_GRUB_2

Issue: https://github.com/archlinux/archinstall/issues/586

This work is done while working on CachyOS which is Arch based and
it is using customized archinstaller.

To test these changes you can try CachyOS installer which supports
encrypted disk with grub (https://wiki.cachyos.org/).

Hamad

🚨 PR Guidelines:

# New features *(v2.2.0)*

All future work towards *`v2.2.0`* is done against `master` now.<br>
Any patch work to existing versions will have to create a new branch against the tagged versions.

# Fix encryption + GRUB
https://github.com/archlinux/archinstall/issues/586<br>

We need to have two partitions in BIOS one for boot (grub)
and the other for root (/). The format of the boot partition
is ext2 (so it is added).

If disk is chosen to be encrypted, `then /etc/default/grub` is edited
as the followings: https://wiki.archlinux.org/title/Dm-crypt/Encrypting_an_entire_system#Configuring_GRUB_2

Issue: https://github.com/archlinux/archinstall/issues/586

This work is done while working on CachyOS which is Arch based and
it is using customized archinstaller.

To test these changes you can try CachyOS installer which supports
encrypted disk with grub (https://wiki.cachyos.org/).


# Testing
It has been tested with CachyOS ISO (https://wiki.cachyos.org).

Hamad