### PR TITLE
Fix use_mirrors

### DIFF
--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -116,14 +116,13 @@ def insert_mirrors(mirrors, *args, **kwargs):
 def use_mirrors(
 	regions: Mapping[str, Iterable[str]],
 	destination: str ='/etc/pacman.d/mirrorlist'
-) -> bool:
+) -> None:
 	log(f'A new package mirror-list has been created: {destination}', level=logging.INFO)
 	with open(destination, 'w') as mirrorlist:
 		for region, mirrors in regions.items():
 			for mirror in mirrors:
 				mirrorlist.write(f'## {region}\n')
 				mirrorlist.write(f'Server = {mirror}\n')
-	return True
 
 
 def re_rank_mirrors(top=10, *positionals, **kwargs):


### PR DESCRIPTION
Fixes #667 
https://github.com/archlinux/archinstall/blob/ba725517fd290a60cd4e1ea570dbbf94a47ede05/archinstall/lib/mirrors.py#L116-L123

The previous code doesn't open destination file in append mode. So, if we pass a dict of mirrors with multiple regions, file will be rewritten `len(regions)` times and only the last entry will be preserved.