### PR TITLE
FIX: disk layout: partprobe should be called and checked only for target device

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -139,7 +139,7 @@ class Filesystem:
 				return partition
 
 	def partprobe(self) -> bool:
-		return SysCommand(f'bash -c "partprobe"').exit_code == 0
+		return SysCommand(f'bash -c "partprobe {self.blockdevice.device}"').exit_code == 0
 
 	def raw_parted(self, string: str) -> SysCommand:
 		if (cmd_handle := SysCommand(f'/usr/bin/parted -s {string}')).exit_code != 0:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -139,7 +139,7 @@ class Filesystem:
 				return partition
 
 	def partprobe(self) -> bool:
-		return SysCommand(f'bash -c "partprobe {self.blockdevice.device}"').exit_code == 0
+		return SysCommand(f'partprobe {self.blockdevice.device}').exit_code == 0
 
 	def raw_parted(self, string: str) -> SysCommand:
 		if (cmd_handle := SysCommand(f'/usr/bin/parted -s {string}')).exit_code != 0:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -225,7 +225,7 @@ class Partition:
 		return bind_name
 
 	def partprobe(self) -> bool:
-		if SysCommand(f'bash -c "partprobe {self.block_device.device}"').exit_code == 0:
+		if SysCommand(f'partprobe {self.block_device.device}').exit_code == 0:
 			time.sleep(1)
 			return True
 		return False

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -225,7 +225,7 @@ class Partition:
 		return bind_name
 
 	def partprobe(self) -> bool:
-		if SysCommand(f'bash -c "partprobe"').exit_code == 0:
+		if SysCommand(f'bash -c "partprobe {self.block_device.device}"').exit_code == 0:
 			time.sleep(1)
 			return True
 		return False


### PR DESCRIPTION
I was using archinstaller from usb flash, which gave error (even after reboot) on partprobe for usb flash for some reason.
archinstaller was failing on creating disk layout because of this, even if target device was not affected at all.
Obviously this is wrong, this PR fixes this.