### PR TITLE
Make text for getting filesystems more grammatically correct

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -200,7 +200,7 @@ class Filesystem:
 						raise err
 				else:
 					count += 1
-					log(f"Could not get UUID for partition. Waiting for the {count} time",level=logging.DEBUG)
+					log(f"Could not get UUID for partition. Retry attempt {count} of 10 ...",level=logging.DEBUG)
 					time.sleep(float(storage['arguments'].get('disk-sleep', 0.2)))
 			else:
 				log("Add partition is exiting due to excessive wait time",level=logging.INFO)

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -200,7 +200,7 @@ class Filesystem:
 						raise err
 				else:
 					count += 1
-					log(f"Could not get UUID for partition. Retry attempt {count} of 10 ...",level=logging.DEBUG)
+					log(f"Could not get UUID for partition. Waiting before retry attempt {count} of 10 ...",level=logging.DEBUG)
 					time.sleep(float(storage['arguments'].get('disk-sleep', 0.2)))
 			else:
 				log("Add partition is exiting due to excessive wait time",level=logging.INFO)


### PR DESCRIPTION
Use 'Retry attempt {count} of 10.' instead of Waiting for the {count} time". It's more grammatically correct since we're not doing '1st', '2nd', etc.