### PR TITLE
Removed the GPT vs MBR lookup on __enter__

### DIFF
--- a/archinstall/1
+++ b/archinstall/1
@@ -1,0 +1,4 @@
+grep: lib/__pycache__/disk.cpython-39.pyc: binary file matches
+grep: lib/__pycache__/installer.cpython-39.pyc: binary file matches
+grep: lib/__pycache__/user_interaction.cpython-39.pyc: binary file matches
+grep: lib/disk/__pycache__/helpers.cpython-39.pyc: binary file matches

--- a/archinstall/1
+++ b/archinstall/1
@@ -1,4 +1,0 @@
-grep: lib/__pycache__/disk.cpython-39.pyc: binary file matches
-grep: lib/__pycache__/installer.cpython-39.pyc: binary file matches
-grep: lib/__pycache__/user_interaction.cpython-39.pyc: binary file matches
-grep: lib/disk/__pycache__/helpers.cpython-39.pyc: binary file matches

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -20,12 +20,6 @@ class Filesystem:
 		self.mode = mode
 
 	def __enter__(self, *args, **kwargs):
-		# TODO: partition_table_type is hardcoded to GPT at the moment. This has to be changed.
-		if self.mode == self.blockdevice.partition_table_type:
-			log(f'Kept partition format {self.mode} for {self.blockdevice}', level=logging.DEBUG)
-		else:
-			raise DiskError(f'The selected partition table format {self.mode} does not match that of {self.blockdevice}.')
-
 		return self
 
 	def __repr__(self):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -174,6 +174,7 @@ class Installer:
 				mountpoints[partition['mountpoint']] = partition
 
 		for mountpoint in sorted(mountpoints.keys()):
+			log(f"Mounting {mountpoint} to {self.target}{mountpoint}", level=logging.INFO)
 			if mountpoints[mountpoint]['encrypted']:
 				loopdev = storage.get('ENC_IDENTIFIER', 'ai') + 'loop'
 				if not (password := mountpoints[mountpoint].get('!password', None)):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -622,7 +622,6 @@ class Installer:
 				self.helper_flags['bootloader'] = True
 				return True
 			else:
-				boot_partition = find_partition_by_mountpoint(self.partitions, relative_mountpoint=f"/boot")
 				SysCommand(f'/usr/bin/arch-chroot {self.target} grub-install --target=i386-pc --recheck {boot_partition.path}')
 				SysCommand(f'/usr/bin/arch-chroot {self.target} grub-mkconfig -o /boot/grub/grub.cfg')
 				self.helper_flags['bootloader'] = True

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -189,7 +189,7 @@ class Installer:
 			time.sleep(1)
 			try:
 				get_mount_info(f"{self.target}{mountpoint}", traverse=False)
-			except DiskError as err:
+			except DiskError:
 				raise DiskError(f"Target {self.target}{mountpoint} never got mounted properly (unable to get mount information using findmnt).")
 
 			if (subvolumes := mountpoints[mountpoint].get('btrfs', {}).get('subvolumes', {})):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -7,7 +7,7 @@ import shlex
 import pathlib
 import subprocess
 import glob
-from .disk import get_partitions_in_use, Partition, find_partition_by_mountpoint
+from .disk import get_partitions_in_use, Partition
 from .general import SysCommand
 from .hardware import has_uefi, is_vm, cpu_vendor
 from .locale_helpers import verify_keyboard_layout, verify_x11_keyboard_layout

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -186,8 +186,10 @@ class Installer:
 				mountpoints[mountpoint]['device_instance'].mount(f"{self.target}{mountpoint}")
 
 			time.sleep(1)
-			if not get_mount_info(f"{self.target}{mountpoint}", traverse=False):
-				raise DiskError(f"Target {self.target}{mountpoint} never got mounted properly.")
+			try:
+				get_mount_info(f"{self.target}{mountpoint}", traverse=False)
+			except DiskError as err:
+				raise DiskError(f"Target {self.target}{mountpoint} never got mounted properly (unable to get mount information using findmnt).")
 
 			if (subvolumes := mountpoints[mountpoint].get('btrfs', {}).get('subvolumes', {})):
 				for name, location in subvolumes.items():


### PR DESCRIPTION
it's no longer necessary to validate this on instance creation. load_layout() Uses this only to detect what partition table format it should use when wiping the drive. Other than that we only check if MBR and part numbers are > 3, that's the only use of this variable at this moment.

This will fix #705 