### PR TITLE
Removed check for file.endswith('.json') on --disk_layouts

### DIFF
--- a/examples/guided.py
+++ b/examples/guided.py
@@ -51,7 +51,7 @@ def load_config():
 	if archinstall.arguments.get('servers', None) is not None:
 		archinstall.storage['_selected_servers'] = archinstall.arguments.get('servers', None)
 	if archinstall.arguments.get('disk_layouts', None) is not None:
-		if (dl_path := pathlib.Path(archinstall.arguments['disk_layouts'])).exists() and str(dl_path).endswith('.json'):
+		if (dl_path := pathlib.Path(archinstall.arguments['disk_layouts'])).exists():
 			try:
 				with open(dl_path) as fh:
 					archinstall.storage['disk_layouts'] = json.load(fh)


### PR DESCRIPTION
This enables users to call their configurations to .json.new and other file endings.
This will have no impact on the actual JSON parsing. It will still always check if the file exists, which should really be the only goal of parsing local files. The file name should be less important.

This fixes #858