### PR TITLE
Update installer.py (#1)

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -666,7 +666,7 @@ class Installer:
 			log(f"GRUB uses {boot_partition.path} as the boot partition.", level=logging.INFO)
 			if has_uefi():
 				self.pacstrap('efibootmgr') # TODO: Do we need? Yes, but remove from minimal_installation() instead?
-				if not (handle := SysCommand(f'/usr/bin/arch-chroot {self.target} grub-install --target=x86_64-efi --efi-directory=/boot --bootloader-id=GRUB')).exit_code == 0:
+				if not (handle := SysCommand(f'/usr/bin/arch-chroot {self.target} grub-install --target=x86_64-efi --efi-directory=/boot --bootloader-id=GRUB --removable')).exit_code == 0:
 					raise DiskError(f"Could not install GRUB to {self.target}/boot: {handle}")
 			else:
 				if not (handle := SysCommand(f'/usr/bin/arch-chroot {self.target} grub-install --target=i386-pc --recheck {boot_partition.parent}')).exit_code == 0:


### PR DESCRIPTION
Added "--removable" after "--bootloader-id=GRUB" on Line 669, because it would throw:
"Could not prepare Boot variable:
Interrupted system call
grub-install: error efibootmgr failed to register the boot entry: Input/output error"
without it on my laptop (with every distro I tried installing)

🚨 PR Guidelines:

# New features *(v2.2.0)*

All future work towards *`v2.2.0`* is done against `master` now.<br>
Any patch work to existing versions will have to create a new branch against the tagged versions.

# Describe your PR

If the changes has been discussed in an Issue, please tag it so that we can backtrace from the issue later on.<br>
If the PR is larger than ~20 lines, please describe it here unless described in an issue.

# Testing

Any new feature or stability improvement should be tested if possible. Please follow the test instructions at the bottom of the README or use the ISO built on each PR.
