### PR TITLE
Support encrypting multiple partitions

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -128,7 +128,7 @@ class BlockDevice:
 				if part_id not in self.part_cache:
 					# TODO: Force over-write even if in cache?
 					if part_id not in self.part_cache or self.part_cache[part_id].size != part['size']:
-						self.part_cache[part_id] = Partition(root_path + part_id, self, part_id=part_id, size=part['size'])
+						self.part_cache[part_id] = Partition(root_path + part_id, self, part_id=part_id)
 
 		return {k: self.part_cache[k] for k in sorted(self.part_cache)}
 
@@ -156,7 +156,7 @@ class BlockDevice:
 	@property
 	def size(self):
 		from .helpers import convert_size_to_gb
-		
+
 		output = json.loads(SysCommand(f"lsblk --json -b -o+SIZE {self.path}").decode('UTF-8'))
 
 		for device in output['blockdevices']:

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -156,7 +156,7 @@ class BlockDevice:
 	@property
 	def size(self):
 		from .helpers import convert_size_to_gb
-		
+
 		output = json.loads(SysCommand(f"lsblk --json -b -o+SIZE {self.path}").decode('UTF-8'))
 
 		for device in output['blockdevices']:

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -2,7 +2,6 @@ import os
 import json
 import logging
 import time
-from .helpers import convert_size_to_gb
 from ..exceptions import DiskError
 from ..output import log
 from ..general import SysCommand
@@ -156,6 +155,8 @@ class BlockDevice:
 
 	@property
 	def size(self):
+		from .helpers import convert_size_to_gb
+		
 		output = json.loads(SysCommand(f"lsblk --json -b -o+SIZE {self.path}").decode('UTF-8'))
 
 		for device in output['blockdevices']:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -90,6 +90,7 @@ class Filesystem:
 							storage['arguments']['!encryption-password'] = get_password(f"Enter a encryption password for {partition['device_instance']}")
 
 						partition['!password'] = storage['arguments']['!encryption-password']
+						print(partition['mountpoint'])
 						if partition['mountpoint'] != '/':
 							partition['generate-encryption-key-file'] = True
 

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -91,9 +91,6 @@ class Filesystem:
 
 						partition['!password'] = storage['arguments']['!encryption-password']
 
-					if partition['mountpoint'] != '/':
-						partition['generate-encryption-key-file'] = True
-
 					loopdev = f"{storage.get('ENC_IDENTIFIER', 'ai')}{pathlib.Path(partition['mountpoint']).name}loop"
 
 					partition['device_instance'].encrypt(password=partition['!password'])

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -4,7 +4,7 @@ import json
 from .partition import Partition
 from .validators import valid_fs_type
 from ..exceptions import DiskError
-from ..general import SysCommand
+from ..general import SysCommand, generate_password
 from ..output import log
 from ..storage import storage
 

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -103,7 +103,7 @@ class Filesystem:
 							with open(encryption_key_path, "w") as keyfile:
 								keyfile.write(generate_password(length=512))
 
-							unlocked_device.add_key(pathlib.Path(encryption_key_path), password=password)
+							unlocked_device.add_key(pathlib.Path(encryption_key_path), password=partition['!password'])
 
 						if not partition.get('format'):
 							if storage['arguments'] == 'silent':

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -4,7 +4,7 @@ import json
 from .partition import Partition
 from .validators import valid_fs_type
 from ..exceptions import DiskError
-from ..general import SysCommand, generate_password
+from ..general import SysCommand
 from ..output import log
 from ..storage import storage
 
@@ -81,19 +81,17 @@ class Filesystem:
 			if partition.get('filesystem', {}).get('format', False):
 				if partition.get('encrypted', False):
 					if not partition.get('!password'):
-						if partition.target_mountpoint == '/' and storage['arguments'].get('!encryption-password'):
-							partition['!password'] = storage['arguments']['!encryption-password']
-
-						elif partition.target_mountpoint == '/' and not storage['arguments'].get('!encryption-password'):
+						if not storage['arguments'].get('!encryption-password'):
 							if storage['arguments'] == 'silent':
 								raise ValueError(f"Missing encryption password for {partition['device_instance']}")
-							else:
-								from ..user_interaction import get_password
-								partition['!password'] = get_password(f"Enter a encryption password for {partition['device_instance']}")
 
