### PR TITLE
NTFS Root Filesystem Support

### DIFF
--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -341,18 +341,15 @@ class Partition:
 					raise DiskError(f'Need to format (or define) the filesystem on {self} before mounting.')
 				fs = self.filesystem
 
-			if fs == 'ntfs':
-				fs = 'ntfs3'  # Needed to use the Paragon R/W NTFS driver
-			elif fs == 'fat32':
-				fs = 'vfat'  # This is the actual type used for fat32 mounting.
+			fs_type = self.get_mount_fs_type(fs)
 
 			pathlib.Path(target).mkdir(parents=True, exist_ok=True)
 
 			try:
 				if options:
-					mnt_handle = SysCommand(f"/usr/bin/mount -t {fs} -o {options} {self.path} {target}")
+					mnt_handle = SysCommand(f"/usr/bin/mount -t {fs_type} -o {options} {self.path} {target}")
 				else:
-					mnt_handle = SysCommand(f"/usr/bin/mount -t {fs} {self.path} {target}")
+					mnt_handle = SysCommand(f"/usr/bin/mount -t {fs_type} {self.path} {target}")
 
 				# TODO: Should be redundant to check for exit_code
 				if mnt_handle.exit_code != 0:
@@ -362,6 +359,13 @@ class Partition:
 
 			self.mountpoint = target
 			return True
+
+	def get_mount_fs_type(self, fs):
+		if fs == 'ntfs':
+			return 'ntfs3'  # Needed to use the Paragon R/W NTFS driver
+		elif fs == 'fat32':
+			return 'vfat'  # This is the actual type used for fat32 mounting.
+		return fs
 
 	def unmount(self):
 		try:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -13,6 +13,7 @@ from ..exceptions import DiskError, SysCallError, UnknownFilesystemFormat
 from ..output import log
 from ..general import SysCommand
 
+
 class Partition:
 	def __init__(self, path: str, block_device: BlockDevice, part_id=None, size=-1, filesystem=None, mountpoint=None, encrypted=False, autodetect_filesystem=True):
 		if not part_id:
