### PR TITLE
Add Noto fonts

### DIFF
--- a/profiles/desktop.py
+++ b/profiles/desktop.py
@@ -19,6 +19,9 @@ __packages__ = [
 	'wpa_supplicant',
 	'smartmontools',
 	'xdg-utils',
+	'noto-fonts-cjk',
+	'noto-fonts-emoji',
+	'noto-fonts',
 ]
 
 __supported__ = [


### PR DESCRIPTION
As a Linux user who visit Thai sites, I find the Noto fonts essential since some text in certain languages(notably Thai and Japanese) won't render without these.
