### PR TITLE
Add support for 32-bit UEFI

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -50,7 +50,11 @@ storage['__version__'] = __version__
 DeferredTranslation.install()
 
 # Log various information about hardware before starting the installation. This might assist in troubleshooting
-debug(f"Hardware model detected: {SysInfo.sys_vendor()} {SysInfo.product_name()}; UEFI mode: {SysInfo.has_uefi()}")
+if SysInfo.has_uefi():
+	debug(f"Boot mode: UEFI ({SysInfo.uefi_size()}-bit)")
+else:
+	debug("Boot mode: BIOS")
+debug(f"Hardware model detected: {SysInfo.sys_vendor()} {SysInfo.product_name()}")
 debug(f"Processor model detected: {SysInfo.cpu_model()}")
 debug(f"Memory statistics: {SysInfo.mem_available()} available out of {SysInfo.mem_total()} total installed")
 debug(f"Virtualization detected: {SysInfo.virtualization()}; is VM: {SysInfo.is_vm()}")

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -199,6 +199,11 @@ class SysInfo:
 		return os.path.isdir('/sys/firmware/efi')
 
 	@staticmethod
+	def uefi_size() -> int:
+		with open(f"/sys/firmware/efi/fw_platform_size") as size:
+			return int(size.read().strip())
+
+	@staticmethod
 	def _graphics_devices() -> Dict[str, str]:
 		cards: Dict[str, str] = {}
 		for line in SysCommand("lspci"):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -943,12 +943,14 @@ class Installer:
 
 			self.pacman.strap('efibootmgr') # TODO: Do we need? Yes, but remove from minimal_installation() instead?
 
+			efi_target = 'i386' if SysInfo.uefi_size() == 32 else 'x86-64'
+
 			boot_dir_arg = []
 			if boot_partition != efi_partition:
 				boot_dir_arg.append(f'--boot-directory={boot_dir}')
 
 			add_options = [
-				'--target=x86_64-efi',
+				f'--target={efi_target}-efi',
 				f'--efi-directory={efi_partition.mountpoint}',
 				*boot_dir_arg,
 				'--bootloader-id=GRUB',
@@ -1015,8 +1017,9 @@ class Installer:
 				efi_dir_path = self.target / efi_partition.mountpoint.relative_to('/') / 'EFI' / 'BOOT'
 				efi_dir_path.mkdir(parents=True, exist_ok=True)
 
-				for file in ('BOOTIA32.EFI', 'BOOTX64.EFI'):
-					shutil.copy(limine_path / file, efi_dir_path)
+				efi_binary = 'BOOTIA32.EFI' if SysInfo.uefi_size() == 32 else 'BOOTX64.EFI'
+
+				shutil.copy(limine_path / efi_binary, efi_dir_path)
 			except Exception as err:
 				raise DiskError(f'Failed to install Limine in {self.target}{efi_partition.mountpoint}: {err}')
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -943,7 +943,7 @@ class Installer:
 
 			self.pacman.strap('efibootmgr') # TODO: Do we need? Yes, but remove from minimal_installation() instead?
 
-			efi_target = 'i386' if SysInfo.uefi_size() == 32 else 'x86-64'
+			efi_target = 'i386' if SysInfo.uefi_size() == 32 else 'x86_64'
 
 			boot_dir_arg = []
 			if boot_partition != efi_partition:


### PR DESCRIPTION
This PR adds support for devices with a 32-bit UEFI (and a 64-bit CPU), which include many Bay-Trail-powered devices.