@@ -71,17 +72,17 @@ class Partition:
 
 	def __dump__(self):
 		return {
-			'type' : 'primary',
-			'PARTUUID' : self._safe_uuid,
-			'wipe' : self.allow_formatting,
-			'boot' : self.boot,
-			'ESP' : self.boot,
-			'mountpoint' : self.target_mountpoint,
-			'encrypted' : self._encrypted,
-			'start' : self.start,
-			'size' : self.end,
-			'filesystem' : {
-				'format' : get_filesystem_type(self.path)
+			'type': 'primary',
+			'PARTUUID': self._safe_uuid,
+			'wipe': self.allow_formatting,
+			'boot': self.boot,
+			'ESP': self.boot,
+			'mountpoint': self.target_mountpoint,
+			'encrypted': self._encrypted,
+			'start': self.start,
+			'size': self.end,
+			'filesystem': {
+				'format': get_filesystem_type(self.path)
 			}
 		}
 
@@ -98,7 +99,7 @@ class Partition:
 
 		for partition in output.get('partitiontable', {}).get('partitions', []):
 			if partition['node'] == self.path:
-				return partition['start']# * self.sector_size
+				return partition['start']  # * self.sector_size
 
 	@property
 	def end(self):
@@ -107,7 +108,7 @@ class Partition:
 
 		for partition in output.get('partitiontable', {}).get('partitions', []):
 			if partition['node'] == self.path:
-				return partition['size']# * self.sector_size
+				return partition['size']  # * self.sector_size
 
 	@property
 	def boot(self):
@@ -301,6 +302,13 @@ class Partition:
 				raise DiskError(f"Could not format {path} with {filesystem} because: {handle.decode('UTF-8')}")
 			self.filesystem = filesystem
 
+		elif filesystem == 'ntfs':
+			options = ['-f'] + options
+
+			if (handle := SysCommand(f"/usr/bin/mkfs.ntfs {' '.join(options)} {path}")).exit_code != 0:
+				raise DiskError(f"Could not format {path} with {filesystem} because: {handle.decode('UTF-8')}")
+			self.filesystem = filesystem
+
 		elif filesystem == 'crypto_LUKS':
 			# 	from ..luks import luks2
 			# 	encrypted_partition = luks2(self, None, None)
@@ -333,13 +341,18 @@ class Partition:
 					raise DiskError(f'Need to format (or define) the filesystem on {self} before mounting.')
 				fs = self.filesystem
 
+			if fs == 'ntfs':
+				fs = 'ntfs3'  # Needed to use the Paragon R/W NTFS driver
+			elif fs == 'fat32':
+				fs = 'vfat'  # This is the actual type used for fat32 mounting.
+
 			pathlib.Path(target).mkdir(parents=True, exist_ok=True)
 
 			try:
 				if options:
-					mnt_handle = SysCommand(f"/usr/bin/mount -o {options} {self.path} {target}")
+					mnt_handle = SysCommand(f"/usr/bin/mount -t {fs} -o {options} {self.path} {target}")
 				else:
-					mnt_handle = SysCommand(f"/usr/bin/mount {self.path} {target}")
+					mnt_handle = SysCommand(f"/usr/bin/mount -t {fs} {self.path} {target}")
 
 				# TODO: Should be redundant to check for exit_code
 				if mnt_handle.exit_code != 0:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -305,7 +305,7 @@ class Partition:
 		elif filesystem == 'ntfs':
 			options = ['-f'] + options
 
-			if (handle := SysCommand(f"/usr/bin/mkfs.ntfs {' '.join(options)} {path}")).exit_code != 0:
+			if (handle := SysCommand(f"/usr/bin/mkfs.ntfs -Q {' '.join(options)} {path}")).exit_code != 0:
 				raise DiskError(f"Could not format {path} with {filesystem} because: {handle.decode('UTF-8')}")
 			self.filesystem = filesystem
 

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -341,7 +341,7 @@ class Partition:
 					raise DiskError(f'Need to format (or define) the filesystem on {self} before mounting.')
 				fs = self.filesystem
 
-			fs_type = self.get_mount_fs_type(fs)
+			fs_type = get_mount_fs_type(fs)
 
 			pathlib.Path(target).mkdir(parents=True, exist_ok=True)
 
@@ -359,13 +359,6 @@ class Partition:
 
 			self.mountpoint = target
 			return True
-
-	def get_mount_fs_type(self, fs):
-		if fs == 'ntfs':
-			return 'ntfs3'  # Needed to use the Paragon R/W NTFS driver
-		elif fs == 'fat32':
-			return 'vfat'  # This is the actual type used for fat32 mounting.
-		return fs
 
 	def unmount(self):
 		try:
@@ -399,3 +392,11 @@ class Partition:
 		except UnknownFilesystemFormat as err:
 			raise err
 		return True
+
+
+def get_mount_fs_type(fs):
+	if fs == 'ntfs':
+		return 'ntfs3'  # Needed to use the Paragon R/W NTFS driver
+	elif fs == 'fat32':
+		return 'vfat'  # This is the actual type used for fat32 mounting.
+	return fs

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -454,7 +454,7 @@ class Installer:
 			# There is not yet an fsck tool for NTFS. If it's being used for the root filesystem, the hook should be removed.
 			if partition.filesystem == 'ntfs3' and partition.mountpoint == self.target:
 				if 'fsck' in self.HOOKS:
-					self.hooks.remove('fsck')
+					self.HOOKS.remove('fsck')
 
 			if self.detect_encryption(partition):
 				if 'encrypt' not in self.HOOKS:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -441,8 +441,6 @@ class Installer:
 				self.base_packages.append('xfsprogs')
 			if partition.filesystem == 'f2fs':
 				self.base_packages.append('f2fs-tools')
-			if partition.filesystem == 'ntfs3':
-				self.base_packages.append('ntfsprogs')
 
 			# Configure mkinitcpio to handle some specific use cases.
 			if partition.filesystem == 'btrfs':

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -614,12 +614,16 @@ class Installer:
 			if real_device := self.detect_encryption(root_partition):
 				root_uuid = SysCommand(f"blkid -s UUID -o value {real_device.path}").decode().rstrip()
 				_file = "/etc/default/grub"
-				add_to_CMDLINE_LINUX = f"sed -i 's/GRUB_CMDLINE_LINUX=\"\"/GRUB_CMDLINE_LINUX=\"cryptdevice=UUID={root_uuid}:cryptlvm\"/'"
+				add_to_CMDLINE_LINUX = f"sed -i 's/GRUB_CMDLINE_LINUX=\"\"/GRUB_CMDLINE_LINUX=\"cryptdevice=UUID={root_uuid}:cryptlvm rootfstype={get_mount_fs_type(root_partition_fs)}\"/'"
 				enable_CRYPTODISK = "sed -i 's/#GRUB_ENABLE_CRYPTODISK=y/GRUB_ENABLE_CRYPTODISK=y/'"
 
 				log(f"Using UUID {root_uuid} of {real_device} as encrypted root identifier.", level=logging.INFO)
 				SysCommand(f"/usr/bin/arch-chroot {self.target} {add_to_CMDLINE_LINUX} {_file}")
 				SysCommand(f"/usr/bin/arch-chroot {self.target} {enable_CRYPTODISK} {_file}")
+			else:
+				_file = "/etc/default/grub"
+				add_to_CMDLINE_LINUX = f"sed -i 's/GRUB_CMDLINE_LINUX=\"\"/GRUB_CMDLINE_LINUX=\"rootfstype={get_mount_fs_type(root_partition_fs)}\"/'"
+				SysCommand(f"/usr/bin/arch-chroot {self.target} {add_to_CMDLINE_LINUX} {_file}")
 
 			log(f"GRUB uses {boot_partition.path} as the boot partition.", level=logging.INFO)
 			if has_uefi():

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -450,6 +450,11 @@ class Installer:
 					self.MODULES.append('btrfs')
 				if '/usr/bin/btrfs-progs' not in self.BINARIES:
 					self.BINARIES.append('/usr/bin/btrfs')
+					
+			# There is not yet an fsck tool for NTFS. If it's being used for the root filesystem, the hook should be removed.
+			if partition.filesystem == 'ntfs' and partition.mountpoint == self.target:
+				if 'fsck' in self.HOOKS:
+					self.hooks.remove('fsck')
 
 			if self.detect_encryption(partition):
 				if 'encrypt' not in self.HOOKS:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -441,7 +441,7 @@ class Installer:
 				self.base_packages.append('xfsprogs')
 			if partition.filesystem == 'f2fs':
 				self.base_packages.append('f2fs-tools')
-			if partition.filesystem == 'ntfs':
+			if partition.filesystem == 'ntfs3':
 				self.base_packages.append('ntfsprogs')
 
 			# Configure mkinitcpio to handle some specific use cases.
@@ -452,7 +452,7 @@ class Installer:
 					self.BINARIES.append('/usr/bin/btrfs')
 					
 			# There is not yet an fsck tool for NTFS. If it's being used for the root filesystem, the hook should be removed.
-			if partition.filesystem == 'ntfs' and partition.mountpoint == self.target:
+			if partition.filesystem == 'ntfs3' and partition.mountpoint == self.target:
 				if 'fsck' in self.HOOKS:
 					self.hooks.remove('fsck')
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -441,6 +441,8 @@ class Installer:
 				self.base_packages.append('xfsprogs')
 			if partition.filesystem == 'f2fs':
 				self.base_packages.append('f2fs-tools')
+			if partition.filesystem == 'ntfs':
+				self.base_packages.append('ntfsprogs')
 
 			# Configure mkinitcpio to handle some specific use cases.
 			if partition.filesystem == 'btrfs':

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -40,15 +40,16 @@ class InstallationFile:
 	def __exit__(self, *args):
 		self.fh.close()
 		self.installation.chown(self.owner, self.filename)
-	
-	def write(self, data :Union[str, bytes]):
+
+	def write(self, data: Union[str, bytes]):
 		return self.fh.write(data)
-	
+
 	def read(self, *args):
 		return self.fh.read(*args)
-	
+
 	def poll(self, *args):
 		return self.fh.poll(*args)
+
 
 class Installer:
 	"""
@@ -165,7 +166,7 @@ class Installer:
 
 		return True
 
-	def mount_ordered_layout(self, layouts :dict):
+	def mount_ordered_layout(self, layouts: dict):
 		from .luks import luks2
 
 		mountpoints = {}
@@ -499,7 +500,7 @@ class Installer:
 		if kind == 'zram':
 			self.log(f"Setting up swap on zram")
 			self.pacstrap('zram-generator')
-			
+
 			# We could use the default example below, but maybe not the best idea: https://github.com/archlinux/archinstall/pull/678#issuecomment-962124813
 			# zram_example_location = '/usr/share/doc/zram-generator/zram-generator.conf.example'
 			# shutil.copy2(f"{self.target}{zram_example_location}", f"{self.target}/usr/lib/systemd/zram-generator.conf")

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -486,7 +486,8 @@ def ask_for_main_filesystem_format():
 		'btrfs': 'btrfs',
 		'ext4': 'ext4',
 		'xfs': 'xfs',
-		'f2fs': 'f2fs'
+		'f2fs': 'f2fs',
+		'ntfs': 'ntfs'
 	}
 
 	value = generic_select(options, "Select which filesystem your main partition should use (by number or name): ", allow_empty_input=False)


### PR DESCRIPTION
![VirtualBox_Arch_21_11_2021_12_00_27](https://user-images.githubusercontent.com/277927/142771672-fee71bc5-2ace-4017-86e5-98637f659a1b.png)


![VirtualBox_Arch_21_11_2021_14_45_14](https://user-images.githubusercontent.com/277927/142776677-4eeafeb8-88fa-4ac1-b05e-2100d8a4c0cb.png)

This is just for fun (and not really practical), but inspired by 
https://www.reddit.com/r/archlinux/comments/qwsftq/arch_linux_on_ntfs3/, I decided to see if it could be done. 

This probably shouldn't be used by anyone as anything other than as a toy.

Tested working with/without encryption on both systemd-boot (UEFI) and GRUB (BIOS) installations using VirtualBox. 

Thanks to Paragon for their excellent work on the new NTFS3 driver.