### PR TITLE
Switch from flags to an 'additional repository' menu

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -353,7 +353,7 @@ class Installer:
 		self.log(f'Installing packages: {packages}', level=logging.INFO)
 
 		if (sync_mirrors := SysCommand('/usr/bin/pacman -Syy')).exit_code == 0:
-			if (pacstrap := SysCommand(f'/usr/bin/pacstrap {self.target} {" ".join(packages)} --noconfirm', peak_output=True)).exit_code == 0:
+			if (pacstrap := SysCommand(f'/usr/bin/pacstrap -C /etc/pacman.conf {self.target} {" ".join(packages)} --noconfirm', peak_output=True)).exit_code == 0:
 				return True
 			else:
 				self.log(f'Could not strap in packages: {pacstrap}', level=logging.ERROR, fg="red")

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -304,11 +304,11 @@ class Installer:
 		with open("/etc/pacman.conf", "w") as pacman_conf:
 			for line in lines:
 				if pattern.match(line):
-					# If this is the [] block containing 'testing', uncomment it and set the matched tracking boolean.
+					# If this is the [] block containing 'multilib', uncomment it and set the matched tracking boolean.
 					pacman_conf.write(line.lstrip('#'))
 					matched = True
 				elif matched:
-					# The previous line was a match for [.*testing.*].
+					# The previous line was a match for [.*multilib.*].
 					# This means we're on a line that looks like '#Include = /etc/pacman.d/mirrorlist'
 					pacman_conf.write(line.lstrip('#'))
 					matched = False # Reset the state of matched to False.

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -289,6 +289,32 @@ class Installer:
 	def post_install_check(self, *args :str, **kwargs :str) -> List[str]:
 		return [step for step, flag in self.helper_flags.items() if flag is False]
 
+	def enable_multilib_repository(self):
+		# Set up a regular expression pattern of a commented line containing 'multilib' within []
+		pattern = re.compile("^#\\[.*multilib.*\\]$")
+		
+		# This is used to track if the previous line is a match, so we end up uncommenting the line after the block.
+		matched = False
+
+		# Read in the lines from the original file
+		with open("/etc/pacman.conf", "r") as pacman_conf:
+			lines = pacman_conf.readlines()
+
+		# Open the file again in write mode, to replace the contents
+		with open("/etc/pacman.conf", "w") as pacman_conf:
+			for line in lines:
+				if pattern.match(line):
+					# If this is the [] block containing 'testing', uncomment it and set the matched tracking boolean.
+					pacman_conf.write(line.lstrip('#'))
+					matched = True
+				elif matched:
+					# The previous line was a match for [.*testing.*].
+					# This means we're on a line that looks like '#Include = /etc/pacman.d/mirrorlist'
+					pacman_conf.write(line.lstrip('#'))
+					matched = False # Reset the state of matched to False.
+				else:
+					pacman_conf.write(line)
+
 	def enable_testing_repositories(self, enable_multilib_testing=False):
 		# Set up a regular expression pattern of a commented line containing 'testing' within []
 		pattern = re.compile("^#\\[.*testing.*\\]$")
@@ -560,7 +586,7 @@ class Installer:
 
 		return SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}').exit_code == 0
 
-	def minimal_installation(self, testing=False) -> bool:
+	def minimal_installation(self, testing=False, multilib=False) -> bool:
 		# Add necessary packages if encrypting the drive
 		# (encrypted partitions default to btrfs for now, so we need btrfs-progs)
 		# TODO: Perhaps this should be living in the function which dictates
@@ -609,11 +635,17 @@ class Installer:
 			else:
 				self.log(f"Unknown CPU vendor '{vendor}' detected. Archinstall won't install any ucode.", level=logging.DEBUG)
 
-		# Determine whether to enable testing repositories before running pacstrap if testing flag is set.
+		# Determine whether to enable multilib/testing repositories before running pacstrap if testing flag is set.
 		# This action takes place on the host system as pacstrap copies over package repository lists.
+		if multilib:
+			self.log("The multilib flag is set. This system will be installed with the multilib repository enabled.")
+			self.enable_multilib_repository()
+		else:
+			self.log("The testing flag is not set. This system will be installed without testing repositories enabled.")
+
 		if testing:
 			self.log("The testing flag is set. This system will be installed with testing repositories enabled.")
-			self.enable_testing_repositories()
+			self.enable_testing_repositories(multilib)
 		else:
 			self.log("The testing flag is not set. This system will be installed without testing repositories enabled.")
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -652,6 +652,10 @@ class Installer:
 		self.pacstrap(self.base_packages)
 		self.helper_flags['base-strapped'] = True
 
+		# This handles making sure that the repositories we enabled persist on the installed system 
+		if multilib or testing:
+			shutil.copy2("/etc/pacman.conf", f"{self.target}/etc/pacman.conf")
+
 		# Periodic TRIM may improve the performance and longevity of SSDs whilst
 		# having no adverse effect on other devices. Most distributions enable
 		# periodic TRIM by default.

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -652,7 +652,7 @@ class Installer:
 		self.pacstrap(self.base_packages)
 		self.helper_flags['base-strapped'] = True
 
