### PR TITLE
Fixes #783, #782 and #805

### DIFF
--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -72,7 +72,7 @@ class Partition:
 	def __dump__(self):
 		return {
 			'type': 'primary',
-			'PARTUUID': self._safe_uuid,
+			'PARTUUID': self.uuid,
 			'wipe': self.allow_formatting,
 			'boot': self.boot,
 			'ESP': self.boot,
@@ -158,14 +158,13 @@ class Partition:
 		"""
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
+			time.sleep(storage['DISK_TIMEOUTS'] * storage['DISK_RETRY_ATTEMPTS'])
 
 			partuuid_struct = SysCommand(f'lsblk -J -o+PARTUUID {self.path}')
 			if partuuid_struct.exit_code == 0:
 				if partition_information := next(iter(json.loads(partuuid_struct.decode('UTF-8'))['blockdevices']), None):
 					if partuuid := partition_information.get('partuuid', None):
 						return partuuid
-
-			time.sleep(storage['DISK_TIMEOUTS'])
 
 		raise DiskError(f"Could not get PARTUUID for {self.path} using 'lsblk -J -o+PARTUUID {self.path}'")
 
@@ -176,7 +175,7 @@ class Partition:
 		This function should only be used where uuid is not crucial.
 		For instance when you want to get a __repr__ of the class.
 		"""
-		self.partprobe()
+		# self.partprobe()
 
 		partuuid_struct = SysCommand(f'lsblk -J -o+PARTUUID {self.path}')
 		if partuuid_struct.exit_code == 0:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -158,7 +158,7 @@ class Partition:
 		"""
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(storage['DISK_TIMEOUTS'] * storage['DISK_RETRY_ATTEMPTS'])
+			time.sleep(storage['DISK_TIMEOUTS'] * i)
 
 			partuuid_struct = SysCommand(f'lsblk -J -o+PARTUUID {self.path}')
 			if partuuid_struct.exit_code == 0:

--- a/archinstall/lib/disk/user_guides.py
+++ b/archinstall/lib/disk/user_guides.py
@@ -78,7 +78,7 @@ def suggest_single_disk_layout(block_device, default_filesystem=None, advanced_o
 			"type" : "primary",
 			"encrypted" : False,
 			"format" : True,
-			"start" : f"{min(block_device.size + 0.5, MIN_SIZE_TO_ALLOW_HOME_PART + 0.5)}GB",
+			"start" : f"{min(block_device.size, MIN_SIZE_TO_ALLOW_HOME_PART)}GB",
 			"size" : "100%",
 			"mountpoint" : "/home",
 			"filesystem" : {

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -271,6 +271,9 @@ class SysCommandWorker:
 				except UnicodeDecodeError:
 					return False
 
+			with open(f"{storage['LOG_PATH']}/cmd_output.txt", "a") as peak_output:
+				peak_output.write(output)
+				
 			sys.stdout.write(output)
 			sys.stdout.flush()
 		return True

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -187,7 +187,7 @@ class Installer:
 			for partition in layouts[blockdevice]['partitions']:
 				mountpoints[partition['mountpoint']] = partition
 
-		for mountpoint in sorted(mountpoints.keys()):
+		for mountpoint in sorted([mnt_dest for mnt_dest in mountpoints.keys() if mnt_dest != None]):
 			partition = mountpoints[mountpoint]
 
 			if partition.get('encrypted', False):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -187,7 +187,7 @@ class Installer:
 			for partition in layouts[blockdevice]['partitions']:
 				mountpoints[partition['mountpoint']] = partition
 
-		for mountpoint in sorted([mnt_dest for mnt_dest in mountpoints.keys() if mnt_dest != None]):
+		for mountpoint in sorted([mnt_dest for mnt_dest in mountpoints.keys() if mnt_dest is not None]):
 			partition = mountpoints[mountpoint]
 
 			if partition.get('encrypted', False):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -108,7 +108,7 @@ def ask_user_questions():
 												text="Select one or more harddrives to use and configure (leave blank to skip this step): ",
 												allow_empty=True)
 
-	if archinstall.arguments.get('harddrives', None) is not None and archinstall.storage.get('disk_layouts', None) is None:
+	if archinstall.arguments.get('harddrives', None) and archinstall.storage.get('disk_layouts', None) is None:
 		archinstall.storage['disk_layouts'] = archinstall.select_disk_layout(archinstall.arguments['harddrives'], archinstall.arguments.get('advanced', False))
 
 	# Get disk encryption password (or skip if blank)


### PR DESCRIPTION
This fixes:
 * #783
 * #782
 * #805 

This eliminates *(hopefully)* the `0.5GB` windows between partitions.
It's still not perfect, as I'll need to create a `xB -> xiB` converter for parted.

But this also fixes a sorting issue when re-using partitions and partition ID's.
`PARTUUID` should no longer be able to be `None`.