### PR TITLE
Changed lsblk to blkid where possible

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -150,8 +150,7 @@ class BlockDevice:
 		This is more reliable than relying on /dev/disk/by-partuuid as
 		it doesn't seam to be able to detect md raid partitions.
 		"""
-		for partition in json.loads(SysCommand(f'lsblk -J -o+UUID {self.path}').decode('UTF-8'))['blockdevices']:
-			return partition.get('uuid', None)
+		return SysCommand(f'blkid -s PTUUID -o value {self.path}').decode('UTF-8')
 
 	@property
 	def size(self):

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -36,6 +36,9 @@ class Filesystem:
 	def partuuid_to_index(self, uuid):
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
+			time.sleep(5)
+			
+			# TODO: Convert to blkid (or something similar, but blkid doesn't support traversing to list sub-PARTUUIDs based on blockdevice path?)
 			output = json.loads(SysCommand(f"lsblk --json -o+PARTUUID {self.blockdevice.device}").decode('UTF-8'))
 			
 			for device in output['blockdevices']:
@@ -127,7 +130,6 @@ class Filesystem:
 
 	def partprobe(self):
 		SysCommand(f'bash -c "partprobe"')
-		time.sleep(1)
 
 	def raw_parted(self, string: str):
 		if (cmd_handle := SysCommand(f'/usr/bin/parted -s {string}')).exit_code != 0:
@@ -205,5 +207,9 @@ class Filesystem:
 			SysCommand(f'bash -c "umount {device}?"')
 		except:
 			pass
+		
 		self.partprobe()
-		return self.raw_parted(f'{device} mklabel {disk_label}').exit_code == 0
+		worked = self.raw_parted(f'{device} mklabel {disk_label}').exit_code == 0
+		self.partprobe()
+		
+		return worked

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -214,10 +214,14 @@ def find_partition_by_mountpoint(block_devices, relative_mountpoint :str):
 
 def partprobe():
 	SysCommand(f'bash -c "partprobe"')
+	time.sleep(5)
 
 def convert_device_to_uuid(path :str) -> str:
 	for i in range(storage['DISK_RETRY_ATTEMPTS']):
 		partprobe()
+		
+		# TODO: Convert lsblk to blkid
+		# (lsblk supports BlockDev and Partition UUID grabbing, blkid requires you to pick PTUUID and PARTUUID)
 		output = json.loads(SysCommand(f"lsblk --json -o+UUID {path}").decode('UTF-8'))
 
 		for device in output['blockdevices']:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -159,7 +159,7 @@ class Partition:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
 
-			partuuid = self._safe_uuid()
+			partuuid = self._safe_uuid
 			if partuuid:
 				return partuuid
 

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -159,15 +159,13 @@ class Partition:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
 
-			partuuid_struct = SysCommand(f'lsblk -J -o+PARTUUID {self.path}')
-			if partuuid_struct.exit_code == 0:
-				if partition_information := next(iter(json.loads(partuuid_struct.decode('UTF-8'))['blockdevices']), None):
-					if partuuid := partition_information.get('partuuid', None):
-						return partuuid
+			partuuid = self._safe_uuid()
+			if partuuid:
+				return partuuid
 
 			time.sleep(storage['DISK_TIMEOUTS'])
 
-		raise DiskError(f"Could not get PARTUUID for {self.path} using 'lsblk -J -o+PARTUUID {self.path}'")
+		raise DiskError(f"Could not get PARTUUID for {self.path} using 'blkid -s PARTUUID -o value {self.path}'")
 
 	@property
 	def _safe_uuid(self) -> Optional[str]:
@@ -178,11 +176,7 @@ class Partition:
 		"""
 		self.partprobe()
 
-		partuuid_struct = SysCommand(f'lsblk -J -o+PARTUUID {self.path}')
-		if partuuid_struct.exit_code == 0:
-			if partition_information := next(iter(json.loads(partuuid_struct.decode('UTF-8'))['blockdevices']), None):
-				if partuuid := partition_information.get('partuuid', None):
-					return partuuid
+		return SysCommand(f'blkid -s PARTUUID -o value {self.path}').decode('UTF-8').strip()
 
 	@property
 	def encrypted(self):


### PR DESCRIPTION
There's a at least two more places where I'd like to swap out `lsblk`.
However, due to possibly adding complexity I'll avoid it.
Instead I bumped up the sleep and moved it to a more strategic place in two places.

`partuuid_to_index` gets a higher sleep, which leaves `partprobe` to be quick in the many places we use it.
And the helper `partprobe()` *(not the class methods)* also got a heavy sleep. As it's mainly used in `convert_device_to_uuid()` which is also used rarely.

This should speed things up, and safely grab the `PARTUUID` and `UUID` in the places we need it to.
Other alternatives are:
 * [sfdisk](https://linux.die.net/man/8/sfdisk)
 * [partx](https://man7.org/linux/man-pages/man8/partx.8.html)
 * [findfs](https://man7.org/linux/man-pages/man8/findfs.8.html)
 * [hdparm](https://man7.org/linux/man-pages/man8/hdparm.8.html)

I've tested `sfdisk` as well as `blkid` and both seem to have a 100% success rate of grabbing the `PARTUUID` no matter how quickly I attempted to grab it right after `parted` commands.

For historical purposes, this was the command I used to test it:
```
dd if=/dev/zero of=/dev/loop0 bs=4096 count=10 && \
partprobe /dev/loop0 && \
parted /dev/loop0 mklabel gpt && \
python test.py && \
echo $(sfdisk --part-uuid /dev/loop0 1 && lsblk -o+PARTUUID /dev/loop0p1) >> result.txt
```
[test.py](https://github.com/dcantrell/pyparted/tree/master/examples) being an example script using [pyparted](https://github.com/dcantrell/pyparted). And the loop device was set up using:
```
# truncate -s 20G testimage.img
# losetup -fP ./testimage.img
```