### PR TITLE
disk layout: allow to omit partition "start" option to start from previous partition end

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -18,7 +18,10 @@ from ..storage import storage
 GPT = 0b00000001
 MBR = 0b00000010
 
-DEFAULT_PARTITION_START = '1MiB' # TODO: Revisit sane block starts (4MB for memorycards for instance)
+# A sane default is 5MiB, that allows for plenty of buffer for GRUB on MBR
+# but also 4MiB for memory cards for instance. And another 1MiB to avoid issues.
+# (we've been pestered by disk issues since the start, so please let this be here for a few versions)
+DEFAULT_PARTITION_START = '5MiB'
 
 class Filesystem:
 	# TODO:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -73,14 +73,14 @@ class Filesystem:
 
 			self.blockdevice.flush_cache()
 
-        prev_partition = None
+		prev_partition = None
 		# We then iterate the partitions in order
 		for partition in layout.get('partitions', []):
 			# We don't want to re-add an existing partition (those containing a UUID already)
 			if partition.get('format', False) and not partition.get('PARTUUID', None):
 				print("Adding partition....")
-                start = partition.get('start') or (
-                    prev_partition and f'{prev_partition["device_instance"].end_sectors}s' or DEFAULT_PARTITION_START)
+				start = partition.get('start') or (
+					prev_partition and f'{prev_partition["device_instance"].end_sectors}s' or DEFAULT_PARTITION_START)
 				partition['device_instance'] = self.add_partition(partition.get('type', 'primary'),
 																	start=start,
 																	end=partition.get('size', '100%'),
@@ -138,7 +138,7 @@ class Filesystem:
 				log(f"Marking partition {partition['device_instance']} as bootable.")
 				self.set(self.partuuid_to_index(partition['device_instance'].uuid), 'boot on')
 
-            prev_partition = partition
+			prev_partition = partition
 
 	def find_partition(self, mountpoint :str) -> Partition:
 		for partition in self.blockdevice:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -18,6 +18,8 @@ from ..storage import storage
 GPT = 0b00000001
 MBR = 0b00000010
 
+DEFAULT_PARTITION_START = '1MiB' # TODO: Revisit sane block starts (4MB for memorycards for instance)
+
 class Filesystem:
 	# TODO:
 	#   When instance of a HDD is selected, check all usages and gracefully unmount them
@@ -71,13 +73,16 @@ class Filesystem:
 
 			self.blockdevice.flush_cache()
 
+        prev_partition = None
 		# We then iterate the partitions in order
 		for partition in layout.get('partitions', []):
 			# We don't want to re-add an existing partition (those containing a UUID already)
 			if partition.get('format', False) and not partition.get('PARTUUID', None):
 				print("Adding partition....")
+                start = partition.get('start') or (
+                    prev_partition and f'{prev_partition["device_instance"].end_sectors}s' or DEFAULT_PARTITION_START)
 				partition['device_instance'] = self.add_partition(partition.get('type', 'primary'),
-																	start=partition.get('start', '1MiB'), # TODO: Revisit sane block starts (4MB for memorycards for instance)
+																	start=start,
 																	end=partition.get('size', '100%'),
 																	partition_format=partition.get('filesystem', {}).get('format', 'btrfs'))
 				# TODO: device_instance some times become None
@@ -132,6 +137,8 @@ class Filesystem:
 			if partition.get('boot', False):
 				log(f"Marking partition {partition['device_instance']} as bootable.")
 				self.set(self.partuuid_to_index(partition['device_instance'].uuid), 'boot on')
+
+            prev_partition = partition
 
 	def find_partition(self, mountpoint :str) -> Partition:
 		for partition in self.blockdevice:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -113,12 +113,21 @@ class Partition:
 
 	@property
 	def end(self) -> Optional[str]:
+        # TODO: rename it to size_sectors
 		# TODO: Verify that the logic holds up, that 'size' is the size without 'start' added to it.
 		output = json.loads(SysCommand(f"sfdisk --json {self.block_device.path}").decode('UTF-8'))
 
 		for partition in output.get('partitiontable', {}).get('partitions', []):
 			if partition['node'] == self.path:
 				return partition['size']  # * self.sector_size
+
+	@property
+	def end_sectors(self) -> Optional[str]:
+		output = json.loads(SysCommand(f"sfdisk --json {self.block_device.path}").decode('UTF-8'))
+
+		for partition in output.get('partitiontable', {}).get('partitions', []):
+			if partition['node'] == self.path:
+				return partition['start'] + partition['size']
 
 	@property
 	def size(self) -> Optional[float]:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -113,7 +113,7 @@ class Partition:
 
 	@property
 	def end(self) -> Optional[str]:
-        # TODO: rename it to size_sectors
+		# TODO: actually this is size in sectors unit
 		# TODO: Verify that the logic holds up, that 'size' is the size without 'start' added to it.
 		output = json.loads(SysCommand(f"sfdisk --json {self.block_device.path}").decode('UTF-8'))
 


### PR DESCRIPTION
disk layout: allow to omit partition "start" option to start from previous partition end.

Actually this is almost only possible solution not to have sector gaps between partitions, so I guess example configs should be also updated (not with this PR, though)