### PR TITLE
Some issues at Guided.py

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -163,10 +163,13 @@ def post_process_arguments(arguments):
 		load_plugin(arguments['plugin'])
 
 	if arguments.get('disk_layouts', None) is not None:
-		if 'disk_layouts' not in storage:
-			storage['disk_layouts'] = {}
-		if not json_stream_to_structure('--disk_layouts',arguments['disk_layouts'],storage['disk_layouts']):
+		# if 'disk_layouts' not in storage:
+		# 	storage['disk_layouts'] = {}
+		layout_storage = {}
+		if not json_stream_to_structure('--disk_layouts',arguments['disk_layouts'],layout_storage):
 			exit(1)
+		else:
+			arguments['disk_layouts'] = layout_storage
 
 
 define_arguments()

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -240,7 +240,7 @@ class GlobalMenu:
 					self._process_selection(selection)
 		for key in self._menu_options:
 			sel = self._menu_options[key]
-			if sel.has_selection() and key not in archinstall.arguments:
+			if key not in archinstall.arguments:
 				archinstall.arguments[key] = sel._current_selection
 
 	def _process_selection(self, selection):

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -240,7 +240,7 @@ class GlobalMenu:
 					self._process_selection(selection)
 		for key in self._menu_options:
 			sel = self._menu_options[key]
-			if sel.enabled and sel.has_selection() and key not in archinstall.arguments:
+			if sel.has_selection() and key not in archinstall.arguments:
 				archinstall.arguments[key] = sel._current_selection
 
 	def _process_selection(self, selection):


### PR DESCRIPTION
* Disk_layouts file content was still loaded at archinstall.storage, now it loads at archinstall.arguments, before the menu is called. There remains a wart, namely that the disk layout gets written in both config and disk_layouts file. 
* The patch at PR #871 was too restrictive in what it moved from menu to archinstall.arguments. Now everything at the menu not in archinstall.arguments gets moved there. It was the cause of issue #873 
Just growing pains of the new interface ...