### PR TITLE
Fix #689 by adding a exception to filesystem.parted() on failure

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -143,7 +143,10 @@ class Filesystem:
 		:param string: A raw string passed to /usr/bin/parted -s <string>
 		:type string: str
 		"""
-		return self.raw_parted(string).exit_code == 0
+		if (parted_handle := self.raw_parted(string)).exit_code == 0:
+			return True
+		else:
+			raise DiskError(f"Parted failed to add a partition: {parted_handle}")
 
 	def use_entire_disk(self, root_filesystem_type='ext4') -> Partition:
 		# TODO: Implement this with declarative profiles instead.


### PR DESCRIPTION
This might not entirely solve it, but it's a step along the way by adding a failsafe to `parted()` calls.
We check if the PARTUUID shows up only if parted succeeds, so maybe this solves it?