### PR TITLE
Rename Partition attribute "size" to "end"

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -7,7 +7,7 @@ from typing import Optional, Dict, Any, TYPE_CHECKING
 # https://stackoverflow.com/a/39757388/929999
 if TYPE_CHECKING:
 	from .blockdevice import BlockDevice
-	
+
 from .partition import Partition
 from .validators import valid_fs_type
 from ..exceptions import DiskError
@@ -78,7 +78,7 @@ class Filesystem:
 				print("Adding partition....")
 				partition['device_instance'] = self.add_partition(partition.get('type', 'primary'),
 																	start=partition.get('start', '1MiB'), # TODO: Revisit sane block starts (4MB for memorycards for instance)
-																	end=partition.get('size', '100%'),
+																	end=partition.get('end', '100%'),
 																	partition_format=partition.get('filesystem', {}).get('format', 'btrfs'))
 				# TODO: device_instance some times become None
 				# print('Device instance:', partition['device_instance'])

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -90,7 +90,7 @@ class Partition:
 			'mountpoint': self.target_mountpoint,
 			'encrypted': self._encrypted,
 			'start': self.start,
-			'size': self.end,
+			'end': self.end,
 			'filesystem': {
 				'format': get_filesystem_type(self.path)
 			}
@@ -402,7 +402,7 @@ class Partition:
 
 	def unmount(self) -> bool:
 		worker = SysCommand(f"/usr/bin/umount {self.path}")
-			
+
 		# Without to much research, it seams that low error codes are errors.
 		# And above 8k is indicators such as "/dev/x not mounted.".
 		# So anything in between 0 and 8k are errors (?).

--- a/archinstall/lib/disk/user_guides.py
+++ b/archinstall/lib/disk/user_guides.py
@@ -43,7 +43,7 @@ def suggest_single_disk_layout(block_device :BlockDevice,
 		# Boot
 		"type" : "primary",
 		"start" : "3MiB",
-		"size" : "203MiB",
+		"end" : "203MiB",
 		"boot" : True,
 		"encrypted" : False,
 		"format" : True,
@@ -58,12 +58,12 @@ def suggest_single_disk_layout(block_device :BlockDevice,
 	# like we do in MBR layouts where the boot loader is installed traditionally.
 	if has_uefi():
 		layout[block_device.path]['partitions'][-1]['start'] = '1MiB'
-		layout[block_device.path]['partitions'][-1]['size'] = '512MiB'
+		layout[block_device.path]['partitions'][-1]['end'] = '513MiB'
 
 	layout[block_device.path]['partitions'].append({
 		# Root
 		"type" : "primary",
-		"start" : "206MiB",
+		"start" : "203MiB",
 		"encrypted" : False,
 		"format" : True,
 		"mountpoint" : "/",
@@ -83,9 +83,9 @@ def suggest_single_disk_layout(block_device :BlockDevice,
 		# We'll use subvolumes
 		# Or the disk size is too small to allow for a separate /home
 		# Or the user doesn't want to create a separate partition for /home
-		layout[block_device.path]['partitions'][-1]['size'] = '100%'
+		layout[block_device.path]['partitions'][-1]['end'] = '100%'
 	else:
-		layout[block_device.path]['partitions'][-1]['size'] = f"{min(block_device.size, 20)}GiB"
+		layout[block_device.path]['partitions'][-1]['end'] = f"{min(block_device.size, 20)}GiB"
 
 	if default_filesystem == 'btrfs' and using_subvolumes:
 		# if input('Do you want to use a recommended structure? (Y/n): ').strip().lower() in ('', 'y', 'yes'):
@@ -111,7 +111,7 @@ def suggest_single_disk_layout(block_device :BlockDevice,
 			# Home
 			"type" : "primary",
 			"start" : f"{min(block_device.size, 20)}GiB",
-			"size" : "100%",
+			"end" : "100%",
 			"encrypted" : False,
 			"format" : True,
 			"mountpoint" : "/home",
@@ -162,7 +162,7 @@ def suggest_multi_disk_layout(block_devices :List[BlockDevice],
 		# Boot
 		"type" : "primary",
 		"start" : "3MiB",
-		"size" : "203MiB",
+		"end" : "203MiB",
 		"boot" : True,
 		"encrypted" : False,
 		"format" : True,
@@ -174,13 +174,13 @@ def suggest_multi_disk_layout(block_devices :List[BlockDevice],
 
 	if has_uefi():
 		layout[root_device.path]['partitions'][-1]['start'] = '1MiB'
-		layout[root_device.path]['partitions'][-1]['size'] = '512MiB'
+		layout[root_device.path]['partitions'][-1]['end'] = '513MiB'
 
 	layout[root_device.path]['partitions'].append({
 		# Root
 		"type" : "primary",
-		"start" : "206MiB",
-		"size" : "100%",
+		"start" : "203MiB",
+		"end" : "100%",
 		"encrypted" : False,
 		"format" : True,
 		"mountpoint" : "/",
@@ -195,7 +195,7 @@ def suggest_multi_disk_layout(block_devices :List[BlockDevice],
 		# Home
 		"type" : "primary",
 		"start" : "1MiB",
-		"size" : "100%",
+		"end" : "100%",
 		"encrypted" : False,
 		"format" : True,
 		"mountpoint" : "/home",


### PR DESCRIPTION
Internally, the "size" attribute of a Partition is treated as an end point. This PR fixes this as discussed in #794.

The changes from 7e959cd were made as a result of this issue and are reverted in this PR.

PR is currently drafted because I'm not sure I replaced all references of "size" to "end" yet.