-						else:
-							partition['!password'] = generate_password(length=512)
-							partition['store-password-on-disk'] = True
+							from ..user_interaction import get_password
+							storage['arguments']['!encryption-password'] = get_password(f"Enter a encryption password for {partition['device_instance']}")
+
+						partition['!password'] = storage['arguments']['!encryption-password']
+
+						if partition.target_mountpoint != '/':
+							partition['create-encryption-key'] = True
 
 					partition['device_instance'].encrypt(password=partition['!password'])
 					with luks2(partition['device_instance'], storage.get('ENC_IDENTIFIER', 'ai') + 'loop', partition['!password']) as unlocked_device:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -90,9 +90,9 @@ class Filesystem:
 							storage['arguments']['!encryption-password'] = get_password(f"Enter a encryption password for {partition['device_instance']}")
 
 						partition['!password'] = storage['arguments']['!encryption-password']
-						print(partition['mountpoint'])
-						if partition['mountpoint'] != '/':
-							partition['generate-encryption-key-file'] = True
+
+					if partition['mountpoint'] != '/':
+						partition['generate-encryption-key-file'] = True
 
 					loopdev = f"{storage.get('ENC_IDENTIFIER', 'ai')}{pathlib.Path(partition['mountpoint']).name}loop"
 

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -1,6 +1,7 @@
 import time
 import logging
 import json
+import pathlib
 from .partition import Partition
 from .validators import valid_fs_type
 from ..exceptions import DiskError

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -93,13 +93,13 @@ class Filesystem:
 
 					partition['device_instance'].encrypt(password=partition['!password'])
 					with luks2(partition['device_instance'], storage.get('ENC_IDENTIFIER', 'ai') + 'loop', partition['!password']) as unlocked_device:
-						if partition.target_mountpoint != '/':
+						if partition['mountpoint'] != '/':
 							if not (cryptkey_dir := pathlib.Path(f"{self.target}/etc/cryptsetup-keys.d")).exists():
 								cryptkey_dir.mkdir(parents=True, exist_ok=True)
 
 							# Once we store the key as ../xyzloop.key systemd-cryptsetup can automatically load this key
 							# if we name the device to "xyzloop".
-							encryption_key_path = f"{self.target}/etc/cryptsetup-keys.d/{pathlib.Path(partition.target_mountpoint).name}loop.key"
+							encryption_key_path = f"{self.target}/etc/cryptsetup-keys.d/{pathlib.Path(partition['mountpoint']).name}loop.key"
 							with open(encryption_key_path, "w") as keyfile:
 								keyfile.write(generate_password(length=512))
 

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -6,10 +6,10 @@ import re
 import time
 from typing import Union
 from .blockdevice import BlockDevice
-from .storage import storage
 from ..exceptions import SysCallError, DiskError
 from ..general import SysCommand
 from ..output import log
+from ..storage import storage
 
 ROOT_DIR_PATTERN = re.compile('^.*?/devices')
 GIGA = 2 ** 30

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -1,10 +1,12 @@
-import re
-import os
 import json
 import logging
+import os
 import pathlib
+import re
+import time
 from typing import Union
 from .blockdevice import BlockDevice
+from .storage import storage
 from ..exceptions import SysCallError, DiskError
 from ..general import SysCommand
 from ..output import log
@@ -209,3 +211,19 @@ def find_partition_by_mountpoint(block_devices, relative_mountpoint :str):
 		for partition in block_devices[device]['partitions']:
 			if partition.get('mountpoint', None) == relative_mountpoint:
 				return partition
+
+def partprobe():
+	SysCommand(f'bash -c "partprobe"')
+
+def convert_device_to_uuid(path :str) -> str:
+	for i in range(storage['DISK_RETRY_ATTEMPTS']):
+		partprobe()
+		output = json.loads(SysCommand(f"lsblk --json -o+UUID {path}").decode('UTF-8'))
+
+		for device in output['blockdevices']:
+			if (dev_uuid := device.get('uuid', None)):
+				return dev_uuid
+
+		time.sleep(storage['DISK_TIMEOUTS'])
+
+	raise DiskError(f"Could not retrieve the UUID of {path} within a timely manner.")

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -15,7 +15,7 @@ from ..general import SysCommand
 
 
 class Partition:
