### PR TITLE
Swapped .get() statement for a verification om Partition().uuid

### DIFF
--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -153,7 +153,8 @@ class Partition:
 			partuuid_struct = SysCommand(f'lsblk -J -o+PARTUUID {self.path}')
 			if partuuid_struct.exit_code == 0:
 				if partition_information := next(iter(json.loads(partuuid_struct.decode('UTF-8'))['blockdevices']), None):
-					return partition_information.get('partuuid', None)
+					if (partuuid := partition_information.get('partuuid', None)):
+						return partuuid
 
 			time.sleep(storage['DISK_TIMEOUTS'])
 


### PR DESCRIPTION
This ensures Partition().uuid doesn't immediately return None