### PR TITLE
Fixes #690 by Clearing storage['active_boot'] if shutdown was successful

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -104,8 +104,6 @@ class Installer:
 		self.HOOKS = ["base", "udev", "autodetect", "keyboard", "keymap", "modconf", "block", "filesystems", "fsck"]
 		self.KERNEL_PARAMS = []
 
-		self.cached_credentials = {} # Used by systemd.py Boot() to get passed the login prompt
-
 	def log(self, *args, level=logging.DEBUG, **kwargs):
 		"""
 		installer.log() wraps output.log() mainly to set a default log-level for this install session.
@@ -132,8 +130,6 @@ class Installer:
 			raise args[1]
 
 		self.genfstab()
-
-		self.cached_credentials = {}
 
 		if not (missing_steps := self.post_install_check()):
 			self.log('Installation completed without any errors. You may now reboot.', fg='green', level=logging.INFO)
@@ -664,8 +660,6 @@ class Installer:
 			self.log(f'Creating user {user}', level=logging.INFO)
 			SysCommand(f'/usr/bin/arch-chroot {self.target} useradd -m -G wheel {user}')
 
-		self.cached_credentials[user] = None
-
 		if password:
 			self.user_set_pw(user, password)
 
@@ -678,8 +672,6 @@ class Installer:
 
 	def user_set_pw(self, user, password):
 		self.log(f'Setting password for {user}', level=logging.INFO)
-
-		self.cached_credentials[user] = password
 
 		if user == 'root':
 			# This means the root account isn't locked/disabled with * in /etc/passwd

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -665,7 +665,7 @@ class Installer:
 			SysCommand(f'/usr/bin/arch-chroot {self.target} useradd -m -G wheel {user}')
 
 		self.cached_credentials[user] = None
-		
+
 		if password:
 			self.user_set_pw(user, password)
 
@@ -675,7 +675,6 @@ class Installer:
 
 		if sudo and self.enable_sudo(user):
 			self.helper_flags['user'] = True
-
 
 	def user_set_pw(self, user, password):
 		self.log(f'Setting password for {user}', level=logging.INFO)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -104,6 +104,8 @@ class Installer:
 		self.HOOKS = ["base", "udev", "autodetect", "keyboard", "keymap", "modconf", "block", "filesystems", "fsck"]
 		self.KERNEL_PARAMS = []
 
+		self.cached_credentials = {} # Used by systemd.py Boot() to get passed the login prompt
+
 	def log(self, *args, level=logging.DEBUG, **kwargs):
 		"""
 		installer.log() wraps output.log() mainly to set a default log-level for this install session.
@@ -130,6 +132,8 @@ class Installer:
 			raise args[1]
 
 		self.genfstab()
+
+		self.cached_credentials = {}
 
 		if not (missing_steps := self.post_install_check()):
 			self.log('Installation completed without any errors. You may now reboot.', fg='green', level=logging.INFO)
@@ -660,6 +664,8 @@ class Installer:
 			self.log(f'Creating user {user}', level=logging.INFO)
 			SysCommand(f'/usr/bin/arch-chroot {self.target} useradd -m -G wheel {user}')
 
+		self.cached_credentials[user] = None
+		
 		if password:
 			self.user_set_pw(user, password)
 
@@ -670,8 +676,11 @@ class Installer:
 		if sudo and self.enable_sudo(user):
 			self.helper_flags['user'] = True
 
+
 	def user_set_pw(self, user, password):
 		self.log(f'Setting password for {user}', level=logging.INFO)
+
+		self.cached_credentials[user] = password
 
 		if user == 'root':
 			# This means the root account isn't locked/disabled with * in /etc/passwd

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -699,6 +699,7 @@ class Installer:
 		return InstallationFile(self, filename, owner)
 
 	def set_keyboard_language(self, language: str) -> bool:
+		log(f"Setting keyboard language to {language}", level=logging.INFO)
 		if len(language.strip()):
 			if not verify_keyboard_layout(language):
 				self.log(f"Invalid keyboard language specified: {language}", fg="red", level=logging.ERROR)
@@ -720,6 +721,7 @@ class Installer:
 		return True
 
 	def set_x11_keyboard_language(self, language: str) -> bool:
