### PR TITLE
Adds Partition()._safe_uuid as a addon to Partition().uuid without exceptions

### DIFF
--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -160,7 +160,6 @@ class Partition:
 
 		raise DiskError(f"Could not get PARTUUID for {self.path} using 'lsblk -J -o+PARTUUID {self.path}'")
 
-	@property
 	def _safe_uuid(self):
 		try:
 			return self.uuid


### PR DESCRIPTION
Reworked the last uuid fix, and introduced _safe_uuid which does the same thing but handles the DisKerror. This way we can use it in more places.
This way we can safely try to get the UUID without delays.