### PR TITLE
Fix errors on selection of additional packages

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -21,13 +21,12 @@ from .lib.models.dataclasses import (
 	LocalPackage
 )
 from .lib.packages.packages import (
-	find_group,
+	group_search,
 	package_search,
-	IsGroup,
 	find_package,
 	find_packages,
 	installed_package,
-	validate_package_list
+	validate_package_list,
 )
 from .lib.profiles import *
 from .lib.services import *

--- a/archinstall/lib/menu/text_input.py
+++ b/archinstall/lib/menu/text_input.py
@@ -1,0 +1,17 @@
+import readline
+
+
+class TextInput:
+	def __init__(self, prompt: str, prefilled_text=''):
+		self._prompt = prompt
+		self._prefilled_text = prefilled_text
+
+	def _hook(self):
+		readline.insert_text(self._prefilled_text)
+		readline.redisplay()
+
+	def run(self) -> str:
+		readline.set_pre_input_hook(self._hook)
+		result = input(self._prompt)
+		readline.set_pre_input_hook()
+		return result

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -4,7 +4,7 @@ import json
 from typing import Dict, Any, Optional, Tuple
 from ..general import SysCommand
 from ..models.dataclasses import PackageSearch, PackageSearchResult, LocalPackage
-from ..exceptions import PackageError, SysCallError, RequirementError
+from ..exceptions import PackageError, SysCallError
 
 BASE_URL_PKG_SEARCH = 'https://archlinux.org/packages/search/json/?name={package}'
 # BASE_URL_PKG_CONTENT = 'https://archlinux.org/packages/search/json/'

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -27,7 +27,7 @@ def group_search(name :str) -> Iterator[PackageSearchResult]:
 	# Just to be sure some code didn't slip through the exception
 	data = response.read().decode('UTF-8')
 
-	for package in data['results']:
+	for package in json.loads(data)['results']:
 		yield PackageSearchResult(**package)
 
 def package_search(package :str) -> PackageSearch:

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -1,12 +1,11 @@
+import json
 import ssl
 import urllib.request
-import json
-from typing import Dict, Any, Tuple, Iterator, List
+from typing import Dict, Any, Tuple, List
 
-import archinstall
+from ..exceptions import PackageError, SysCallError
 from ..general import SysCommand
 from ..models.dataclasses import PackageSearch, PackageSearchResult, LocalPackage
-from ..exceptions import PackageError, SysCallError
 
 BASE_URL_PKG_SEARCH = 'https://archlinux.org/packages/search/json/?name={package}'
 # BASE_URL_PKG_CONTENT = 'https://archlinux.org/packages/search/json/'

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -1,7 +1,7 @@
 import ssl
 import urllib.request
 import json
-from typing import Dict, Any, Optional, Tuple, Iterator
+from typing import Dict, Any, Tuple, Iterator
 from ..general import SysCommand
 from ..models.dataclasses import PackageSearch, PackageSearchResult, LocalPackage
 from ..exceptions import PackageError, SysCallError

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import getpass
+import readline
 import ipaddress
 import logging
 import re
@@ -12,6 +13,9 @@ from collections.abc import Iterable
 from typing import List, Any, Optional, Dict, Union, TYPE_CHECKING
 
 # https://stackoverflow.com/a/39757388/929999
+import archinstall
+from .menu.text_input import TextInput
+
 if TYPE_CHECKING:
 	from .disk.partition import Partition
 
@@ -31,6 +35,7 @@ from .mirrors import list_mirrors
 from .translation import Translation
 from .disk.validators import fs_types
 from .packages.packages import validate_package_list
+
 
 # TODO: These can be removed after the move to simple_menu.py
 def get_terminal_height() -> int:
@@ -396,22 +401,27 @@ def ask_additional_packages_to_install(packages :List[str] = None) -> List[str]:
 	print(_('Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed.'))
 	print(_('If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt.'))
 
-	while True:
-		packages = [p for p in input(
-			_('Write additional packages to install (space separated, leave blank to skip): ')
-		).split(' ') if len(p)]
+	def read_packages(already_defined: list = []) -> list:
+		display = ' '.join(already_defined)
+		input_packages = TextInput(
+			_('Write additional packages to install (space separated, leave blank to skip): '),
+			display
+		).run()
+		return input_packages.split(' ') if input_packages else []
 
+	packages = read_packages()
+
+	while True:
 		if len(packages):
 			# Verify packages that were given
-			try:
-				print(_("Verifying that additional packages exist (this might take a few seconds)"))
-				validate_package_list(packages)
-				break
-			except RequirementError as e:
-				log(e, fg='red')
-		else:
-			# no additional packages were selected, which we'll allow
-			break
+			print(_("Verifying that additional packages exist (this might take a few seconds)"))
+			valid, invalid = validate_package_list(packages)
+
+			if invalid:
+				log(f"Some packages could not be found in the repository: {invalid}", level=logging.WARNING, fg='red')
+				packages = read_packages(valid)
+				continue
+		break
 
 	return packages
 

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import getpass
-import readline
 import ipaddress
 import logging
 import re
@@ -13,7 +12,6 @@ from collections.abc import Iterable
 from typing import List, Any, Optional, Dict, Union, TYPE_CHECKING
 
 # https://stackoverflow.com/a/39757388/929999
-import archinstall
 from .menu.text_input import TextInput
 
 if TYPE_CHECKING:

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -393,8 +393,7 @@ def ask_for_audio_selection(desktop :bool = True) -> str:
 	return selected_audio
 
 
-# TODO: Remove? Moved?
-def ask_additional_packages_to_install(packages :List[str] = None) -> List[str]:
+def ask_additional_packages_to_install(pre_set_packages :List[str] = []) -> List[str]:
 	# Additional packages (with some light weight error handling for invalid package names)
 	print(_('Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed.'))
 	print(_('If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt.'))
@@ -407,7 +406,8 @@ def ask_additional_packages_to_install(packages :List[str] = None) -> List[str]:
 		).run()
 		return input_packages.split(' ') if input_packages else []
 
-	packages = read_packages()
+	pre_set_packages = pre_set_packages if pre_set_packages else []
+	packages = read_packages(pre_set_packages)
 
 	while True:
 		if len(packages):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -241,10 +241,12 @@ if not (archinstall.check_mirror_reachable() or archinstall.arguments.get('skip-
 	exit(1)
 
 if not archinstall.arguments.get('offline', False):
+	latest_version_archlinux_keyring = max([k.pkg_version for k in archinstall.find_package('archlinux-keyring')])
+
 	# If we want to check for keyring updates
 	# and the installed package version is lower than the upstream version
 	if archinstall.arguments.get('skip-keyring-update', False) is False and \
-		archinstall.installed_package('archlinux-keyring') < archinstall.find_package('archlinux-keyring'):
+		archinstall.installed_package('archlinux-keyring').version < latest_version_archlinux_keyring:
 
 		# Then we update the keyring in the ISO environment
 		if not archinstall.update_keyring():


### PR DESCRIPTION
This fixes both issues mentioned in #951.
 
In addition to the fixes it also introduces and new text input class that allows to pre-define text on an `input(...)` prompt. When valid and invalid packages are entered in the prompt, after the validation was run it will pre-fill the prompt with the valid packages so that they don't have to be retyped again and only remove the invalid ones. 