### PR TITLE
Add a flag to install testing repositories

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -304,7 +304,7 @@ class Installer:
 		with open("/etc/pacman.conf", "w") as pacman_conf:
 			for line in lines:
 				if pattern.match(line):
-					# If this is the 
+					# If this is the [] block containing 'testing', uncomment it and set the matched tracking boolean.
 					pacman_conf.write(line.lstrip('#'))
 					matched = True
 				elif matched:
@@ -312,7 +312,6 @@ class Installer:
 					# This means we're on a line that looks like '#Include = /etc/pacman.d/mirrorlist'
 					pacman_conf.write(line.lstrip('#'))
 					matched = False # Reset the state of matched to False.
-					pac
 				else:
 					pacman_conf.write(line)
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -291,7 +291,7 @@ class Installer:
 
 	def enable_testing_repositories(self):
 		# Set up a regular expression pattern of a commented line containing 'testing' within []
-		pattern = re.compile("^#\[.*testing.*\]$")
+		pattern = re.compile("^#\\[.*testing.*\\]$")
 		
 		# This is used to track if the previous line is a match, so we end up uncommenting the line after the block.
 		matched = False

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -288,6 +288,9 @@ class Installer:
 	def post_install_check(self, *args :str, **kwargs :str) -> List[str]:
 		return [step for step, flag in self.helper_flags.items() if flag is False]
 
+	def enable_testing_repositories(self):
+		return # FIX ME		
+
 	def pacstrap(self, *packages :str, **kwargs :str) -> bool:
 		if type(packages[0]) in (list, tuple):
 			packages = packages[0]
@@ -582,9 +585,13 @@ class Installer:
 			else:
 				self.log(f"Unknown CPU vendor '{vendor}' detected. Archinstall won't install any ucode.", level=logging.DEBUG)
 
-		# Enable testing repositories before running pacstrap if testing flag is set
+		# Determine whether to enable testing repositories before running pacstrap if testing flag is set.
+		# This action takes place on the host system as pacstrap copies over package repository lists.
 		if testing:
-			# TODO: FIX ME.
+			self.log("The testing flag is set. This system will be installed with testing repositories enabled.")
+			self.enable_testing_repositories() 
+		else:
+			self.log("The testing flag is not set. This system will be installed without testing repositories enabled.")
 
 		self.pacstrap(self.base_packages)
 		self.helper_flags['base-strapped'] = True

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1,6 +1,7 @@
 import time
 import logging
 import os
+import re
 import shutil
 import shlex
 import pathlib
@@ -289,7 +290,31 @@ class Installer:
 		return [step for step, flag in self.helper_flags.items() if flag is False]
 
 	def enable_testing_repositories(self):
-		return # FIX ME		
+		# Set up a regular expression pattern of a commented line containing 'testing' within []
+		pattern = re.compile("^#\[.*testing.*\]$")
+		
+		# This is used to track if the previous line is a match, so we end up uncommenting the line after the block.
+		matched = False
+
+		# Read in the lines from the original file
+		with open("/etc/pacman.conf", "r") as pacman_conf:
+			lines = pacman_conf.readlines()
+
+		# Open the file again in write mode, to replace the contents
+		with open("/etc/pacman.conf", "w") as pacman_conf:
+			for line in lines:
+				if pattern.match(line):
+					# If this is the 
+					pacman_conf.write(line.lstrip('#'))
+					matched = True
+				elif matched:
+					# The previous line was a match for [.*testing.*].
+					# This means we're on a line that looks like '#Include = /etc/pacman.d/mirrorlist'
+					pacman_conf.write(line.lstrip('#'))
+					matched = False # Reset the state of matched to False.
+					pac
+				else:
+					pacman_conf.write(line)
 
 	def pacstrap(self, *packages :str, **kwargs :str) -> bool:
 		if type(packages[0]) in (list, tuple):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -560,7 +560,7 @@ class Installer:
 
 		return SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}').exit_code == 0
 
-	def minimal_installation(self, testing = False) -> bool:
+	def minimal_installation(self, testing=False) -> bool:
 		# Add necessary packages if encrypting the drive
 		# (encrypted partitions default to btrfs for now, so we need btrfs-progs)
 		# TODO: Perhaps this should be living in the function which dictates

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -533,7 +533,7 @@ class Installer:
 
 		return SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}').exit_code == 0
 
-	def minimal_installation(self) -> bool:
+	def minimal_installation(self, testing = False) -> bool:
 		# Add necessary packages if encrypting the drive
 		# (encrypted partitions default to btrfs for now, so we need btrfs-progs)
 		# TODO: Perhaps this should be living in the function which dictates
@@ -581,6 +581,10 @@ class Installer:
 					ucode.unlink()
 			else:
 				self.log(f"Unknown CPU vendor '{vendor}' detected. Archinstall won't install any ucode.", level=logging.DEBUG)
+
+		# Enable testing repositories before running pacstrap if testing flag is set
+		if testing:
+			# TODO: FIX ME.
 
 		self.pacstrap(self.base_packages)
 		self.helper_flags['base-strapped'] = True

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -613,7 +613,7 @@ class Installer:
 		# This action takes place on the host system as pacstrap copies over package repository lists.
 		if testing:
 			self.log("The testing flag is set. This system will be installed with testing repositories enabled.")
-			self.enable_testing_repositories() 
+			self.enable_testing_repositories()
 		else:
 			self.log("The testing flag is not set. This system will be installed without testing repositories enabled.")
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -144,7 +144,7 @@ def perform_installation(mountpoint):
 		if archinstall.arguments.get('mirror-region', None):
 			archinstall.use_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors for the live medium
 
-		if installation.minimal_installation():
+		if installation.minimal_installation(archinstall.arguments.get('testing', False)):
 			installation.set_locale(archinstall.arguments['sys-language'], archinstall.arguments['sys-encoding'].upper())
 			installation.set_hostname(archinstall.arguments['hostname'])
 			if archinstall.arguments['mirror-region'].get("mirrors", None) is not None:


### PR DESCRIPTION
This PR closes #686. Essentially, this will give users the option to install and play around with packages not in the main repositories yet, but in the testing repos. We'll want some sort of warning that this shouldn't be used for production systems.