### PR TITLE
Synchronize `archlinux-keyring` when running guided.py

### DIFF
--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -40,6 +40,16 @@ def check_mirror_reachable() -> bool:
 
 	return False
 
+def update_keyring() -> bool:
+	log("Updating archlinux-keyring ...", level=logging.INFO)
+	if SysCommand("pacman -Sy archlinux-keyring").exit_code == 0:
+		return True
+	
+	elif os.geteuid() != 0:
+		log("update_keyring() uses 'pacman -Sy archlinux-keyring' which requires root.", level=logging.ERROR, fg="red")
+
+	return False
+
 
 def enrich_iface_types(interfaces: Union[Dict[str, Any], List[str]]) -> Dict[str, str]:
 	result = {}

--- a/docs/archinstall/general.rst
+++ b/docs/archinstall/general.rst
@@ -74,6 +74,8 @@ Networking
 
 .. autofunction:: archinstall.check_mirror_reachable
 
+.. autofunction:: archinstall.update_keyring
+
 .. autofunction:: archinstall.enrich_iface_types
 
 .. autofunction:: archinstall.get_interface_from_mac

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -11,10 +11,6 @@ if archinstall.arguments.get('help'):
 if os.getuid() != 0:
 	print("Archinstall requires root privileges to run. See --help for more.")
 	exit(1)
-	
-# update the arch linux keyring to ensure package integrity
-archinstall.log(f"Updating achlinux-keyring.")
-os.system("pacman -Sy archlinux-keyring")
 
 # Log various information about hardware before starting the installation. This might assist in troubleshooting
 archinstall.log(f"Hardware model detected: {archinstall.sys_vendor()} {archinstall.product_name()}; UEFI mode: {archinstall.has_uefi()}", level=logging.DEBUG)
@@ -311,6 +307,12 @@ def perform_installation(mountpoint):
 if not (archinstall.check_mirror_reachable() or archinstall.arguments.get('skip-mirror-check', False)):
 	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
+	exit(1)
+	
+# update the arch linux keyring to ensure package integrity
+if not os.system('pacman -Sy archlinux-keyring') != 0:
+	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
+	archinstall.log("Failed to install archlinux-keyring. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
 load_config()

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -14,8 +14,7 @@ if os.getuid() != 0:
 	
 # update the arch linux keyring to ensure package integrity
 archinstall.log(f"Updating achlinux-keyring.")
-os.system("pacman -Syy")
-os.system("pacman -S archlinux-keyring")
+os.system("pacman -Sy archlinux-keyring")
 
 # Log various information about hardware before starting the installation. This might assist in troubleshooting
 archinstall.log(f"Hardware model detected: {archinstall.sys_vendor()} {archinstall.product_name()}; UEFI mode: {archinstall.has_uefi()}", level=logging.DEBUG)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -308,11 +308,10 @@ if not (archinstall.check_mirror_reachable() or archinstall.arguments.get('skip-
 	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
-	
-# update the arch linux keyring to ensure package integrity
-if os.system('pacman -Sy archlinux-keyring') != 0:
+
+if not (archinstall.update_keyring() or archinstall.arguments.get('skip-keyring-update', False)):
 	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
-	archinstall.log(f"Failed to update archlinux-keyring. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
+	archinstall.log(f"Failed to update the keyring. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
 load_config()

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -11,6 +11,11 @@ if archinstall.arguments.get('help'):
 if os.getuid() != 0:
 	print("Archinstall requires root privileges to run. See --help for more.")
 	exit(1)
+	
+# update the arch linux keyring to ensure package integrity
+archinstall.log(f"Updating achlinux-keyring.")
+os.system("pacman -Syy")
+os.system("pacman -S archlinux-keyring")
 
 # Log various information about hardware before starting the installation. This might assist in troubleshooting
 archinstall.log(f"Hardware model detected: {archinstall.sys_vendor()} {archinstall.product_name()}; UEFI mode: {archinstall.has_uefi()}", level=logging.DEBUG)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -312,7 +312,7 @@ if not (archinstall.check_mirror_reachable() or archinstall.arguments.get('skip-
 # update the arch linux keyring to ensure package integrity
 if os.system('pacman -Sy archlinux-keyring') != 0:
 	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
-	archinstall.log("Failed to install archlinux-keyring. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
+	archinstall.log(f"Failed to update archlinux-keyring. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
 load_config()

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -310,7 +310,7 @@ if not (archinstall.check_mirror_reachable() or archinstall.arguments.get('skip-
 	exit(1)
 	
 # update the arch linux keyring to ensure package integrity
-if not os.system('pacman -Sy archlinux-keyring') != 0:
+if os.system('pacman -Sy archlinux-keyring') != 0:
 	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
 	archinstall.log("Failed to install archlinux-keyring. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)


### PR DESCRIPTION
### Error
To reproduce error, use guided install without first synchronizing `archlinux-keyring`

### Manual Fix
Simply synchronize the **keyring** before running `archinstall`:
```bash
pacman -Sy archlinux-keyring
```
### Installer fix:
Simply run the command in `guided.py`
```python
archinstall.log(f"Updating achlinux-keyring.")
os.system("pacman -Sy archlinux-keyring")
``` 
**NOTE**: Untested code, may not work as intended!

### Reason for PR:
New users and even experienced users won't usually think about synchronizing the keyring, which almost always ends up failing the installer when running in **guided** mode. This wastes time for experienced users, forcing them to rerun the installation, and scares away the new users, who then open issues such as: #907, while the experienced make notice about it in #911. I am by no means an experienced arch linux user, and have made an untested _blind_ hotfix. Edits are enabled should my code need changes :) Hope this helps out!