### PR TITLE
Clarification on boot entries when using multiple kernels

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -578,7 +578,7 @@ class Installer:
 				with open(f'{self.target}/boot/loader/entries/{self.init_time}_{kernel}.conf', 'w') as entry:
 					entry.write('# Created by: archinstall\n')
 					entry.write(f'# Created on: {self.init_time}\n')
-					entry.write('title Arch Linux\n')
+					entry.write(f'title Arch Linux ({kernel})\n')
 					entry.write(f"linux /vmlinuz-{kernel}\n")
 					if not is_vm():
 						vendor = cpu_vendor()


### PR DESCRIPTION
This addresses a question that came up in my head when testing for #720.
It should make it more clear on `systemd-boot` which kernel the user is booting.