-		# This handles making sure that the repositories we enabled persist on the installed system 
+		# This handles making sure that the repositories we enabled persist on the installed system
 		if multilib or testing:
 			shutil.copy2("/etc/pacman.conf", f"{self.target}/etc/pacman.conf")
 

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -493,6 +493,11 @@ class GlobalMenu(GeneralMenu):
 				_('Additional packages to install'),
 				lambda: ask_additional_packages_to_install(storage['arguments'].get('packages', None)),
 				default=[])
+		self._menu_options['additional-repositories'] = \
+			Selector(
+				_('Additional repositories to enable'),
+				lambda: select_additional_repositories(),
+				default=None)
 		self._menu_options['nic'] = \
 			Selector(
 				_('Configure network'),

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -498,7 +498,7 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Additional repositories to enable'),
 				lambda: select_additional_repositories(),
-				default=None)
+				default=[])
 		self._menu_options['nic'] = \
 			Selector(
 				_('Configure network'),

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -31,6 +31,7 @@ from ..user_interaction import select_encrypted_partitions
 from ..user_interaction import select_harddrives
 from ..user_interaction import select_profile
 from ..user_interaction import select_archinstall_language
+from ..user_interaction import select_additional_repositories
 from ..translation import Translation
 
 class Selector:

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -981,7 +981,7 @@ def select_additional_repositories() -> List[str]:
 		repositories,
 		sort=False,
 		multi=True,
-		default_option=None
+		default_option=[]
 	).run()
 	return additional_repositories
 

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -966,6 +966,24 @@ def select_kernel() -> List[str]:
 	).run()
 	return selected_kernels
 
+def select_additional_repositories() -> List[str]:
+	"""
+	Allows the user to select additional repositories (multilib, and testing) if desired.
+
+	:return: The string as a selected kernel
+	:rtype: string
+	"""
+
+	repositories = ["multilib", "testing"]
+
+	additional_repositories = Menu(
+		_('Choose which optional additional repositories to enable'),
+		repositories,
+		sort=False,
+		multi=True,
+		default_option=None
+	).run()
+	return additional_repositories
 
 def select_locale_lang(default):
 	locales = list_locales()

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -983,7 +983,11 @@ def select_additional_repositories() -> List[str]:
 		multi=True,
 		default_option=[]
 	).run()
-	return additional_repositories
+
+	if additional_repositories is not None:
+		return additional_repositories
+
+	return []
 
 def select_locale_lang(default):
 	locales = list_locales()

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -970,7 +970,7 @@ def select_additional_repositories() -> List[str]:
 	"""
 	Allows the user to select additional repositories (multilib, and testing) if desired.
 
-	:return: The string as a selected kernel
+	:return: The string as a selected repository
 	:rtype: string
 	"""
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -144,7 +144,7 @@ def perform_installation(mountpoint):
 		if archinstall.arguments.get('mirror-region', None):
 			archinstall.use_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors for the live medium
 
-		if installation.minimal_installation(archinstall.arguments.get('testing', False)):
+		if installation.minimal_installation(testing=archinstall.arguments.get('testing', False), multilib=archinstall.arguments.get('multilib', False)):
 			installation.set_locale(archinstall.arguments['sys-language'], archinstall.arguments['sys-encoding'].upper())
 			installation.set_hostname(archinstall.arguments['hostname'])
 			if archinstall.arguments['mirror-region'].get("mirrors", None) is not None:

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -87,6 +87,8 @@ def ask_user_questions():
 
 	global_menu.enable('ntp')
 
+	global_menu.enable('additional-repositories')
+
 	global_menu.run()
 
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -145,8 +145,12 @@ def perform_installation(mountpoint):
 		# Set mirrors used by pacstrap (outside of installation)
 		if archinstall.arguments.get('mirror-region', None):
 			archinstall.use_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors for the live medium
-
-		if installation.minimal_installation(testing=archinstall.arguments.get('testing', False), multilib=archinstall.arguments.get('multilib', False)):
+		
+		# Retrieve list of additional repositories and set boolean values appropriately
+		enable_testing = 'testing' in archinstall.arguments.get('additional-repositories', None)
+		enable_multilib = 'multilib' in archinstall.arguments.get('additional-repositories', None)
+		
+		if installation.minimal_installation(testing=enable_testing, multilib=enable_multilib):
 			installation.set_locale(archinstall.arguments['sys-language'], archinstall.arguments['sys-encoding'].upper())
 			installation.set_hostname(archinstall.arguments['hostname'])
 			if archinstall.arguments['mirror-region'].get("mirrors", None) is not None:

--- a/schema.json
+++ b/schema.json
@@ -4,6 +4,14 @@
     "description": "A schema for the archinstall command config, more info over at https://archinstall.readthedocs.io/installing/guided.html#options-for-config",
     "type": "object",
     "properties": {
+        "additional-repositories": {
+            "description": "Additional repositories to optionally enable",
+            "type": "string",
+            "enum": [
+                "multilib",
+                "testing"
+            ]
+        },
         "audio": {
             "description": "Audio server to be installed",
             "type": "string",


### PR DESCRIPTION
This is a new rework, in addition to the fixes in #975.  The idea is that you can optionally select 'multilib' and 'testing' and it'll set the booleans to use the existing logic from the multilib and testing PRs. These will also be added to the schema and work with the configuration file.