### PR TITLE
Fix trailing comma in schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -147,7 +147,7 @@
     "required": [
         "bootloader",
         "kernels",
-        "mirror-region",
+        "mirror-region"
     ],
     "anyOf": [
         {


### PR DESCRIPTION
(Tried to [generate docs](https://github.com/coveooss/json-schema-for-humans) and noticed the comma preventing that)

🚨 PR Guidelines:

# Describe your PR

Remove invalid trailing comma in json file.
