### PR TITLE
Removing /tmp from fstab

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -403,9 +403,6 @@ class Installer:
 		self.pacstrap(self.base_packages)
 		self.helper_flags['base-strapped'] = True
 
-		with open(f"{self.target}/etc/fstab", "a") as fstab:
-			fstab.write("\ntmpfs /tmp tmpfs defaults,noatime,mode=1777 0 0\n")  # Redundant \n at the start? who knows?
-
 		# TODO: Support locale and timezone
 		# os.remove(f'{self.target}/etc/localtime')
 		# sys_command(f'/usr/bin/arch-chroot {self.target} ln -s /usr/share/zoneinfo/{localtime} /etc/localtime')


### PR DESCRIPTION
Since systemd takes care of mounting /tmp as a tmpt, there's no point in having a manual entry in fstab.
This will fix #616 