### PR TITLE
partition.py: Use exit code for mkfs.fat exception

### DIFF
--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -299,9 +299,8 @@ class Partition:
 		elif filesystem == 'fat32':
 			options = ['-F32'] + options
 
-			mkfs = SysCommand(f"/usr/bin/mkfs.vfat {' '.join(options)} {path}").decode('UTF-8')
-			if ('mkfs.fat' not in mkfs and 'mkfs.vfat' not in mkfs) or 'command not found' in mkfs:
-				raise DiskError(f"Could not format {path} with {filesystem} because: {mkfs}")
+			if (handle := SysCommand(f"/usr/bin/mkfs.vfat {' '.join(options)} {path}")).exit_code != 0:
+				raise DiskError(f"Could not format {path} with {filesystem} because: {handle.decode('UTF-8')}")
 			self.filesystem = filesystem
 
 		elif filesystem == 'ext4':


### PR DESCRIPTION
When using archinstall on an existing Arch Linux installation, (e.g. for migrating the current system on a new drive), no exception is raised if mkfs.vfat is missing in the base install (the dosfstools package is not installed).

NOTE: I have just tested this change with the context described above.