### PR TITLE
profiles/sway: replace alacritty with foot

### DIFF
--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -13,7 +13,7 @@ __packages__ = [
 	"grim",
 	"slurp",
 	"pavucontrol",
-	"alacritty",
+	"foot",
 ]
 
 


### PR DESCRIPTION
In Sway 1.7, the terminal emulator in the default config file has been changed to foot.

Without this change, on first boot there is no way to launch a terminal inside sway, since `dmenu` seems to be botched. 

See https://github.com/swaywm/sway/releases/tag/1.7

Cheers, fellas.