### PR TITLE
Adding sudoers.d file instead of appending to sudoers

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -956,6 +956,7 @@ class Installer:
 
 	def enable_sudo(self, entity: str, group :bool = False) -> bool:
 		self.log(f'Enabling sudo permissions for {entity}.', level=logging.INFO)
+		
 		sudoers_dir = f"{self.target}/etc/sudoers.d"
 		
 		# Creates directory if not exists
@@ -969,19 +970,18 @@ class Installer:
 		
 		# We count how many files are there already so we know which number to prefix the file with
 		num_of_rules_already = len(os.listdir(sudoers_dir))
-		file_num_str = "{:02d}".format(num_of_rules_already) # 00_user1, 01_user2, etc
+		file_num_str = "{:02d}".format(num_of_rules_already) # We want 00_user1, 01_user2, etc
 
 		# Guarantees that entity str does not contain invalid characters for a linux file name:
 		# \ / : * ? " < > |
-		safe_entity_file_name = re.sub(r'(\\|\/|:|\*|\?|"|<|>|\)', '', entity)
+		safe_entity_file_name = re.sub(r'(\\|\/|:|\*|\?|"|<|>|\|)', '', entity)
 
 		rule_file_name = f"{sudoers_dir}/{file_num_str}_{safe_entity_file_name}"
 		
-
 		with open(rule_file_name, 'a') as sudoers:
 			sudoers.write(f'{"%" if group else ""}{entity} ALL=(ALL) ALL\n')
-			# Guarantees sudoer conf file recommended perms
 		
+		# Guarantees sudoer conf file recommended perms
 		os.chmod(pathlib.Path(rule_file_name), 0o440)
 
 		return True

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -961,7 +961,7 @@ class Installer:
 		# Creates directory if not exists
 		if not (sudoers_path := pathlib.Path(sudoers_dir)).exists():
 			sudoers_path.mkdir(parents=True)
-			# guarantees sudoer conf file recommended perms
+			# guarantees sudoer confs directory recommended perms
 			os.chmod(sudoers_dir, 0o440)
 		
 		# We count how many files are there so we know which number to prefix the file with

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -963,6 +963,9 @@ class Installer:
 			sudoers_path.mkdir(parents=True)
 			# Guarantees sudoer confs directory recommended perms
 			os.chmod(sudoers_dir, 0o440)
+			# Appends a reference to the sudoers file, because if we are here sudoers.d did not exist yet
+			with open(f'{self.target}/etc/sudoers', 'a') as sudoers:
+				sudoers.write('@includedir /etc/sudoers.d\n')
 		
 		# We count how many files are there already so we know which number to prefix the file with
 		num_of_rules_already = len(os.listdir(sudoers_dir))
@@ -978,7 +981,8 @@ class Installer:
 		with open(rule_file_name, 'a') as sudoers:
 			sudoers.write(f'{"%" if group else ""}{entity} ALL=(ALL) ALL\n')
 			# Guarantees sudoer conf file recommended perms
-			os.chmod(pathlib.Path(rule_file_name), 0o440)
+		
+		os.chmod(pathlib.Path(rule_file_name), 0o440)
 
 		return True
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -961,10 +961,10 @@ class Installer:
 		# Creates directory if not exists
 		if not (sudoers_path := pathlib.Path(sudoers_dir)).exists():
 			sudoers_path.mkdir(parents=True)
-			# guarantees sudoer confs directory recommended perms
+			# Guarantees sudoer confs directory recommended perms
 			os.chmod(sudoers_dir, 0o440)
 		
-		# We count how many files are there so we know which number to prefix the file with
+		# We count how many files are there already so we know which number to prefix the file with
 		num_of_rules_already = len(os.listdir(sudoers_dir))
 		file_num_str = "{:02d}".format(num_of_rules_already) # 00_user1, 01_user2, etc
 
@@ -977,7 +977,7 @@ class Installer:
 
 		with open(rule_file_name, 'a') as sudoers:
 			sudoers.write(f'{"%" if group else ""}{entity} ALL=(ALL) ALL\n')
-			# guarantees sudoer conf file recommended perms
+			# Guarantees sudoer conf file recommended perms
 			os.chmod(pathlib.Path(rule_file_name), 0o440)
 
 		return True

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -966,9 +966,13 @@ class Installer:
 		
 		# We count how many files are there so we know which number to prefix the file with
 		num_of_rules_already = len(os.listdir(sudoers_dir))
-		file_num_str = "{:02d}".format(num_of_rules_already)
+		file_num_str = "{:02d}".format(num_of_rules_already) # 00_user1, 01_user2, etc
 
-		rule_file_name = f"{sudoers_dir}/{file_num_str}_{entity}"
+		# Guarantees that entity str does not contain invalid characters for a linux file name:
+		# \ / : * ? " < > |
+		safe_entity_file_name = re.sub(r'(\\|\/|:|\*|\?|"|<|>|\)', '', entity)
+
+		rule_file_name = f"{sudoers_dir}/{file_num_str}_{safe_entity_file_name}"
 		
 
 		with open(rule_file_name, 'a') as sudoers:


### PR DESCRIPTION
# Describe your PR

Addresses issue #985, creating one file in sudoers.d per user added as a sudoer user during the installation process.

This implementation:
* Makes sure sudoers.d exists and is referenced through `@includedir` in `/etc/sudoer`
* Creates one rule file per sudoer user, in the format: `00_user1`, `01_user2`, `02_user3`, and so on...
* Makes sure the created filenames do not contain [illegal characters](https://stackoverflow.com/a/35352640/2684616)
* Makes sure the recommended permissions are applied, as specified in [Arch Wiki - sudo](https://wiki.archlinux.org/title/sudo#Sudoers_default_file_permissions)

# Summed up contribution

https://github.com/archlinux/archinstall/pull/1025/files

# Testing

* Create multiple users that can sudo through the interactive CLI installer `python -m archinstall` modified with this contribution.
* Reboot (or chroot)
* As superuser, `cd /etc/sudoers.d` and then `ls -la`. You should also log in as one of the created sudoer users and attempt to sudo.

I tested it in `virtualbox` using a fresh environment and following the instructions at `README.MD#Testing`