### PR TITLE
Fixing possible race condition with partprobe

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -127,6 +127,7 @@ class Filesystem:
 
 	def partprobe(self):
 		SysCommand(f'bash -c "partprobe"')
+		time.sleep(1)
 
 	def raw_parted(self, string: str):
 		if (cmd_handle := SysCommand(f'/usr/bin/parted -s {string}')).exit_code != 0:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -207,6 +207,7 @@ class Partition:
 
 	def partprobe(self):
 		SysCommand(f'bash -c "partprobe"')
+		time.sleep(1)
 
 	def detect_inner_filesystem(self, password):
 		log(f'Trying to detect inner filesystem format on {self} (This might take a while)', level=logging.INFO)


### PR DESCRIPTION
Added delay so that partprobe has time to finish.
Otherwise information such as partuuid wont be readable with lsblk (udev returns null for partuuid property).

This behaviour causes the installer to fail, since it cant retreive the uuid of the selected device. And later because it cant map the uuid (if fixed in only partition.py) to the correct device.