### PR TITLE
Remove Konsole from cutefish profile

### DIFF
--- a/profiles/cutefish.py
+++ b/profiles/cutefish.py
@@ -7,7 +7,6 @@ is_top_level_profile = False
 __packages__ = [
 	"cutefish",
 	"noto-fonts",
-	"konsole",
 	"sddm"
 ]
 


### PR DESCRIPTION
Since Cutefish has now it's [own terminal emulator](https://archlinux.org/packages/community/x86_64/cutefish-terminal/) it's no longer needed to include Kosnole in the profile.