### PR TITLE
Add handling of default options in multi-choice menus

### DIFF
--- a/archinstall/lib/menu.py
+++ b/archinstall/lib/menu.py
@@ -68,7 +68,7 @@ class Menu(TerminalMenu):
 		idx = self.show()
 		if idx is not None:
 			if isinstance(idx, (list, tuple)):
-				return [self.menu_options[i] for i in idx]
+				return [self.default_option if ' (default)' in self.menu_options[i] else self.menu_options[i] for i in idx]
 			else:
 				selected = self.menu_options[idx]
 				if ' (default)' in selected and self.default_option:


### PR DESCRIPTION
In multiple choice menu: Return `self.default_option` instead of visible name if visible name contains " (default)".
Fix for: https://github.com/archlinux/archinstall/issues/785

Tested by both running `archinstall.select_kernel()` directly and by running a full install.