### PR TITLE
The "xfce4-goodies" package has been removed.

### DIFF
--- a/profiles/xfce4.py
+++ b/profiles/xfce4.py
@@ -6,7 +6,9 @@ is_top_level_profile = False
 
 __packages__ = [
 	"xfce4",
-	"xfce4-goodies",
+	"xfce4-pulseaudio-plugin",
+	"xfce4-whiskermenu-plugin",
+	"xfce4-screenshooter",
 	"pavucontrol",
 	"lightdm",
 	"lightdm-gtk-greeter",


### PR DESCRIPTION
Removed the "xfce4-goodies" package and added the two plugins that the package has and are the most used: xfce4-pulseaudio-plugin and xfce4-whiskermenu-plugin. The "xfce4-screenshooter" package has also been added.