### PR TITLE
Add `gnome-software-packagekit-plugin`

### DIFF
--- a/profiles/gnome.py
+++ b/profiles/gnome.py
@@ -9,6 +9,7 @@ __packages__ = [
 	"gnome",
 	"gnome-tweaks",
 	"gdm",
+	"gnome-software-packagekit-plugin",
 ]
 
 


### PR DESCRIPTION
This allows GNOME Software to work out of the box. I don't know why it's not a dependency, but GNOME Software is kinda borked without it.