### PR TITLE
Move from the basic pipewire media session manager to wireplumber

### DIFF
--- a/profiles/applications/pipewire.py
+++ b/profiles/applications/pipewire.py
@@ -3,7 +3,7 @@ import logging
 
 # Define the package list in order for lib to source
 # which packages will be installed by this profile
-__packages__ = ["pipewire", "pipewire-alsa", "pipewire-jack", "pipewire-media-session", "pipewire-pulse", "gst-plugin-pipewire", "libpulse"]
+__packages__ = ["pipewire", "pipewire-alsa", "pipewire-jack", "pipewire-pulse", "gst-plugin-pipewire", "libpulse", "wireplumber"]
 
 archinstall.log('Installing pipewire', level=logging.INFO)
 archinstall.storage['installation_session'].add_additional_packages(__packages__)


### PR DESCRIPTION
It looks like wireplumber is now the preferred session manager for desktop audio, and Fedora in its latest release also made this same change. https://fedoraproject.org/wiki/Changes/WirePlumber

pipewire-media-session is provided by the wireplumber package. https://archlinux.org/packages/extra/x86_64/wireplumber/

https://wiki.archlinux.org/title/PipeWire#WirePlumber

It looks like starting the wireplumber user service should be handled by the package.

Closes #912 