### PR TITLE
Solves issue #674

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -154,7 +154,7 @@ class BlockDevice:
 			return partition.get('uuid', None)
 
 	def convert_size_to_gb(self, size):
-		return size / GIGA
+		return round(size / GIGA,1)
 
 	@property
 	def size(self):

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -5,6 +5,8 @@ from ..exceptions import DiskError
 from ..output import log
 from ..general import SysCommand
 
+GIGA=2**30
+
 class BlockDevice:
 	def __init__(self, path, info=None):
 		if not info:
@@ -152,20 +154,11 @@ class BlockDevice:
 			return partition.get('uuid', None)
 
 	def convert_size_to_gb(self, size):
-		units = {
-			'P' : lambda s : float(s) * 2048,
-			'T' : lambda s : float(s) * 1024,
-			'G' : lambda s : float(s),
-			'M' : lambda s : float(s) / 1024,
-			'K' : lambda s : float(s) / 2048,
-			'B' : lambda s : float(s) / 3072,
-		}
-		unit = size[-1]
-		return float(units.get(unit, lambda s : None)(size[:-1]))
+		return size / GIGA
 
 	@property
 	def size(self):
-		output = json.loads(SysCommand(f"lsblk --json -o+SIZE {self.path}").decode('UTF-8'))
+		output = json.loads(SysCommand(f"lsblk --json -b -o+SIZE {self.path}").decode('UTF-8'))
 
 		for device in output['blockdevices']:
 			return self.convert_size_to_gb(device['size'])


### PR DESCRIPTION
We turned the size query of the devices to byte mode in lsblk (lsblk -b)
It avoids problems with the localized output of the lsblk utility.
Output formatting may be in need of some care (too much decimal)
