### PR TITLE
Add `xdg-desktop-portal-gnome`

### DIFF
--- a/profiles/gnome.py
+++ b/profiles/gnome.py
@@ -10,6 +10,7 @@ __packages__ = [
 	"gnome-tweaks",
 	"gdm",
 	"gnome-software-packagekit-plugin",
+	"xdg-desktop-portal-gnome",
 ]
 
 


### PR DESCRIPTION
This should make screen sharing and recording work on Wayland.

A few days ago I was pretty confused because I didn't know what to install to make screen sharing work on Wayland. Well now I know.

```
Optional dependencies for firefox
    networkmanager: Location detection via available WiFi networks [installed]
    libnotify: Notification integration [installed]
    pulseaudio: Audio support [installed]
    speech-dispatcher: Text-to-Speech [installed]
    hunspell-en_US: Spell checking, American English
    xdg-desktop-portal: Screensharing with Wayland
```