### PR TITLE
Remove network-manager-applet from XFCE4 package list

### DIFF
--- a/profiles/xfce4.py
+++ b/profiles/xfce4.py
@@ -11,7 +11,6 @@ __packages__ = [
 	"lightdm",
 	"lightdm-gtk-greeter",
 	"gvfs",
-	"network-manager-applet",
 	"xarchiver"
 ]
 


### PR DESCRIPTION
Based on the discussion in #777 it seems like this forces NetworkManager which is not desired. We need a way to detect network manager being selected and install this only in that case.
