### PR TITLE
XFCE profile: enabled service NetworkManager

### DIFF
--- a/profiles/xfce4.py
+++ b/profiles/xfce4.py
@@ -43,4 +43,5 @@ if __name__ == 'xfce4':
 	# Install the XFCE4 packages
 	archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
+	archinstall.storage['installation_session'].enable_service('NetworkManager') # NetworkManager
 	archinstall.storage['installation_session'].enable_service('lightdm')  # Light Display Manager


### PR DESCRIPTION
Without enabling `NetworkManager` the `network-manager-applet` is not usable.