+		log(f"Setting x11 keyboard language to {language}", level=logging.INFO)
 		"""
 		A fallback function to set x11 layout specifically and separately from console layout.
 		This isn't strictly necessary since .set_keyboard_language() does this as well.

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -75,7 +75,6 @@ class Boot:
 		if not self.ready:
 			while self.session.is_alive():
 				if b' login:' in self.session:
-					
 					self.ready = True
 					break
 

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -85,7 +85,8 @@ class Boot:
 			log(args[1], level=logging.ERROR, fg='red')
 			log(f"The error above occured in a temporary boot-up of the installation {self.instance}", level=logging.ERROR, fg="red")
 
-		SysCommand(f'machinectl shell {self.container_name} /bin/bash -c "shutdown now"')
+		if SysCommand(f'machinectl shell {self.container_name} /bin/bash -c "shutdown now"').exit_code == 0:
+			storage['active_boot'] = None
 
 	def __iter__(self):
 		if self.session:

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -58,10 +58,10 @@ class Boot:
 			raise KeyError("Archinstall only supports booting up one instance, and a active session is already active and it is not this one.")
 
 		if not self.user:
-			if (self.user := self.instance.cached_credentials.get('root', None)):
-				pass # We'll use root
-			elif (self.user := self.instance.cached_credentials.keys()[0]):
-				pass # We'll use the first available user
+			if (user := self.instance.cached_credentials.get('root', None)):
+				self.user = user # We'll use root
+			elif (user := self.instance.cached_credentials.keys()[0]):
+				self.user = user # We'll use the first available user
 			else:
 				raise ValueError(f"archinstall.Boot() requires you to first call either archinstall.user_create(), archinstall.user_set_pw() or specify user=X in Boot() for at least one user before Boot() can be used and get passed the login prompt.")
 

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -48,25 +48,15 @@ class Networkd(Systemd):
 
 
 class Boot:
-	def __init__(self, installation: Installer, user=None):
+	def __init__(self, installation: Installer):
 		self.instance = installation
 		self.container_name = 'archinstall'
 		self.session = None
 		self.ready = False
-		self.user = user
 
 	def __enter__(self):
 		if (existing_session := storage.get('active_boot', None)) and existing_session.instance != self.instance:
 			raise KeyError("Archinstall only supports booting up one instance, and a active session is already active and it is not this one.")
-
-		if not self.user:
-			if (user := self.instance.cached_credentials.get('root', None)):
-				self.user = user # We'll use root
-			elif (user := list(self.instance.cached_credentials.keys())[0]):
-				self.user = user # We'll use the first available user
-			else:
-				raise ValueError(f"archinstall.Boot() requires you to first call either archinstall.user_create(), archinstall.user_set_pw() or specify user=X in Boot() for at least one user before Boot() can be used."
-								" This in order to get passed the login prompt when booting up the installed system.")
 
 		if existing_session:
 			self.session = existing_session.session

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -104,8 +104,6 @@ class Boot:
 		while self.session.is_alive():
 			time.sleep(0.25)
 
-		log(f"Shutdown traceback: {shutdown}")
-		
 		if shutdown.exit_code == 0:
 			storage['active_boot'] = None
 		else:

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -89,7 +89,9 @@ class Boot:
 
 					if b'Password: ' in self.session:
 						if not (password := self.instance.cached_credentials[self.user]):
-							raise ValueError(f"No password found for {self.user} when trying to archinstall.Boot() into the system. The attempted boot will hang indefinitely so the installer cannot continue. call archinstall.user_set_pw() on {self.user} before calling archinstall.Boot()")
+							raise ValueError(f"No password found for {self.user} when trying to archinstall.Boot() into the system."
+											" The attempted boot will hang indefinitely so the installer cannot continue."
+											f" Call archinstall.user_set_pw() on {self.user} before calling archinstall.Boot()")
 						
 						self.session.write(bytes(password, 'UTF-8'))
 						time.sleep(2)

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -61,7 +61,7 @@ class Boot:
 		if not self.user:
 			if (user := self.instance.cached_credentials.get('root', None)):
 				self.user = user # We'll use root
-			elif (user := self.instance.cached_credentials.keys()[0]):
+			elif (user := list(self.instance.cached_credentials.keys())[0]):
 				self.user = user # We'll use the first available user
 			else:
 				raise ValueError(f"archinstall.Boot() requires you to first call either archinstall.user_create(), archinstall.user_set_pw() or specify user=X in Boot() for at least one user before Boot() can be used."

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from .general import SysCommand, SysCommandWorker, locate_binary
 from .installer import Installer
 from .output import log
@@ -63,7 +64,8 @@ class Boot:
 			elif (user := self.instance.cached_credentials.keys()[0]):
 				self.user = user # We'll use the first available user
 			else:
-				raise ValueError(f"archinstall.Boot() requires you to first call either archinstall.user_create(), archinstall.user_set_pw() or specify user=X in Boot() for at least one user before Boot() can be used and get passed the login prompt.")
+				raise ValueError(f"archinstall.Boot() requires you to first call either archinstall.user_create(), archinstall.user_set_pw() or specify user=X in Boot() for at least one user before Boot() can be used."
+								" This in order to get passed the login prompt when booting up the installed system.")
 
 		if existing_session:
 			self.session = existing_session.session


### PR DESCRIPTION
Since we run `machinectl shell X /bin/bash -c "shutdown now"` upon `__exit__` of the with context, we can't leave the machine instance dangling in `storage`, that's probably why the transport isn't connected - because the machine is dead.

We'll also make sure we wait for the shutdown to complete before releasing, to avoid double-boots on the file structure.

Swapped `machinectl` for `systemd-run` instead.