### PR TITLE
fix logic: could not detect root **or** boot

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -569,7 +569,7 @@ class Installer:
 				root_partition_fs = partition.filesystem
 				root_fs_type = get_mount_fs_type(root_partition_fs)
 
-		if boot_partition is None and root_partition is None:
+		if boot_partition is None or root_partition is None:
 			raise ValueError(f"Could not detect root (/) or boot (/boot) in {self.target} based on: {self.partitions}")
 
 		self.log(f'Adding bootloader {bootloader} to {boot_partition if boot_partition else root_partition}', level=logging.INFO)


### PR DESCRIPTION
This PR contains a simple logic fix upon root and boot directory detection.