### PR TITLE
Adding a warning when /boot is reasonably too small

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -2,12 +2,11 @@ import os
 import json
 import logging
 import time
+from .helpers import convert_size_to_gb
 from ..exceptions import DiskError
 from ..output import log
 from ..general import SysCommand
 from ..storage import storage
-
-GIGA = 2 ** 30
 
 class BlockDevice:
 	def __init__(self, path, info=None):
@@ -155,15 +154,12 @@ class BlockDevice:
 		for partition in json.loads(SysCommand(f'lsblk -J -o+UUID {self.path}').decode('UTF-8'))['blockdevices']:
 			return partition.get('uuid', None)
 
-	def convert_size_to_gb(self, size):
-		return round(size / GIGA,1)
-
 	@property
 	def size(self):
 		output = json.loads(SysCommand(f"lsblk --json -b -o+SIZE {self.path}").decode('UTF-8'))
 
 		for device in output['blockdevices']:
-			return self.convert_size_to_gb(device['size'])
+			return convert_size_to_gb(device['size'])
 
 	@property
 	def bus_type(self):

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -10,6 +10,10 @@ from ..general import SysCommand
 from ..output import log
 
 ROOT_DIR_PATTERN = re.compile('^.*?/devices')
+GIGA = 2 ** 30
+
+def convert_size_to_gb(size):
+	return round(size / GIGA,1)
 
 def sort_block_devices_based_on_performance(block_devices):
 	result = {device: 0 for device in block_devices}

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -7,7 +7,7 @@ import os
 import hashlib
 from typing import Optional
 from .blockdevice import BlockDevice
-from .helpers import get_mount_info, get_filesystem_type
+from .helpers import get_mount_info, get_filesystem_type, convert_size_to_gb
 from ..storage import storage
 from ..exceptions import DiskError, SysCallError, UnknownFilesystemFormat
 from ..output import log
@@ -110,17 +110,26 @@ class Partition:
 				return partition['size']# * self.sector_size
 
 	@property
+	def size(self):
+		for i in range(storage['DISK_RETRY_ATTEMPTS']):
+			self.partprobe()
+
+			if (handle := SysCommand(f"lsblk --json -b -o+SIZE {self.path}")).exit_code == 0:
+				lsblk = json.loads(handle.decode('UTF-8'))
+
+				for device in lsblk['blockdevices']:
+					return convert_size_to_gb(device['size'])
+
+			time.sleep(storage['DISK_TIMEOUTS'])
+
+	@property
 	def boot(self):
 		output = json.loads(SysCommand(f"sfdisk --json {self.block_device.path}").decode('UTF-8'))
 
 		# Get the bootable flag from the sfdisk output:
 		# {
 		#    "partitiontable": {
-		#       "label":"dos",
-		#       "id":"0xd202c10a",
 		#       "device":"/dev/loop0",
-		#       "unit":"sectors",
-		#       "sectorsize":512,
 		#       "partitions": [
 		#          {"node":"/dev/loop0p1", "start":2048, "size":10483712, "type":"83", "bootable":true}
 		#       ]

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -268,7 +268,7 @@ def perform_installation(mountpoint):
 		for partition in installation.partitions:
 			if partition.mountpoint == installation.target + '/boot':
 				if partition.size <= 0.25: # in GB
-					raise archinstall.DiskError(f"The /boot partition in use is not large enough to install boot loaders on properly. Please resize it using a tool like gparted and re-run the installation.")
+					raise archinstall.DiskError(f"The selected /boot partition in use is not large enough to properly install a boot loader. Please resize it to at least 256MB and re-run the installation.")
 
 		# if len(mirrors):
 		# Certain services might be running that affects the system during installation.

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -264,6 +264,12 @@ def perform_installation(mountpoint):
 		# This *can* be done outside of the installation, but the installer can deal with it.
 		installation.mount_ordered_layout(archinstall.storage['disk_layouts'])
 
+		# Placing /boot check during installation because this will catch both re-use and wipe scenarios.
+		for partition in installation.partitions:
+			if partition.mountpoint == installation.target + '/boot':
+				if partition.size <= 0.15: # in GB
+					raise archinstall.DiskError(f"The /boot partition in use is not large enough to install boot loaders on properly. Please resize it using a tool like gparted and re-run the installation.")
+
 		# if len(mirrors):
 		# Certain services might be running that affects the system during installation.
 		# Currently, only one such service is "reflector.service" which updates /etc/pacman.d/mirrorlist

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -267,7 +267,7 @@ def perform_installation(mountpoint):
 		# Placing /boot check during installation because this will catch both re-use and wipe scenarios.
 		for partition in installation.partitions:
 			if partition.mountpoint == installation.target + '/boot':
-				if partition.size <= 0.15: # in GB
+				if partition.size <= 0.25: # in GB
 					raise archinstall.DiskError(f"The /boot partition in use is not large enough to install boot loaders on properly. Please resize it using a tool like gparted and re-run the installation.")
 
 		# if len(mirrors):


### PR DESCRIPTION
Moved convert_size_to_gb() into disk/helpers.py, Added a Partition().size property meta function. Using the .size value to check if /boot is too small which will raise an exception. The only drawback is that it's done post-formatting. This in order to catch scenarios where formatting isn't used.

This will address #527 