### PR TITLE
Added a by-path import to support git clone - import of the library

### DIFF
--- a/archinstall/__main__.py
+++ b/archinstall/__main__.py
@@ -1,4 +1,15 @@
-import archinstall
+import importlib
+import sys
+import pathlib
+
+# Load .git version before the builtin version
+if pathlib.Path('./archinstall/__init__.py').absolute().exists():
+	spec = importlib.util.spec_from_file_location("archinstall", "./archinstall/__init__.py")
+	archinstall = importlib.util.module_from_spec(spec)
+	sys.modules["archinstall"] = archinstall
+	spec.loader.exec_module(sys.modules["archinstall"])
+else:
+	import archinstall
 
 if __name__ == '__main__':
 	archinstall.run_as_a_module()


### PR DESCRIPTION
This allows us to do:
```bash
$ git clone https://github.com/archlinux/archinstall.git
$ cd archinstall
$ python archinstall/ --dry-run
```
Without ever needing to install archinstall.
Fallback is to use the system-/user package if one was installed with `pacman -S archinstall` or `pip install archinstall`.

This speeds up testing and removes the need to have archinstall installed every time we make a change locally while testing.