### PR TITLE
Adding in --mount-point argument, which overrides storage['MOUNT_POINT']

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -72,6 +72,8 @@ arguments = initialize_arguments()
 storage['arguments'] = arguments
 if arguments.get('debug'):
 	log(f"Warning: --debug mode will write certain credentials to {storage['LOG_PATH']}/{storage['LOG_FILE']}!", fg="red", level=logging.WARNING)
+if arguments.get('mount-point'):
+	storage['MOUNT_POINT'] = arguments['mount-point']
 
 from .lib.plugins import plugins, load_plugin # This initiates the plugin loading ceremony
 


### PR DESCRIPTION
As per request: https://discord.com/channels/726808923662712894/726808924401172483/908813569808797797

This is experimental. I'm pretty sure it won't cause any issues as there shouldn't be any hidden hardcoded paths.