### PR TITLE
examples/guided: if selected, activate NTP also in installer system

### DIFF
--- a/examples/guided.py
+++ b/examples/guided.py
@@ -69,6 +69,8 @@ def ask_user_questions():
 		archinstall.arguments['ntp'] = input("Would you like to use automatic time synchronization (NTP) with the default time servers? [Y/n]: ").strip().lower() in ('y', 'yes', '')
 		if archinstall.arguments['ntp']:
 			archinstall.log("Hardware time and other post-configuration steps might be required in order for NTP to work. For more information, please check the Arch wiki.", fg="yellow")
+			from archinstall.lib.general import SysCommand
+			SysCommand(f'timedatectl set-ntp true')
 
 	# Set which region to download packages from during the installation
 	if not archinstall.arguments.get('mirror-region', None):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -179,11 +179,10 @@ def ask_user_questions():
 	if not archinstall.arguments.get('timezone', None):
 		archinstall.arguments['timezone'] = archinstall.ask_for_a_timezone()
 
-	if archinstall.arguments['timezone']:
-		if not archinstall.arguments.get('ntp', False):
-			archinstall.arguments['ntp'] = input("Would you like to use automatic time synchronization (NTP) with the default time servers? [Y/n]: ").strip().lower() in ('y', 'yes', '')
-			if archinstall.arguments['ntp']:
-				archinstall.log("Hardware time and other post-configuration steps might be required in order for NTP to work. For more information, please check the Arch wiki.", fg="yellow")
+	if not archinstall.arguments.get('ntp', False):
+		archinstall.arguments['ntp'] = input("Would you like to use automatic time synchronization (NTP) with the default time servers? [Y/n]: ").strip().lower() in ('y', 'yes', '')
+		if archinstall.arguments['ntp']:
+			archinstall.log("Hardware time and other post-configuration steps might be required in order for NTP to work. For more information, please check the Arch wiki.", fg="yellow")
 
 
 def perform_filesystem_operations():

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -69,7 +69,7 @@ def ask_user_questions():
 		archinstall.arguments['ntp'] = input("Would you like to use automatic time synchronization (NTP) with the default time servers? [Y/n]: ").strip().lower() in ('y', 'yes', '')
 		if archinstall.arguments['ntp']:
 			archinstall.log("Hardware time and other post-configuration steps might be required in order for NTP to work. For more information, please check the Arch wiki.", fg="yellow")
-			archinstall.SysCommand(f'timedatectl set-ntp true')
+			archinstall.SysCommand('timedatectl set-ntp true')
 
 	# Set which region to download packages from during the installation
 	if not archinstall.arguments.get('mirror-region', None):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -69,8 +69,7 @@ def ask_user_questions():
 		archinstall.arguments['ntp'] = input("Would you like to use automatic time synchronization (NTP) with the default time servers? [Y/n]: ").strip().lower() in ('y', 'yes', '')
 		if archinstall.arguments['ntp']:
 			archinstall.log("Hardware time and other post-configuration steps might be required in order for NTP to work. For more information, please check the Arch wiki.", fg="yellow")
-			from archinstall.lib.general import SysCommand
-			SysCommand(f'timedatectl set-ntp true')
+			archinstall.SysCommand(f'timedatectl set-ntp true')
 
 	# Set which region to download packages from during the installation
 	if not archinstall.arguments.get('mirror-region', None):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -65,6 +65,11 @@ def ask_user_questions():
 	if len(archinstall.arguments['keyboard-layout']):
 		archinstall.set_keyboard_language(archinstall.arguments['keyboard-layout'])
 
+	if not archinstall.arguments.get('ntp', False):
+		archinstall.arguments['ntp'] = input("Would you like to use automatic time synchronization (NTP) with the default time servers? [Y/n]: ").strip().lower() in ('y', 'yes', '')
+		if archinstall.arguments['ntp']:
+			archinstall.log("Hardware time and other post-configuration steps might be required in order for NTP to work. For more information, please check the Arch wiki.", fg="yellow")
+
 	# Set which region to download packages from during the installation
 	if not archinstall.arguments.get('mirror-region', None):
 		archinstall.arguments['mirror-region'] = archinstall.select_mirror_regions()
@@ -178,11 +183,6 @@ def ask_user_questions():
 
 	if not archinstall.arguments.get('timezone', None):
 		archinstall.arguments['timezone'] = archinstall.ask_for_a_timezone()
-
-	if not archinstall.arguments.get('ntp', False):
-		archinstall.arguments['ntp'] = input("Would you like to use automatic time synchronization (NTP) with the default time servers? [Y/n]: ").strip().lower() in ('y', 'yes', '')
-		if archinstall.arguments['ntp']:
-			archinstall.log("Hardware time and other post-configuration steps might be required in order for NTP to work. For more information, please check the Arch wiki.", fg="yellow")
 
 
 def perform_filesystem_operations():


### PR DESCRIPTION
This is a proposed solution for #830

Activating the time synchronization (NTP) for the installation system [is part of the installation guide](https://wiki.archlinux.org/title/Installation_guide#Update_the_system_clock).

Here I modified #505 for activating NTP as soon as the user selects it for the target system.
And moved the question about NTP before the mirror selection, which is the first step that requires a valid date.