### PR TITLE
profiles/kde: replace `kate` with `kwrite`

### DIFF
--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -7,7 +7,7 @@ is_top_level_profile = False
 __packages__ = [
 	"plasma-meta",
 	"konsole",
-	"kate",
+	"kwrite",
 	"dolphin",
 	"ark",
 	"sddm",


### PR DESCRIPTION
# Describe Your PR
[The merge request on invent.kde.org that replaces Kate with Kwrite has been merged.](https://invent.kde.org/plasma/plasma-desktop/-/merge_requests/704)
# Quote From Merge Request
```
Kate is a programmer's text editor that may not be the best choice for a
general-purpose note taking or text editing tool. Furthermore, its name
and icon do not make its purpose obvious, and this is important for the
Favorites view, where any given menu representation is not guaranteed to
show the description (and in fact most do not) so being recognizable by
icon or name is important.
```