### PR TITLE
Add multilib flag and enable multilib-testing if testing flag is also passed

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -353,7 +353,7 @@ class Installer:
 		self.log(f'Installing packages: {packages}', level=logging.INFO)
 
 		if (sync_mirrors := SysCommand('/usr/bin/pacman -Syy')).exit_code == 0:
-			if (pacstrap := SysCommand(f'/usr/bin/pacstrap {self.target} {" ".join(packages)} --noconfirm', peak_output=True)).exit_code == 0:
+			if (pacstrap := SysCommand(f'/usr/bin/pacstrap -C /etc/pacman.conf {self.target} {" ".join(packages)} --noconfirm', peak_output=True)).exit_code == 0:
 				return True
 			else:
 				self.log(f'Could not strap in packages: {pacstrap}', level=logging.ERROR, fg="red")

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -304,11 +304,11 @@ class Installer:
 		with open("/etc/pacman.conf", "w") as pacman_conf:
 			for line in lines:
 				if pattern.match(line):
-					# If this is the [] block containing 'testing', uncomment it and set the matched tracking boolean.
+					# If this is the [] block containing 'multilib', uncomment it and set the matched tracking boolean.
 					pacman_conf.write(line.lstrip('#'))
 					matched = True
 				elif matched:
-					# The previous line was a match for [.*testing.*].
+					# The previous line was a match for [.*multilib.*].
 					# This means we're on a line that looks like '#Include = /etc/pacman.d/mirrorlist'
 					pacman_conf.write(line.lstrip('#'))
 					matched = False # Reset the state of matched to False.

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -289,6 +289,32 @@ class Installer:
 	def post_install_check(self, *args :str, **kwargs :str) -> List[str]:
 		return [step for step, flag in self.helper_flags.items() if flag is False]
 
+	def enable_multilib_repository(self):
+		# Set up a regular expression pattern of a commented line containing 'multilib' within []
+		pattern = re.compile("^#\\[.*multilib.*\\]$")
+		
+		# This is used to track if the previous line is a match, so we end up uncommenting the line after the block.
+		matched = False
+
+		# Read in the lines from the original file
+		with open("/etc/pacman.conf", "r") as pacman_conf:
+			lines = pacman_conf.readlines()
+
+		# Open the file again in write mode, to replace the contents
+		with open("/etc/pacman.conf", "w") as pacman_conf:
+			for line in lines:
+				if pattern.match(line):
+					# If this is the [] block containing 'testing', uncomment it and set the matched tracking boolean.
+					pacman_conf.write(line.lstrip('#'))
+					matched = True
+				elif matched:
+					# The previous line was a match for [.*testing.*].
+					# This means we're on a line that looks like '#Include = /etc/pacman.d/mirrorlist'
+					pacman_conf.write(line.lstrip('#'))
+					matched = False # Reset the state of matched to False.
+				else:
+					pacman_conf.write(line)
+
 	def enable_testing_repositories(self, enable_multilib_testing=False):
 		# Set up a regular expression pattern of a commented line containing 'testing' within []
 		pattern = re.compile("^#\\[.*testing.*\\]$")
@@ -560,7 +586,7 @@ class Installer:
 
 		return SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}').exit_code == 0
 
-	def minimal_installation(self, testing=False) -> bool:
+	def minimal_installation(self, testing=False, multilib=False) -> bool:
 		# Add necessary packages if encrypting the drive
 		# (encrypted partitions default to btrfs for now, so we need btrfs-progs)
 		# TODO: Perhaps this should be living in the function which dictates
@@ -609,11 +635,17 @@ class Installer:
 			else:
 				self.log(f"Unknown CPU vendor '{vendor}' detected. Archinstall won't install any ucode.", level=logging.DEBUG)
 
-		# Determine whether to enable testing repositories before running pacstrap if testing flag is set.
+		# Determine whether to enable multilib/testing repositories before running pacstrap if testing flag is set.
 		# This action takes place on the host system as pacstrap copies over package repository lists.
+		if multilib:
+			self.log("The multilib flag is set. This system will be installed with the multilib repository enabled.")
+			self.enable_multilib_repository()
+		else:
+			self.log("The testing flag is not set. This system will be installed without testing repositories enabled.")
+
 		if testing:
 			self.log("The testing flag is set. This system will be installed with testing repositories enabled.")
-			self.enable_testing_repositories()
+			self.enable_testing_repositories(multilib)
 		else:
 			self.log("The testing flag is not set. This system will be installed without testing repositories enabled.")
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -652,6 +652,10 @@ class Installer:
 		self.pacstrap(self.base_packages)
 		self.helper_flags['base-strapped'] = True
 
+		# This handles making sure that the repositories we enabled persist on the installed system 
+		if multilib or testing:
+			shutil.copy2("/etc/pacman.conf", f"{self.target}/etc/pacman.conf")
+
 		# Periodic TRIM may improve the performance and longevity of SSDs whilst
 		# having no adverse effect on other devices. Most distributions enable
 		# periodic TRIM by default.

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -652,7 +652,7 @@ class Installer:
 		self.pacstrap(self.base_packages)
 		self.helper_flags['base-strapped'] = True
 
-		# This handles making sure that the repositories we enabled persist on the installed system 
+		# This handles making sure that the repositories we enabled persist on the installed system
 		if multilib or testing:
 			shutil.copy2("/etc/pacman.conf", f"{self.target}/etc/pacman.conf")
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -144,7 +144,7 @@ def perform_installation(mountpoint):
 		if archinstall.arguments.get('mirror-region', None):
 			archinstall.use_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors for the live medium
 
-		if installation.minimal_installation(archinstall.arguments.get('testing', False)):
+		if installation.minimal_installation(testing=archinstall.arguments.get('testing', False), multilib=archinstall.arguments.get('multilib', False)):
 			installation.set_locale(archinstall.arguments['sys-language'], archinstall.arguments['sys-encoding'].upper())
 			installation.set_hostname(archinstall.arguments['hostname'])
 			if archinstall.arguments['mirror-region'].get("mirrors", None) is not None:


### PR DESCRIPTION
This also fixes issues with the pacman configuration not being copied to the target system after installation