### PR TITLE
Set the default timezone to UTC in the menu

### DIFF
--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -500,7 +500,10 @@ class GlobalMenu(GeneralMenu):
 				display_func=lambda x: x if x else _('Not configured, unavailable unless setup manually'),
 				default={})
 		self._menu_options['timezone'] = \
-			Selector(_('Select timezone'), lambda: ask_for_a_timezone())
+			Selector(
+				_('Select timezone'),
+				lambda: ask_for_a_timezone(),
+				default='UTC')
 		self._menu_options['ntp'] = \
 			Selector(
 				_('Set automatic time sync (NTP)'),


### PR DESCRIPTION
It's already the default, this just keeps the user from needing to make the selection unless they desire another timezone.