### PR TITLE
Missing arguments after GlobalMenu execution (issue #868)

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -90,8 +90,6 @@ class Installer:
 			base_packages = __packages__[:3]
 		if kernels is None:
 			self.kernels = ['linux']
-		elif isinstance(kernels,str):
-			self.kernels = [kernels]
 		else:
 			self.kernels = kernels
 		self.target = target

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -238,6 +238,10 @@ class GlobalMenu:
 						break
 				else:
 					self._process_selection(selection)
+		for key in self._menu_options:
+			sel = self._menu_options[key]
+			if sel.enabled and sel.has_selection() and key not in archinstall.arguments:
+				archinstall.arguments[key] = sel._current_selection
 
 	def _process_selection(self, selection):
 		# find the selected option in our option list

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -138,7 +138,7 @@ def save_user_configurations():
 
 	with open("/var/log/archinstall/user_configuration.json", "w") as config_file:
 		config_file.write(user_configuration)
-	
+
 	if archinstall.arguments.get('disk_layouts'):
 		user_disk_layout = json.dumps(archinstall.arguments['disk_layouts'], indent=4, sort_keys=True, cls=archinstall.JSON)
 		with open("/var/log/archinstall/user_disk_layout.json", "w") as disk_layout_file:
@@ -148,10 +148,10 @@ def perform_filesystem_operations():
 	print()
 	print('This is your chosen configuration:')
 	archinstall.log("-- Guided template chosen (with below config) --", level=logging.DEBUG)
-	
+
 	user_configuration = json.dumps({**archinstall.arguments, 'version' : archinstall.__version__} , indent=4, sort_keys=True, cls=archinstall.JSON)
 	archinstall.log(user_configuration, level=logging.INFO)
-	
+
 	if archinstall.arguments.get('disk_layouts'):
 		user_disk_layout = json.dumps(archinstall.arguments['disk_layouts'], indent=4, sort_keys=True, cls=archinstall.JSON)
 		archinstall.log(user_disk_layout, level=logging.INFO)
@@ -192,7 +192,7 @@ def perform_installation(mountpoint):
 	Only requirement is that the block devices are
 	formatted and setup prior to entering this function.
 	"""
-	with archinstall.Installer(mountpoint, kernels=archinstall.arguments.get('kernels', 'linux')) as installation:
+	with archinstall.Installer(mountpoint, kernels=archinstall.arguments.get('kernels', ['linux'])) as installation:
 		# Mount all the drives to the desired mountpoint
 		# This *can* be done outside of the installation, but the installer can deal with it.
 		if archinstall.arguments.get('disk_layouts'):

--- a/examples/only_hd.py
+++ b/examples/only_hd.py
@@ -174,7 +174,7 @@ def perform_installation(mountpoint):
 	Only requirement is that the block devices are
 	formatted and setup prior to entering this function.
 	"""
-	with archinstall.Installer(mountpoint, kernels=archinstall.arguments.get('kernels', 'linux')) as installation:
+	with archinstall.Installer(mountpoint, kernels=None) as installation:
 		# Mount all the drives to the desired mountpoint
 		# This *can* be done outside of the installation, but the installer can deal with it.
 		if archinstall.storage.get('disk_layouts'):


### PR DESCRIPTION
A more general solution of issue #868 than PR #869.
While #869 solved the puntual issue of argument **kernels**, this PR solves a more general problem: At GlobalMenu, parameters which were enabled with a default value, but had no user interaction during menu manipulation were not transferred to the *arguments* dictionary. Now they are.
As a side effect, the use of the paramater *kernel* at **Installer** intializacion has been normalized to the fact that it only should acept lists