### PR TITLE
Forgot to change the cls=JSON inside the recursive call of UNSAFE_JSON

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -94,15 +94,17 @@ class Filesystem:
 
 			if partition.get('filesystem', {}).get('format', False):
 				if partition.get('encrypted', False):
-					if not partition.get('password'):
+					if not partition.get('!password') and not storage['arguments'].get('!encryption-password'):
 						if storage['arguments'] == 'silent':
 							raise ValueError(f"Missing encryption password for {partition['device_instance']}")
 						else:
 							from ..user_interaction import get_password
-							partition['password'] = get_password(f"Enter a encryption password for {partition['device_instance']}")
+							partition['!password'] = get_password(f"Enter a encryption password for {partition['device_instance']}")
+					elif not partition.get('!password') and storage['arguments'].get('!encryption-password'):
+						partition['!password'] = storage['arguments']['!encryption-password']
 
-					partition['device_instance'].encrypt(password=partition['password'])
-					with luks2(partition['device_instance'], storage.get('ENC_IDENTIFIER', 'ai') + 'loop', partition['password']) as unlocked_device:
+					partition['device_instance'].encrypt(password=partition['!password'])
+					with luks2(partition['device_instance'], storage.get('ENC_IDENTIFIER', 'ai') + 'loop', partition['!password']) as unlocked_device:
 						if not partition.get('format'):
 							if storage['arguments'] == 'silent':
 								raise ValueError(f"Missing fs-type to format on newly created encrypted partition {partition['device_instance']}")

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -121,11 +121,11 @@ class JsonEncoder:
 			for key, val in list(obj.items()):
 				if isinstance(val, dict):
 					# This, is a EXTREMELY ugly hack.. but it's the only quick way I can think of to trigger a encoding of sub-dictionaries.
-					val = json.loads(json.dumps(val, cls=JSON))
+					val = json.loads(json.dumps(val, cls=UNSAFE_JSON))
 				else:
-					val = JsonEncoder._encode(val)
+					val = JsonEncoder._unsafe_encode(val)
 
-					copy[JsonEncoder._encode(key)] = val
+				copy[JsonEncoder._unsafe_encode(key)] = val
 			return copy
 		else:
 			return JsonEncoder._encode(obj)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -176,7 +176,9 @@ class Installer:
 		for mountpoint in sorted(mountpoints.keys()):
 			if mountpoints[mountpoint]['encrypted']:
 				loopdev = storage.get('ENC_IDENTIFIER', 'ai') + 'loop'
-				password = mountpoints[mountpoint]['password']
+				if not (password := mountpoints[mountpoint].get('!password', None)):
+					raise RequirementError(f"Missing mountpoint {mountpoint} encryption password in layout: {mountpoints[mountpoint]}")
+
 				with luks2(mountpoints[mountpoint]['device_instance'], loopdev, password, auto_unmount=False) as unlocked_device:
 					unlocked_device.mount(f"{self.target}{mountpoint}")
 

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -195,7 +195,7 @@ def generic_multi_select(options, text="Select one or more of the options above 
 def select_encrypted_partitions(block_devices :dict, password :str) -> dict:
 	root = find_partition_by_mountpoint(block_devices, '/')
 	root['encrypted'] = True
-	root['password'] = password
+	root['!password'] = password
 
 	return block_devices
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -245,8 +245,8 @@ def perform_filesystem_operations():
 def perform_installation(mountpoint):
 	user_credentials = {
 		"!users" : archinstall.arguments['!users'],
-		"!superusers" : archinstall.arguments['!users'],
-		"!root-password" : archinstall.arguments['!users'],
+		"!superusers" : archinstall.arguments['!superusers'],
+		"!root-password" : archinstall.arguments['!root-password'],
 	}
 	if archinstall.arguments.get('!encryption-password'):
 		user_credentials["!encryption-password"] = archinstall.arguments.get('!encryption-password')

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -243,15 +243,16 @@ def perform_filesystem_operations():
 				fs.load_layout(archinstall.storage['disk_layouts'][drive.path])
 
 def perform_installation(mountpoint):
-	user_credentials = json.dumps({
+	user_credentials = {
 		"!users" : archinstall.arguments['!users'],
 		"!superusers" : archinstall.arguments['!users'],
 		"!root-password" : archinstall.arguments['!users'],
-		"!encryption-password" : archinstall.arguments['!encryption-password'],
-	}, indent=4, sort_keys=True, cls=archinstall.UNSAFE_JSON)
+	}
+	if archinstall.arguments.get('!encryption-password'):
+		user_credentials["!encryption-password"] = archinstall.arguments.get('!encryption-password')
 
 	with open("/var/log/archinstall/user_credentials.json", "w") as config_file:
-		config_file.write(user_credentials)
+		config_file.write(json.dumps(user_credentials, indent=4, sort_keys=True, cls=archinstall.UNSAFE_JSON))
 
 	"""
 	Performs the installation steps on a block device.


### PR DESCRIPTION
This should make sure nested dictionaries don't have their `!<sensitive>` data exposed, even on print.
It also allows for sensitive data to be printed when using `UNSAFE_JSON` rather than `JSON` as the `cls=` trigger to `json.dumps`.