### PR TITLE
Mention GNOME and KDE's soft dependency on NetworkManager in the installation process

### DIFF
--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -388,13 +388,13 @@ def ask_to_configure_network():
 	# {MAC: Ifname}
 	interfaces = {
 		'ISO-CONFIG': 'Copy ISO network configuration to installation',
-		'NetworkManager': 'Use NetworkManager to control and manage your internet connection',
+		'NetworkManager': 'Use NetworkManager (necessary to configure internet graphically in GNOME and KDE)',
 		**list_interfaces()
 	}
 
 	nic = generic_select(interfaces, "Select one network interface to configure (leave blank to skip): ")
 	if nic and nic != 'Copy ISO network configuration to installation':
-		if nic == 'Use NetworkManager to control and manage your internet connection':
+		if nic == 'Use NetworkManager (necessary to configure internet graphically in GNOME and KDE)':
 			return {'nic': nic, 'NetworkManager': True}
 
 		# Current workaround:
@@ -700,7 +700,7 @@ def select_driver(options=AVAILABLE_GFX_DRIVERS):
 	"""
 
 	drivers = sorted(list(options))
-	
+
 	if drivers:
 		arguments = storage.get('arguments', {})
 		if has_amd_graphics():
@@ -711,10 +711,10 @@ def select_driver(options=AVAILABLE_GFX_DRIVERS):
 			print('For the best compatibility with your Nvidia hardware, you may want to use the Nvidia proprietary driver.')
 
 		arguments['gfx_driver'] = generic_select(drivers, input_text="Select a graphics driver or leave blank to install all open-source drivers: ")
-		
+
 		if arguments.get('gfx_driver', None) is None:
 			arguments['gfx_driver'] = "All open-source (default)"
-			
+
 		return options.get(arguments.get('gfx_driver'))
 
 	raise RequirementError("Selecting drivers require a least one profile to be given as an option.")


### PR DESCRIPTION
This PR tags onto #264 - most people don't know that NetworkManager is needed for a fully functional GNOME (and KDE) system, and might accidentally choose to just copy over the ISO network configuration.