### PR TITLE
Adding a Pipewire application profile

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -86,8 +86,8 @@ from .lib.plugins import plugins, load_plugin # This initiates the plugin loadin
 if arguments.get('plugin', None):
 	load_plugin(arguments['plugin'])
 
-# @plugin decorator hook to programmatically add
-# plutins in runtime using @archinstall.plugin
+# @archinstall.plugin decorator hook to programmatically add
+# plugins in runtime. Useful in profiles and other things.
 def plugin(f, *args, **kwargs):
 	plugins[f.__name__] = f
 

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -86,8 +86,10 @@ from .lib.plugins import plugins, load_plugin # This initiates the plugin loadin
 if arguments.get('plugin', None):
 	load_plugin(arguments['plugin'])
 
-# TODO: Learn the dark arts of argparse... (I summon thee dark spawn of cPython)
-
+# @plugin decorator hook to programmatically add
+# plutins in runtime using @archinstall.plugin
+def plugin(f, *args, **kwargs):
+	plugins[f.__name__] = f
 
 def run_as_a_module():
 	"""

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -783,12 +783,17 @@ class Installer:
 		handled_by_plugin = False
 		for plugin in plugins.values():
 			if hasattr(plugin, 'on_user_create'):
-				if result := plugin.on_user_create(user):
+				if result := plugin.on_user_create(self, user):
 					handled_by_plugin = result
 
 		if not handled_by_plugin:
 			self.log(f'Creating user {user}', level=logging.INFO)
 			SysCommand(f'/usr/bin/arch-chroot {self.target} useradd -m -G wheel {user}')
+
+		for plugin in plugins.values():
+			if hasattr(plugin, 'on_user_created'):
+				if result := plugin.on_user_created(self, user):
+					handled_by_plugin = result
 
 		if password:
 			self.user_set_pw(user, password)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -109,7 +109,9 @@ class Installer:
 
 		self.post_base_install = []
 
+		# TODO: Figure out which one of these two we'll use.. But currently we're mixing them..
 		storage['session'] = self
+		storage['installation_session'] = self
 
 		self.MODULES = []
 		self.BINARIES = []

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -312,7 +312,7 @@ def perform_installation(mountpoint):
 			if archinstall.arguments.get('audio', None) is not None:
 				installation.log(f"This audio server will be used: {archinstall.arguments.get('audio', None)}", level=logging.INFO)
 				if archinstall.arguments.get('audio', None) == 'pipewire':
-					archinstall.Application(installation, 'pipewire')
+					archinstall.Application(installation, 'pipewire').install()
 				elif archinstall.arguments.get('audio', None) == 'pulseaudio':
 					print('Installing pulseaudio ...')
 					installation.add_additional_packages("pulseaudio")

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -312,7 +312,7 @@ def perform_installation(mountpoint):
 			if archinstall.arguments.get('audio', None) is not None:
 				installation.log(f"This audio server will be used: {archinstall.arguments.get('audio', None)}", level=logging.INFO)
 				if archinstall.arguments.get('audio', None) == 'pipewire':
-					archinstall.Application(installation, 'pipewire').install()
+					archinstall.Application('pipewire', installer=installation).install()
 				elif archinstall.arguments.get('audio', None) == 'pulseaudio':
 					print('Installing pulseaudio ...')
 					installation.add_additional_packages("pulseaudio")

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -312,9 +312,7 @@ def perform_installation(mountpoint):
 			if archinstall.arguments.get('audio', None) is not None:
 				installation.log(f"This audio server will be used: {archinstall.arguments.get('audio', None)}", level=logging.INFO)
 				if archinstall.arguments.get('audio', None) == 'pipewire':
-					print('Installing pipewire ...')
-
-					installation.add_additional_packages(["pipewire", "pipewire-alsa", "pipewire-jack", "pipewire-media-session", "pipewire-pulse", "gst-plugin-pipewire", "libpulse"])
+					archinstall.Application(installation, 'pipewire')
 				elif archinstall.arguments.get('audio', None) == 'pulseaudio':
 					print('Installing pulseaudio ...')
 					installation.add_additional_packages("pulseaudio")

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -312,7 +312,7 @@ def perform_installation(mountpoint):
 			if archinstall.arguments.get('audio', None) is not None:
 				installation.log(f"This audio server will be used: {archinstall.arguments.get('audio', None)}", level=logging.INFO)
 				if archinstall.arguments.get('audio', None) == 'pipewire':
-					archinstall.Application('pipewire', installer=installation).install()
+					archinstall.Application(installation, 'pipewire').install()
 				elif archinstall.arguments.get('audio', None) == 'pulseaudio':
 					print('Installing pulseaudio ...')
 					installation.add_additional_packages("pulseaudio")

--- a/profiles/applications/pipewire.py
+++ b/profiles/applications/pipewire.py
@@ -1,0 +1,12 @@
+import archinstall
+
+# Define the package list in order for lib to source
+# which packages will be installed by this profile
+__packages__ = ["pipewire", "pipewire-alsa", "pipewire-jack", "pipewire-media-session", "pipewire-pulse", "gst-plugin-pipewire", "libpulse"]
+
+print('Installing pipewire ...')
+archinstall.storage['installation_session'].add_additional_packages(__packages__)
+
+@archinstall.plugin
+def on_user_created(installation :archinstall.Installer, user :str):
+	installation.chroot('systemctl enable --user pipewire-pulse.service', run_as=user)

--- a/profiles/applications/pipewire.py
+++ b/profiles/applications/pipewire.py
@@ -1,13 +1,14 @@
 import archinstall
+import logging
 
 # Define the package list in order for lib to source
 # which packages will be installed by this profile
 __packages__ = ["pipewire", "pipewire-alsa", "pipewire-jack", "pipewire-media-session", "pipewire-pulse", "gst-plugin-pipewire", "libpulse"]
 
-print('Installing pipewire ...')
-print(archinstall.storage)
+archinstall.log('Installing pipewire', level=logging.INFO)
 archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
 @archinstall.plugin
 def on_user_created(installation :archinstall.Installer, user :str):
+	archinstall.log(f"Enabling pipewire-pulse for {user}", level=logging.INFO)
 	installation.chroot('systemctl enable --user pipewire-pulse.service', run_as=user)

--- a/profiles/applications/pipewire.py
+++ b/profiles/applications/pipewire.py
@@ -5,6 +5,7 @@ import archinstall
 __packages__ = ["pipewire", "pipewire-alsa", "pipewire-jack", "pipewire-media-session", "pipewire-pulse", "gst-plugin-pipewire", "libpulse"]
 
 print('Installing pipewire ...')
+print(archinstall.storage)
 archinstall.storage['installation_session'].add_additional_packages(__packages__)
 
 @archinstall.plugin


### PR DESCRIPTION
This to better manage the pipewire setup process and minimize guided a bit. This also adds the concept of `@archinstall.plugin` decorators to add a plugin in run-time. Which pipewire uses to detect user creation and enable the pipewire-pulse service for new users.