### PR TITLE
Fixing the 'device_instance' being None in some partition places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ venv
 .idea/**
 **/install.log
 .DS_Store
+**/cmd_history.txt

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -241,7 +241,7 @@ class BlockDevice:
 		count = 0
 		while count < 5:
 			for partition_uuid, partition in self.partitions.items():
-				if partition.uuid == uuid:
+				if partition.uuid.lower() == uuid.lower():
 					return partition
 			else:
 				log(f"uuid {uuid} not found. Waiting for {count +1} time",level=logging.DEBUG)

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -221,7 +221,7 @@ class Filesystem:
 		# TODO: This should never be able to happen
 		log(f"Could not find the new PARTUUID after adding the partition.", level=logging.ERROR, fg="red")
 		log(f"Previous partitions: {previous_partition_uuids}", level=logging.ERROR, fg="red")
-		log(f"New partitions: {new_uuid_set}", level=logging.ERROR, fg="red")
+		log(f"New partitions: {(previous_partition_uuids ^ {partition.uuid for partition in self.blockdevice.partitions.values()})}", level=logging.ERROR, fg="red")
 		raise DiskError(f"Could not add partition using: {parted_string}")
 
 	def set_name(self, partition: int, name: str) -> bool:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -91,7 +91,6 @@ class Filesystem:
 			else:
 				raise ValueError(f"{self}.load_layout() doesn't know how to continue without a new partition definition or a UUID ({partition.get('PARTUUID')}) on the device ({self.blockdevice.get_partition(uuid=partition.get('PARTUUID'))}).")
 
-
 			if partition.get('filesystem', {}).get('format', False):
 
 				# needed for backward compatibility with the introduction of the new "format_options"

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -167,7 +167,7 @@ class Filesystem:
 		# TODO: Implement this with declarative profiles instead.
 		raise ValueError("Installation().use_entire_disk() has to be re-worked.")
 
-	def add_partition(self, partition_type :str, start :str, end :str, partition_format :Optional[str] = None) -> None:
+	def add_partition(self, partition_type :str, start :str, end :str, partition_format :Optional[str] = None) -> Partition:
 		log(f'Adding partition to {self.blockdevice}, {start}->{end}', level=logging.INFO)
 
 		previous_partition_uuids = {partition.uuid for partition in self.blockdevice.partitions.values()}
@@ -186,8 +186,10 @@ class Filesystem:
 			while count < 10:
 				new_uuid = None
 				new_uuid_set = (previous_partition_uuids ^ {partition.uuid for partition in self.blockdevice.partitions.values()})
+
 				if len(new_uuid_set) > 0:
 					new_uuid = new_uuid_set.pop()
+
 				if new_uuid:
 					try:
 						return self.blockdevice.get_partition(new_uuid)
@@ -205,6 +207,9 @@ class Filesystem:
 			else:
 				log("Add partition is exiting due to excessive wait time",level=logging.INFO)
 				raise DiskError(f"New partition never showed up after adding new partition on {self}.")
+
+		# TODO: This should never be able to happen
+		raise DiskError(f"Could not add partition using: {parted_string}")
 
 	def set_name(self, partition: int, name: str) -> bool:
 		return self.parted(f'{self.blockdevice.device} name {partition + 1} "{name}"') == 0

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -149,7 +149,12 @@ class Filesystem:
 				return partition
 
 	def partprobe(self) -> bool:
-		return SysCommand(f'bash -c "partprobe"').exit_code == 0
+		result = SysCommand(f'partprobe')
+		
+		if result.exit_code != 0:
+			log(f"Could not execute partprobe: {result!r}", level=logging.WARNING, fg="yellow")
+
+		return result.exit_code == 0
 
 	def raw_parted(self, string: str) -> SysCommand:
 		if (cmd_handle := SysCommand(f'/usr/bin/parted -s {string}')).exit_code != 0:

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -190,10 +190,26 @@ def get_partitions_in_use(mountpoint :str) -> List[Partition]:
 
 	output = json.loads(output)
 	for target in output.get('filesystems', []):
-		mounts.append(Partition(target['source'], None, filesystem=target.get('fstype', None), mountpoint=target['target']))
+		# We need to create a BlockDevice() instead of 'None' here when creaiting Partition()
+		# Otherwise subsequent calls to .size etc will fail due to BlockDevice being None.
+
+		# So first, we create the partition without a BlockDevice and carefully only use it to get .real_device
+		# Note: doing print(partition) here will break because the above mentioned issue.
+		partition = Partition(target['source'], None, filesystem=target.get('fstype', None), mountpoint=target['target'])
+		partition = Partition(target['source'], partition.real_device, filesystem=target.get('fstype', None), mountpoint=target['target'])
+
+		# Once we have the real device (for instance /dev/nvme0n1p5) we can find the parent block device using
+		# (lsblk pkname lists both the partition and blockdevice, BD being the last entry)
+		result = SysCommand(f'lsblk -no pkname {partition.real_device}').decode().rstrip('\r\n').split('\r\n')[-1]
+		block_device = BlockDevice(f"/dev/{result}")
+
+		# Once we figured the block device out, we can properly create the partition object
+		partition = Partition(target['source'], block_device, filesystem=target.get('fstype', None), mountpoint=target['target'])
+
+		mounts.append(partition)
 
 		for child in target.get('children', []):
-			mounts.append(Partition(child['source'], None, filesystem=child.get('fstype', None), mountpoint=child['target']))
+			mounts.append(Partition(child['source'], block_device, filesystem=child.get('fstype', None), mountpoint=child['target']))
 
 	return mounts
 

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -225,7 +225,7 @@ class Partition:
 		return bind_name
 
 	def partprobe(self) -> bool:
-		if SysCommand(f'bash -c "partprobe"').exit_code == 0:
+		if SysCommand(f'partprobe {self.block_device.device}').exit_code == 0:
 			time.sleep(1)
 			return True
 		return False

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -46,11 +46,12 @@ class Partition:
 		except DiskError:
 			mount_information = {}
 
-		if self.mountpoint != mount_information.get('target', None) and mountpoint:
-			raise DiskError(f"{self} was given a mountpoint but the actual mountpoint differs: {mount_information.get('target', None)}")
+		if mount_information.get('target', None):
+			if self.mountpoint != mount_information.get('target', None) and mountpoint:
+				raise DiskError(f"{self} was given a mountpoint but the actual mountpoint differs: {mount_information.get('target', None)}")
 
-		if target := mount_information.get('target', None):
-			self.mountpoint = target
+			if target := mount_information.get('target', None):
+				self.mountpoint = target
 
 		if not self.filesystem and autodetect_filesystem:
 			if fstype := mount_information.get('fstype', get_filesystem_type(path)):
@@ -130,6 +131,9 @@ class Partition:
 
 				for device in lsblk['blockdevices']:
 					return convert_size_to_gb(device['size'])
+			elif handle.exit_code == 8192:
+				# Device is not a block device
+				return None
 
 			time.sleep(storage['DISK_TIMEOUTS'])
 
@@ -225,7 +229,7 @@ class Partition:
 		return bind_name
 
 	def partprobe(self) -> bool:
-		if SysCommand(f'partprobe {self.block_device.device}').exit_code == 0:
+		if self.block_device and SysCommand(f'partprobe {self.block_device.device}').exit_code == 0:
 			time.sleep(1)
 			return True
 		return False


### PR DESCRIPTION
One minor issue was that `add_partition` was defined to return `-> None`.
Another issue might be uuid comparison using small/capital letters when comparing, so unified that.
Added a bunch of debugging and placed an exception in case `add_partition` doesn't return anything at all.