### PR TITLE
Added delay to partprobe

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -127,6 +127,7 @@ class Filesystem:
 
 	def partprobe(self):
 		SysCommand(f'bash -c "partprobe"')
+		time.sleep(1)
 
 	def raw_parted(self, string: str):
 		if (cmd_handle := SysCommand(f'/usr/bin/parted -s {string}')).exit_code != 0:


### PR DESCRIPTION
Added delay so that partprobe has time to finish.
Otherwise information such as partuuid wont be readable with lsblk.
