### PR TITLE
Created config schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,215 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Archinstall Config",
+    "description": "A schema for the archinstall command config",
+    "type": "object",
+    "properties": {
+        "audio": {
+            "description": "Audioserver to be installed",
+            "type": "string",
+            "enum": [
+                "pipewire",
+                "pulseaudio"
+            ]
+        },
+        "bootloader": {
+            "description": "Bootloader  to be installed",
+            "type": "string",
+            "enum": [
+                "systemd-bootctl",
+                "grub-install"
+            ]
+        },
+        "custom-commands": {
+            "description": "Custom commands to be run post install",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "!encryption-password": {
+            "description": "Password to encrypt disk, not encrypted if password not provided",
+            "type": "string"
+        },
+        "filesystem": {
+            "description": "Filesystem for root and home partitions",
+            "type": "string",
+            "enum": [
+                "btrfs",
+                "ext4",
+                "xfs",
+                "f2fs"
+            ]
+        },
+        "gfx_driver": {
+            "description": "Graphics Drivers to install",
+            "type": "string",
+            "enum": [
+                "VMware / VirtualBox (open-source)",
+                "Nvidia",
+                "Intel (open-source)",
+                "AMD / ATI (open-source)",
+                "All open-source (default)"
+            ]
+        },
+        "harddrive": {
+            "description": "Path of device to be used",
+            "type": "object",
+            "properties": {
+                "path": {
+                    "description": "<path of device>",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "hostname": {
+            "description": "Hostname of machine after installation",
+            "type": "string"
+        },
+        "kernels": {
+            "description": "List of kernels to install eg: linux, linux-lts, linux-zen etc",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "linux",
+                    "linux-lts",
+                    "linux-zen",
+                    "linux-hardened"
+                ]
+            }
+        },
+        "keyboard-language": {
+            "description": "eg: us, de etc",
+            "type": "string"
+        },
+        "mirror-region": {
+            "description": "List of regions and mirrors to use",
+            "type": "object"
+        },
+        "nic": {
+            "description": "",
+            "type": "object",
+            "properties": {
+                "NetworkManager": {
+                    "description": "<boolean>",
+                    "type": "boolean"
+                },
+                "nic": {
+                    "description": "<nic name>",
+                    "type": "string"
+                }
+            }
+        },
+        "ntp": {
+            "description": "Set to true to set-up ntp post install",
+            "type": "boolean"
+        },
+        "packages": {
+            "description": "List of packages to install post-installation",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "profile": {
+            "description": "Profiles are present in profiles/, use the name of a profile to install it",
+            "type": "string",
+            "enum": [
+                "awesome",
+                "budgie",
+                "cinnamon",
+                "cutefish",
+                "deepin",
+                "desktop",
+                "enlightenment",
+                "gnome",
+                "i3",
+                "kde",
+                "lxqt",
+                "mate",
+                "minimal",
+                "server",
+                "sway",
+                "xfce4",
+                "xorg"
+            ]
+        },
+        "!root-password": {
+            "description": "The root account password",
+            "type": "string"
+        },
+        "services": {
+            "description": "Services to enable post-installation",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "sys-encoding": {
+            "description": "Set to change system encoding post-install, ignored if --advanced flag is not passed",
+            "type": "string"
+        },
+        "sys-language": {
+            "description": "Set to change system language post-install, ignored if --advanced flag is not passed",
+            "type": "string"
+        },
+        "superusers": {
+            "description": "List of superuser credentials, see configuration for reference",
+            "patternProperties": {
+                "*": {
+                    "description": "user - key is username",
+                    "properties": {
+                        "!password": {
+                            "description": "<password>",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "timezone": {
+            "description": "Timezone eg: UTC, Asia/Kolkata etc.",
+            "type": "string"
+        },
+        "users": {
+            "description": "List of regular user credentials, see configuration for reference (can be an empty object)",
+            "patternProperties": {
+                "*": {
+                    "description": "user - key is username",
+                    "properties": {
+                        "!password": {
+                            "description": "<password>",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "required": [
+        "bootloader",
+        "filesystem",
+        "kernels",
+        "keyboard-language",
+        "mirror-region",
+        "nic",
+        "timezone",
+        "users"
+    ],
+    "anyOf": [
+        {
+            "required": [
+                "!root-password"
+            ]
+        },
+        {
+            "required": [
+                "superusers"
+            ]
+        }
+    ]
+}

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Archinstall Config",
-    "description": "A schema for the archinstall command config",
+    "description": "A schema for the archinstall command config, more info over at https://archinstall.readthedocs.io/installing/guided.html#options-for-config",
     "type": "object",
     "properties": {
         "audio": {
@@ -9,7 +9,8 @@
             "type": "string",
             "enum": [
                 "pipewire",
-                "pulseaudio"
+                "pulseaudio",
+                "none"
             ]
         },
         "bootloader": {
@@ -17,7 +18,8 @@
             "type": "string",
             "enum": [
                 "systemd-bootctl",
-                "grub-install"
+                "grub-install",
+                "efistub"
             ]
         },
         "custom-commands": {
@@ -27,22 +29,8 @@
                 "type": "string"
             }
         },
-        "!encryption-password": {
-            "description": "Password to encrypt disk, not encrypted if password not provided",
-            "type": "string"
-        },
-        "filesystem": {
-            "description": "Filesystem for root and home partitions",
-            "type": "string",
-            "enum": [
-                "btrfs",
-                "ext4",
-                "xfs",
-                "f2fs"
-            ]
-        },
         "gfx_driver": {
-            "description": "Graphics Drivers to install",
+            "description": "Graphics Drivers to install if a desktop profile is used, ignored otherwise.",
             "type": "string",
             "enum": [
                 "VMware / VirtualBox (open-source)",
@@ -52,18 +40,12 @@
                 "All open-source (default)"
             ]
         },
-        "harddrive": {
+        "harddrives": {
             "description": "Path of device to be used",
-            "type": "object",
-            "properties": {
-                "path": {
-                    "description": "<path of device>",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "path"
-            ]
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         },
         "hostname": {
             "description": "Hostname of machine after installation",
@@ -83,25 +65,29 @@
             }
         },
         "keyboard-language": {
-            "description": "eg: us, de etc",
+            "description": "eg: us, de, de-latin1 etc",
             "type": "string"
         },
         "mirror-region": {
-            "description": "List of regions and mirrors to use",
+            "description": "By default, it will autodetect the best region. Enter a region or a dictionary of regions and mirrors to use specific ones",
             "type": "object"
         },
         "nic": {
-            "description": "",
+            "description": "Choose between NetworkManager, manual configuration, use systemd-networkd from the ISO or no configuration",
             "type": "object",
             "properties": {
                 "NetworkManager": {
                     "description": "<boolean>",
                     "type": "boolean"
                 },
-                "nic": {
-                    "description": "<nic name>",
-                    "type": "string"
-                }
+                "interface-name": {
+                    "address": "ip address",
+                    "subnet": "255.255.255.0",
+                    "gateway": "ip address",
+                    "dns": "ip address"
+                },
+                "nic": "Copy ISO network configuration to installation",
+                "nic": {}
             }
         },
         "ntp": {
@@ -138,10 +124,6 @@
                 "xorg"
             ]
         },
-        "!root-password": {
-            "description": "The root account password",
-            "type": "string"
-        },
         "services": {
             "description": "Services to enable post-installation",
             "type": "array",
@@ -157,48 +139,15 @@
             "description": "Set to change system language post-install, ignored if --advanced flag is not passed",
             "type": "string"
         },
-        "superusers": {
-            "description": "List of superuser credentials, see configuration for reference",
-            "patternProperties": {
-                "*": {
-                    "description": "user - key is username",
-                    "properties": {
-                        "!password": {
-                            "description": "<password>",
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
         "timezone": {
             "description": "Timezone eg: UTC, Asia/Kolkata etc.",
             "type": "string"
-        },
-        "users": {
-            "description": "List of regular user credentials, see configuration for reference (can be an empty object)",
-            "patternProperties": {
-                "*": {
-                    "description": "user - key is username",
-                    "properties": {
-                        "!password": {
-                            "description": "<password>",
-                            "type": "string"
-                        }
-                    }
-                }
-            }
         }
     },
     "required": [
         "bootloader",
-        "filesystem",
         "kernels",
-        "keyboard-language",
         "mirror-region",
-        "nic",
-        "timezone",
-        "users"
     ],
     "anyOf": [
         {
@@ -208,7 +157,7 @@
         },
         {
             "required": [
-                "superusers"
+                "!superusers"
             ]
         }
     ]


### PR DESCRIPTION
This PR introduces a JSON schema for creating config files against. The main goal here is to make it easier for people to write config files by defining the schema of those files. I'm not 100% that this belongs in this repo but it seems like a nice thing to have and I thought I'd just put it out there.

Will this be useful for others? I'm not sure, but I found it useful when I was messing around with `archinstall`, and testing different set ups. It sped up that process.

# Testing
### VSCode
- Register the schema and associate it with a file (`settings.json`):
```
"json.schemas": [
    {
        "fileMatch": [
            "*.archinstall.json",
        ],
        "url": "https://raw.githubusercontent.com/OhKannaDuh/archinstall/config-json-schema/schema.json"
    }
]
```
- Create a file that matches the pattern (`config.archinstall.json`)
- Start editing the file and bask in auto complete goodness