### PR TITLE
Disable zswap

### DIFF
--- a/examples/guided.py
+++ b/examples/guided.py
@@ -219,11 +219,11 @@ def perform_installation(mountpoint):
 			installation.set_hostname(archinstall.arguments['hostname'])
 			if archinstall.arguments['mirror-region'].get("mirrors", None) is not None:
 				installation.set_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors in the installation medium
+			if archinstall.arguments['swap']:
+				installation.setup_swap('zram')
 			if archinstall.arguments["bootloader"] == "grub-install" and archinstall.has_uefi():
 				installation.add_additional_packages("grub")
 			installation.add_bootloader(archinstall.arguments["bootloader"])
-			if archinstall.arguments['swap']:
-				installation.setup_swap('zram')
 
 			# If user selected to copy the current ISO network configuration
 			# Perform a copy of the config


### PR DESCRIPTION
Disable zswap when using zram.

The swap device is now initialised before the bootloader, inline with the
installation guide.

Fixes https://github.com/archlinux/archinstall/issues/881
