### PR TITLE
Adds pipewire-media-session.service for pipewire

### DIFF
--- a/profiles/applications/pipewire.py
+++ b/profiles/applications/pipewire.py
@@ -12,3 +12,4 @@ archinstall.storage['installation_session'].add_additional_packages(__packages__
 def on_user_created(installation :archinstall.Installer, user :str):
 	archinstall.log(f"Enabling pipewire-pulse for {user}", level=logging.INFO)
 	installation.chroot('systemctl enable --user pipewire-pulse.service', run_as=user)
+	installation.chroot('systemctl enable --user pipewire-media-session.service', run_as=user)


### PR DESCRIPTION
Since we're enabling `pipewire-pulse`, we'll also enable `pipewire-media-session` to avoid `No devices detected` in pipewire and also to enable media buttons where applicable.