### PR TITLE
Define an standard locale for all the commands executed

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -185,6 +185,8 @@ class SysCommandWorker:
 		self.callbacks = callbacks
 		self.peak_output = peak_output
 		self.environment_vars = environment_vars
+		# define the standard locale for command outputs. For now the C ascii one"
+		self.environment_vars['LC_ALL'] = "C"
 		self.logfile = logfile
 		self.working_directory = working_directory
 
@@ -364,7 +366,7 @@ class SysCommand:
 		peak_output :Optional[bool] = False,
 		environment_vars :Optional[Dict[str, Any]] = None,
 		working_directory :Optional[str] = './'):
-	
+
 		_callbacks = {}
 		if callbacks:
 			for hook, func in callbacks.items():

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -184,9 +184,8 @@ class SysCommandWorker:
 		self.cmd = cmd
 		self.callbacks = callbacks
 		self.peak_output = peak_output
-		self.environment_vars = environment_vars
-		# define the standard locale for command outputs. For now the C ascii one"
-		self.environment_vars['LC_ALL'] = "C"
+		# define the standard locale for command outputs. For now the C ascii one. Can be overriden
+		self.environment_vars = { 'LC_ALL':'C' , **environment_vars }
 		self.logfile = logfile
 		self.working_directory = working_directory
 

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -185,7 +185,7 @@ class SysCommandWorker:
 		self.callbacks = callbacks
 		self.peak_output = peak_output
 		# define the standard locale for command outputs. For now the C ascii one. Can be overriden
-		self.environment_vars = { 'LC_ALL':'C' , **environment_vars }
+		self.environment_vars = {'LC_ALL':'C' , **environment_vars}
 		self.logfile = logfile
 		self.working_directory = working_directory
 

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -158,8 +158,8 @@ class luks2:
 			raise OSError(2, f"Could not import {path} as a disk encryption key, file is missing.", str(path))
 
 		log(f'Adding additional key-file {path} for {self.partition}', level=logging.INFO)
-
-		worker = SysCommandWorker(f"/usr/bin/cryptsetup -q -v luksAddKey {self.partition.path} {path}",environment_vars={"LC_ALL":"C"})
+		worker = SysCommandWorker(f"/usr/bin/cryptsetup -q -v luksAddKey {self.partition.path} {path}",
+							environment_vars={'LC_ALL':'C'})
 		pw_injected = False
 		while worker.is_alive():
 			if b'Enter any existing passphrase' in worker and pw_injected is False:

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -159,7 +159,7 @@ class luks2:
 
 		log(f'Adding additional key-file {path} for {self.partition}', level=logging.INFO)
 
-		worker = SysCommandWorker(f"/usr/bin/cryptsetup -q -v luksAddKey {self.partition.path} {path}")
+		worker = SysCommandWorker(f"/usr/bin/cryptsetup -q -v luksAddKey {self.partition.path} {path}",environment_vars={"LC_ALL":"C"})
 		pw_injected = False
 		while worker.is_alive():
 			if b'Enter any existing passphrase' in worker and pw_injected is False:


### PR DESCRIPTION
This one liner makes a standard locale for everything executed as system commands inside Archinstall.
We have selected the C locale, ascii and english texts, as we believe it is always available inside Archlinux.
As it is coded it takes precedence over any possible change specified thru the SysCommand* interfaces.