-	def __init__(self, path: str, block_device: BlockDevice, part_id=None, size=-1, filesystem=None, mountpoint=None, encrypted=False, autodetect_filesystem=True):
+	def __init__(self, path: str, block_device: BlockDevice, part_id=None, filesystem=None, mountpoint=None, encrypted=False, autodetect_filesystem=True):
 		if not part_id:
 			part_id = os.path.basename(path)
 

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -25,7 +25,6 @@ class Partition:
 		self.mountpoint = mountpoint
 		self.target_mountpoint = mountpoint
 		self.filesystem = filesystem
-		self.size = size  # TODO: Refresh?
 		self._encrypted = None
 		self.encrypted = encrypted
 		self.allow_formatting = False

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -50,7 +50,7 @@ def gen_uid(entropy_length=256):
 
 def generate_password(length=64):
 	haystack = string.printable # digits, ascii_letters, punctiation (!"#$[] etc) and whitespace
-	password = ''.join(secrets.choice(haystack) for i in range(length))
+	return ''.join(secrets.choice(haystack) for i in range(length))
 
 def multisplit(s, splitters):
 	s = [s, ]

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -2,8 +2,10 @@ import hashlib
 import json
 import logging
 import os
+import secrets
 import shlex
 import subprocess
+import string
 import sys
 import time
 from datetime import datetime, date
@@ -46,6 +48,9 @@ from .storage import storage
 def gen_uid(entropy_length=256):
 	return hashlib.sha512(os.urandom(entropy_length)).hexdigest()
 
+def generate_password(length=64):
+	haystack = string.printable # digits, ascii_letters, punctiation (!"#$[] etc) and whitespace
+	password = ''.join(secrets.choice(haystack) for i in range(length))
 
 def multisplit(s, splitters):
 	s = [s, ]
@@ -60,7 +65,6 @@ def multisplit(s, splitters):
 					ns.append(key)
 		s = ns
 	return s
-
 
 def locate_binary(name):
 	for PATH in os.environ['PATH'].split(':'):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -8,7 +8,7 @@ import pathlib
 import subprocess
 import glob
 from .disk import get_partitions_in_use, Partition
-from .general import SysCommand, generate_password
+from .general import SysCommand
 from .hardware import has_uefi, is_vm, cpu_vendor
 from .locale_helpers import verify_keyboard_layout, verify_x11_keyboard_layout
 from .disk.helpers import get_mount_info

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -195,6 +195,7 @@ class Installer:
 					raise RequirementError(f"Missing mountpoint {mountpoint} encryption password in layout: {partition}")
 
 				with luks2(partition['device_instance'], loopdev, password, auto_unmount=False) as unlocked_device:
+					print(partition)
 					if partition.get('generate-encryption-key-file'):
 						if not (cryptkey_dir := pathlib.Path(f"{self.target}/etc/cryptsetup-keys.d")).exists():
 							cryptkey_dir.mkdir(parents=True, exist_ok=True)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -200,6 +200,13 @@ class Installer:
 					create_subvolume(self, location)
 					mount_subvolume(self, location)
 
+			if partition.get('store-password-on-disk') and partition.get('!password'):
+				if not (cryptkey_dir := pathlib.Path(f"{self.target}/etc/cryptsetup-keys.d")).exists():
+					cryptkey_dir.mkdir(parents=True, exist_ok=True)
+
+				with open(f"{self.target}/etc/cryptsetup-keys.d/{pathlib.Path(partition.target_mountpoint).name}loop.key", "w") as keyfile:
+					keyfile.write(partition['!password'])
+
 	def mount(self, partition, mountpoint, create_mountpoint=True):
 		if create_mountpoint and not os.path.isdir(f'{self.target}{mountpoint}'):
 			os.makedirs(f'{self.target}{mountpoint}')

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -205,6 +205,8 @@ class Installer:
 						with open(f"{self.target}{encryption_key_path}", "w") as keyfile:
 							keyfile.write(generate_password(length=512))
 
+						os.chmod(encryption_key_path, 0o400)
+
 						luks_handle.add_key(pathlib.Path(f"{self.target}{encryption_key_path}"), password=password)
 						luks_handle.crypttab(self, encryption_key_path, options=["luks", "key-slot=1"])
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -204,6 +204,8 @@ class Installer:
 				if not (cryptkey_dir := pathlib.Path(f"{self.target}/etc/cryptsetup-keys.d")).exists():
 					cryptkey_dir.mkdir(parents=True, exist_ok=True)
 
