### PR TITLE
Fix #746 - Can't create a filesystem on a new partition during the manual partitioning

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -192,7 +192,7 @@ class BlockDevice:
 
 	@property
 	def largest_free_space(self):
-		info = None
+		info = []
 		for space_info in self.free_space:
 			if not info:
 				info = space_info

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -208,13 +208,15 @@ class BlockDevice:
 			start = info[0]
 		else:
 			start = '512MB'
+		return start
 
 	@property
 	def first_end_sector(self):
 		if info := self.largest_free_space:
-			start = info[1]
+			end = info[1]
 		else:
-			start = f"{self.size}GB"
+			end = f"{self.size}GB"
+		return end
 
 	def partprobe(self):
 		SysCommand(['partprobe', self.path])

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -202,6 +202,20 @@ class BlockDevice:
 					info = space_info
 		return info
 
+	@property
+	def first_free_sector(self):
+		if info := self.largest_free_space:
+			start = info[0]
+		else:
+			start = '512MB'
+
+	@property
+	def first_end_sector(self):
+		if info := self.largest_free_space:
+			start = info[1]
+		else:
+			start = f"{self.size}GB"
+
 	def partprobe(self):
 		SysCommand(['partprobe', self.path])
 

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -643,10 +643,10 @@ def manage_new_and_existing_partitions(block_device :BlockDevice) -> dict:
 
 			fstype = input("Enter a desired filesystem type for the partition: ").strip()
 
-			start = input(f"Enter the start sector (percentage or block number, default: {block_device.largest_free_space[0]}): ").strip()
+			start = input(f"Enter the start sector (percentage or block number, default: {block_device.first_free_sector}): ").strip()
 			if not start.strip():
-				start = block_device.largest_free_space[0]
-				end_suggested = block_device.largest_free_space[1]
+				start = block_device.first_free_sector
+				end_suggested = block_device.first_end_sector
 			else:
 				end_suggested = '100%'
 			end = input(f"Enter the end sector of the partition (percentage or block number, ex: {end_suggested}): ").strip()


### PR DESCRIPTION
Changed default value of info in largest_free_space()
Fixes bad assumption that disks always contain minimum of two partitions