### PR TITLE
Solves issue #689. Attribute Error.'None type' has no attribute 'form…

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -223,7 +223,7 @@ class BlockDevice:
 			else:
 				log(f"uuid {uuid} not found. Waiting for {count +1} time",level=logging.DEBUG)
 				time.sleep(float(storage['arguments'].get('disk-sleep', 0.2)))
-				count +=1
+				count += 1
 		else:
 			log(f"Could not find {uuid} in disk after 5 retries",level=logging.INFO)
 			raise DiskError(f"New partition {uuid} never showed up after adding new partition on {self}")


### PR DESCRIPTION
…at' ...

It seems the system does not syncronus update its internal information after a partitioning.
Two places are affected. Directly on filesystem.add_partition (the uuid of the new partition isn't available after the parted command)
and blockdevice.get_partition, where the list of partitions for the iterator might not be available in the query.
The patch places both sections under controlled loops, giving the system the chance to update the information.
Should be more controlled via application parameters

Since implemented i haven't found any more glitches at that place, but a couple of cases for which both loops were triggered. 