+				# Once we store the key as ../xyzloop.key systemd-cryptsetup can automatically load this key
+				# if we name the device to "xyzloop".
 				with open(f"{self.target}/etc/cryptsetup-keys.d/{pathlib.Path(partition.target_mountpoint).name}loop.key", "w") as keyfile:
 					keyfile.write(partition['!password'])
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -201,11 +201,12 @@ class Installer:
 
 						# Once we store the key as ../xyzloop.key systemd-cryptsetup can automatically load this key
 						# if we name the device to "xyzloop".
-						encryption_key_path = f"{self.target}/etc/cryptsetup-keys.d/{pathlib.Path(partition['mountpoint']).name}loop.key"
-						with open(encryption_key_path, "w") as keyfile:
+						encryption_key_path = f"/etc/cryptsetup-keys.d/{pathlib.Path(partition['mountpoint']).name}loop.key"
+						with open(f"{self.target}{encryption_key_path}", "w") as keyfile:
 							keyfile.write(generate_password(length=512))
 
-						unlocked_device.add_key(pathlib.Path(encryption_key_path), password=password)
+						unlocked_device.add_key(pathlib.Path(f"{self.target}{encryption_key_path}"), password=password)
+						unlocked_device.crypttab(self, encryption_key_path, options=["luks", "key-slot=1"])
 
 					log(f"Mounting {mountpoint} to {self.target}{mountpoint} using {unlocked_device}", level=logging.INFO)
 					unlocked_device.mount(f"{self.target}{mountpoint}")

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -8,7 +8,7 @@ import pathlib
 import subprocess
 import glob
 from .disk import get_partitions_in_use, Partition
-from .general import SysCommand
+from .general import SysCommand, generate_password
 from .hardware import has_uefi, is_vm, cpu_vendor
 from .locale_helpers import verify_keyboard_layout, verify_x11_keyboard_layout
 from .disk.helpers import get_mount_info
@@ -184,6 +184,18 @@ class Installer:
 					raise RequirementError(f"Missing mountpoint {mountpoint} encryption password in layout: {partition}")
 
 				with luks2(partition['device_instance'], loopdev, password, auto_unmount=False) as unlocked_device:
+					if partition.get('generate-encryption-key-file'):
+						if not (cryptkey_dir := pathlib.Path(f"{self.target}/etc/cryptsetup-keys.d")).exists():
+							cryptkey_dir.mkdir(parents=True, exist_ok=True)
+
+						# Once we store the key as ../xyzloop.key systemd-cryptsetup can automatically load this key
+						# if we name the device to "xyzloop".
+						encryption_key_path = f"{self.target}/etc/cryptsetup-keys.d/{pathlib.Path(partition['mountpoint']).name}loop.key"
+						with open(encryption_key_path, "w") as keyfile:
+							keyfile.write(generate_password(length=512))
+
+						unlocked_device.add_key(pathlib.Path(encryption_key_path), password=password)
+
 					log(f"Mounting {mountpoint} to {self.target}{mountpoint} using {unlocked_device}", level=logging.INFO)
 					unlocked_device.mount(f"{self.target}{mountpoint}")
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -184,18 +184,6 @@ class Installer:
 					raise RequirementError(f"Missing mountpoint {mountpoint} encryption password in layout: {partition}")
 
 				with luks2(partition['device_instance'], loopdev, password, auto_unmount=False) as unlocked_device:
-					if partition.get('create-encryption-key'):
-						if not (cryptkey_dir := pathlib.Path(f"{self.target}/etc/cryptsetup-keys.d")).exists():
-							cryptkey_dir.mkdir(parents=True, exist_ok=True)
-
-						# Once we store the key as ../xyzloop.key systemd-cryptsetup can automatically load this key
-						# if we name the device to "xyzloop".
-						encryption_key_path = f"{self.target}/etc/cryptsetup-keys.d/{pathlib.Path(partition.target_mountpoint).name}loop.key"
-						with open(encryption_key_path, "w") as keyfile:
-							keyfile.write(generate_password(length=512))
-
-						unlocked_device.add_key(pathlib.Path(encryption_key_path), password=password)
-
 					log(f"Mounting {mountpoint} to {self.target}{mountpoint} using {unlocked_device}", level=logging.INFO)
 					unlocked_device.mount(f"{self.target}{mountpoint}")
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -195,7 +195,7 @@ class Installer:
 					raise RequirementError(f"Missing mountpoint {mountpoint} encryption password in layout: {partition}")
 
 				with luks2(partition['device_instance'], loopdev, password, auto_unmount=False) as unlocked_device:
-					print(partition)
+					log(f"PARTITION INFO: {partition}")
 					if partition.get('generate-encryption-key-file'):
 						if not (cryptkey_dir := pathlib.Path(f"{self.target}/etc/cryptsetup-keys.d")).exists():
 							cryptkey_dir.mkdir(parents=True, exist_ok=True)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -179,7 +179,7 @@ class Installer:
 			partition = mountpoints[mountpoint]
 
 			if partition.get('encrypted', False):
-				loopdev = storage.get('ENC_IDENTIFIER', 'ai') + 'loop'
+				loopdev = f"{storage.get('ENC_IDENTIFIER', 'ai')}{pathlib.Path(partition['mountpoint']).name}loop"
 				if not (password := partition.get('!password', None)):
 					raise RequirementError(f"Missing mountpoint {mountpoint} encryption password in layout: {partition}")
 

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -5,7 +5,7 @@ import pathlib
 import shlex
 import time
 
-from .disk import Partition
+from .disk import Partition, convert_device_to_uuid
 from .general import SysCommand, SysCommandWorker
 from .output import log
 from .exceptions import SysCallError, DiskError
@@ -160,3 +160,9 @@ class luks2:
 
 		if worker.exit_code != 0:
 			raise DiskError(f'Could not add encryption key {path} to {self.partition} because: {worker}')
+
+	def crypttab(self, installation, key_path :str, options=["luks", "key-slot=1"]):
+		# homeloop UUID=247ad289-dbe5-4419-9965-e3cd30f0b080 /etc/cryptsetup-keys.d/homeloop.key luks,key-slot=1
+		mapper_dev = f"/dev/mapper/{self.mountpoint}"
+		with open(f"{installation.target}/etc/crypttab", "a") as crypttab:
+			crypttab.write(f"{self.mountpoint} UUID={convert_device_to_uuid(mapper_dev)} {key_path} {','.join(options)}\n")

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -6,7 +6,7 @@ import shlex
 import time
 
 from .disk import Partition
-from .general import SysCommand
+from .general import SysCommand, SysCommandWorker
 from .output import log
 from .exceptions import SysCallError, DiskError
 

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -146,3 +146,10 @@ class luks2:
 	def format(self, path):
 		if (handle := SysCommand(f"/usr/bin/cryptsetup -q -v luksErase {path}")).exit_code != 0:
 			raise DiskError(f'Could not format {path} with {self.filesystem} because: {b"".join(handle)}')
+
+	def add_key(self, path :pathlib.Path):
+		if not path.exists():
+			raise OSError(2, f"Could not import {path} as a disk encryption key, file is missing.", str(path))
+
+		if (handle := SysCommand(f"/usr/bin/cryptsetup -q -v luksAddKey {self.partition.path} {path}")).exit_code != 0:
+			raise DiskError(f'Could not add encryption key {path} to {self.partition} because: {handle}')

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -172,4 +172,4 @@ class luks2:
 	def crypttab(self, installation, key_path :str, options=["luks", "key-slot=1"]):
 		log(f'Adding a crypttab entry for key {key_path} in {installation}', level=logging.INFO)
 		with open(f"{installation.target}/etc/crypttab", "a") as crypttab:
-			crypttab.write(f"{self.mountpoint} UUID={convert_device_to_uuid(self.partition.parent)} {key_path} {','.join(options)}\n")
+			crypttab.write(f"{self.mountpoint} UUID={convert_device_to_uuid(self.partition.path)} {key_path} {','.join(options)}\n")

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -171,7 +171,5 @@ class luks2:
 
 	def crypttab(self, installation, key_path :str, options=["luks", "key-slot=1"]):
 		log(f'Adding a crypttab entry for key {key_path} in {installation}', level=logging.INFO)
-		# homeloop UUID=247ad289-dbe5-4419-9965-e3cd30f0b080 /etc/cryptsetup-keys.d/homeloop.key luks,key-slot=1
-		mapper_dev = f"/dev/mapper/{self.mountpoint}"
 		with open(f"{installation.target}/etc/crypttab", "a") as crypttab:
-			crypttab.write(f"{self.mountpoint} UUID={convert_device_to_uuid(mapper_dev)} {key_path} {','.join(options)}\n")
+			crypttab.write(f"{self.mountpoint} UUID={convert_device_to_uuid(self.partition.parent)} {key_path} {','.join(options)}\n")

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -151,6 +151,8 @@ class luks2:
 		if not path.exists():
 			raise OSError(2, f"Could not import {path} as a disk encryption key, file is missing.", str(path))
 
+		log(f'Adding additional key-file {path} for {self.partition}', level=logging.INFO)
+
 		worker = SysCommandWorker(f"/usr/bin/cryptsetup -q -v luksAddKey {self.partition.path} {path}")
 		pw_injected = False
 		while worker.is_alive():
@@ -162,6 +164,7 @@ class luks2:
 			raise DiskError(f'Could not add encryption key {path} to {self.partition} because: {worker}')
 
 	def crypttab(self, installation, key_path :str, options=["luks", "key-slot=1"]):
+		log(f'Adding a crypttab entry for key {key_path} in {installation}', level=logging.INFO)
 		# homeloop UUID=247ad289-dbe5-4419-9965-e3cd30f0b080 /etc/cryptsetup-keys.d/homeloop.key luks,key-slot=1
 		mapper_dev = f"/dev/mapper/{self.mountpoint}"
 		with open(f"{installation.target}/etc/crypttab", "a") as crypttab:

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -159,4 +159,4 @@ class luks2:
 				pw_injected = True
 
 		if worker.exit_code != 0:
-			raise DiskError(f'Could not add encryption key {path} to {self.partition} because: {handle}')
+			raise DiskError(f'Could not add encryption key {path} to {self.partition} because: {worker}')

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -193,9 +193,11 @@ def generic_multi_select(options, text="Select one or more of the options above 
 	return selected_options
 
 def select_encrypted_partitions(block_devices :dict, password :str) -> dict:
-	root = find_partition_by_mountpoint(block_devices, '/')
-	root['encrypted'] = True
-	root['!password'] = password
+	for device in block_devices:
+		for partition in block_devices[device]['partitions']:
+			if partition.get('mountpoint', None) != '/boot':
+				partition['encrypted'] = True
+				partition['!password'] = password
 
 	return block_devices
 

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -201,12 +201,8 @@ def select_encrypted_partitions(block_devices :dict, password :str) -> dict:
 
 	return block_devices
 
-	# TODO: Next version perhaps we can support multiple encrypted partitions
-	# options = []
-	# for partition in block_devices.values():
-	# 	options.append({key: val for key, val in partition.items() if val})
-
-	# print(generic_multi_select(options, f"Choose which partitions to encrypt (leave blank when done): "))
+	# TODO: Next version perhaps we can support mixed multiple encrypted partitions
+	# Users might want to single out a partition for non-encryption to share between dualboot etc.
 
 class MiniCurses:
 	def __init__(self, width, height):

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -199,6 +199,10 @@ def select_encrypted_partitions(block_devices :dict, password :str) -> dict:
 				partition['encrypted'] = True
 				partition['!password'] = password
 
+				if partition['mountpoint'] != '/':
+					# Tell the upcoming steps to generate a key-file for non root mounts.
+					partition['generate-encryption-key-file'] = True
+
 	return block_devices
 
 	# TODO: Next version perhaps we can support mixed multiple encrypted partitions

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -9,7 +9,7 @@ import signal
 import sys
 import time
 
-from .disk import BlockDevice, valid_fs_type, find_partition_by_mountpoint, suggest_single_disk_layout, suggest_multi_disk_layout, valid_parted_position
+from .disk import BlockDevice, valid_fs_type, suggest_single_disk_layout, suggest_multi_disk_layout, valid_parted_position
 from .exceptions import RequirementError, UserError, DiskError
 from .hardware import AVAILABLE_GFX_DRIVERS, has_uefi, has_amd_graphics, has_intel_graphics, has_nvidia_graphics
 from .locale_helpers import list_keyboard_languages, verify_keyboard_layout, search_keyboard_layout


### PR DESCRIPTION
Initial work to support storing disk encryption keyfiles.
This will fix #749 by using the root-encryption passphrase in keyslot one, followed by a randomly generated secure string in keyslot two for the volume.

For details see #749 and the changelog.