### PR TITLE
Enable multiple mirror selection #457

### DIFF
--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -797,13 +797,15 @@ def select_mirror_regions():
 	:rtype: dict
 	"""
 
-	# TODO: Support multiple options and country codes, SE,UK for instance.
-
 	mirrors = list_mirrors()
-	selected_mirror = Menu('Select one of the regions to download packages from', mirrors.keys()).run()
+	selected_mirror = Menu(
+		'Select one of the regions to download packages from',
+		mirrors.keys(),
+		multi=True
+	).run()
 
 	if selected_mirror is not None:
-		return {selected_mirror: mirrors[selected_mirror]}
+		return {selected: mirrors[selected] for selected in selected_mirror}
 
 	return {}
 


### PR DESCRIPTION
This addresses https://github.com/archlinux/archinstall/issues/457 to allow multiple mirrors to be selected. 
The installation code should already handle multiple mirrors/regions properly, just the actual gui changes were required. 