### PR TITLE
Remove lightdm packages from Deepin profile

### DIFF
--- a/profiles/deepin.py
+++ b/profiles/deepin.py
@@ -8,6 +8,8 @@ __packages__ = [
 	"deepin",
 	"deepin-terminal",
 	"deepin-editor",
+	"lightdm",
+	"lightdm-deepin-greeter",
 ]
 
 

--- a/profiles/deepin.py
+++ b/profiles/deepin.py
@@ -8,8 +8,6 @@ __packages__ = [
 	"deepin",
 	"deepin-terminal",
 	"deepin-editor",
-	"lightdm",
-	"lightdm-gtk-greeter",
 ]
 
 


### PR DESCRIPTION
As of deepin-session-shell 5.4.42-2 (which is in the deepin group), lightdm is added as a dependency because of lightdm-deepin-greeter. A configuration (usr/share/lightdm/lightdm.conf.d/60-deepin.conf) in startdde (also in the deepin group) should override default lightdm configuration to use lightdm-deepin-greeter instead of the gtk greeter. Thus these two packages could be removed from the profile now.

This effectively reverts #441

🚨 PR Guidelines:

# New features *(v2.2.0)*

All future work towards *`v2.2.0`* is done against `master` now.<br>
Any patch work to existing versions will have to create a new branch against the tagged versions.

# Describe your PR

If the changes has been discussed in an Issue, please tag it so that we can backtrace from the issue later on.<br>
If the PR is larger than ~20 lines, please describe it here unless described in an issue.

# Testing

Any new feature or stability improvement should be tested if possible. Please follow the test instructions at the bottom of the README or use the ISO built on each PR.
