### PR TITLE
Additions to Listmgr et alia

### DIFF
--- a/archinstall/lib/disk/btrfs.py
+++ b/archinstall/lib/disk/btrfs.py
@@ -25,7 +25,7 @@ class BtrfsSubvolume:
 	root :bool = False
 
 def get_subvolumes_from_findmnt(struct :Dict[str, Any], index=0) -> Iterator[BtrfsSubvolume]:
-	if '@' in struct['source']:
+	if '[' in struct['source']:
 		subvolume = re.findall(r'\[.*?\]', struct['source'])[0][1:-1]
 		struct['source'] = struct['source'].replace(f"[{subvolume}]", "")
 		yield BtrfsSubvolume(

--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -90,9 +90,10 @@ from .menu import Menu
 from ..general import RequirementError
 from os import system
 from copy import copy
+from typing import Union
 
 class ListManager:
-	def __init__(self,prompt :str, base_list :list ,base_actions :list = None,null_action :str = None, default_action :str = None):
+	def __init__(self,prompt :str, base_list :Union[list,dict] ,base_actions :list = None,null_action :str = None, default_action :Union[str,list] = None):
 		"""
 		param :prompt  Text which will appear at the header
 		type param: string | DeferredTranslation
@@ -108,7 +109,7 @@ class ListManager:
 
 		param: default_action action which will be presented at the bottom of the list. Shouldn't need a target. If not present, null_action is set there.
 		Both Null and Default actions can be defined outside the base_actions list, as long as they are launched in exec_action
-		type param: string
+		type param: string or list
 		"""
 
 		if not null_action and len(base_list) == 0:
@@ -117,9 +118,11 @@ class ListManager:
 		self.prompt = prompt if prompt else _('Choose an object from the list')
 		self.null_action = str(null_action)
 		if not default_action:
-			self.default_action = self.null_action
+			self.default_action = [self.null_action,]
+		elif isinstance(default_action,(list,tuple,str)):
+			self.default_action = default_action
 		else:
-			self.default_action = str(default_action)
+			self.default_action = [str(default_action)]
 		self.cancel_action = str(_('Cancel'))
 		self.confirm_action = str(_('Confirm and exit'))
 		self.separator = '==>'
@@ -140,7 +143,7 @@ class ListManager:
 			self.data_formatted = self.reformat()
 			options = self.data_formatted + [self.separator]
 			if self.default_action:
-				options += [self.default_action]
+				options += self.default_action
 			options += self.bottom_list
 			system('clear')
 			target = Menu(self.prompt,
@@ -153,10 +156,10 @@ class ListManager:
 				break
 			if target and target == self.separator:
 				continue
-			if target and target == self.default_action:
+			if target and target in self.default_action:
+				self.action = target
 				target = None
 				self.target = None
-				self.action = self.default_action
 				self.exec_action()
 				continue
 			if isinstance(self.data,dict):
@@ -216,7 +219,6 @@ class ListManager:
 		The basic code is useful for simple lists and dictionaries (key:value pairs, both strings)
 		"""
 		# TODO guarantee unicity
-
 		if isinstance(self.data,list):
 			if self.action == str(_('Add')):
 				self.target = TextInput(_('Add :'),None).run()
@@ -264,6 +266,6 @@ if __name__ == "__main__":
 	# opciones = ['uno','dos','tres','cuatro']
 	# opciones = archinstall.list_mirrors()
 	opciones = {'uno':1,'dos':2,'tres':3,'cuatro':4}
-	# acciones = ['editar','borrar','añadir']
-	opciones = ListManager('Vamos alla',opciones,None,_('Add')).run()
+	acciones = ['editar','borrar','añadir']
+	opciones = ListManager('Vamos alla',opciones,None,_('Add'),default_action=acciones).run()
 	print(opciones)

--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -122,10 +122,10 @@ class ListManager:
 		self.null_action = str(null_action)
 		if not default_action:
 			self.default_action = [self.null_action,]
-		elif isinstance(default_action,(list,tuple,str)):
+		elif isinstance(default_action,(list,tuple)):
 			self.default_action = default_action
 		else:
-			self.default_action = [str(default_action)]
+			self.default_action = [str(default_action),]
 
 		self.header = header if header else None
 		self.cancel_action = str(_('Cancel'))

--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -93,7 +93,7 @@ from copy import copy
 from typing import Union
 
 class ListManager:
-	def __init__(self,prompt :str, base_list :Union[list,dict] ,base_actions :list = None,null_action :str = None, default_action :Union[str,list] = None):
+	def __init__(self,prompt :str, base_list :Union[list,dict] ,base_actions :list = None,null_action :str = None, default_action :Union[str,list] = None, header :Union[str,list] = None):
 		"""
 		param :prompt  Text which will appear at the header
 		type param: string | DeferredTranslation
@@ -110,6 +110,9 @@ class ListManager:
 		param: default_action action which will be presented at the bottom of the list. Shouldn't need a target. If not present, null_action is set there.
 		Both Null and Default actions can be defined outside the base_actions list, as long as they are launched in exec_action
 		type param: string or list
+
+		param: header one or more header lines for the list
+		type param: string or list
 		"""
 
 		if not null_action and len(base_list) == 0:
@@ -123,6 +126,8 @@ class ListManager:
 			self.default_action = default_action
 		else:
 			self.default_action = [str(default_action)]
+
+		self.header = header if header else None
 		self.cancel_action = str(_('Cancel'))
 		self.confirm_action = str(_('Confirm and exit'))
 		self.separator = '==>'
@@ -150,7 +155,8 @@ class ListManager:
 				options,
 				sort=False,
 				clear_screen=False,
-				clear_menu_on_exit=False).run()
+				clear_menu_on_exit=False,
+				header=self.header).run()
 
 			if not target or target in self.bottom_list:
 				break
@@ -267,5 +273,6 @@ if __name__ == "__main__":
 	# opciones = archinstall.list_mirrors()
 	opciones = {'uno':1,'dos':2,'tres':3,'cuatro':4}
 	acciones = ['editar','borrar','añadir']
-	opciones = ListManager('Vamos alla',opciones,None,_('Add'),default_action=acciones).run()
+	cabecera = ["En Jaen Donde Resido","Vive don Lope de Sosa"]
+	opciones = ListManager('Vamos alla',opciones,None,_('Add'),default_action=acciones,header=cabecera).run()
 	print(opciones)

--- a/archinstall/lib/menu/menu.py
+++ b/archinstall/lib/menu/menu.py
@@ -26,6 +26,7 @@ class Menu(TerminalMenu):
 		preview_command=None,
 		preview_size=0.75,
 		preview_title='Info',
+		header :Union[List[str],str] = None,
 		**kwargs
 	):
 		"""
@@ -64,6 +65,9 @@ class Menu(TerminalMenu):
 
 		:param preview_title: Title of the preview window
 		:type preview_title: str
+
+		param: header one or more header lines for the menu
+		type param: string or list
 
 		:param kwargs : any SimpleTerminal parameter
 		"""
@@ -104,10 +108,17 @@ class Menu(TerminalMenu):
 		self.default_option = default_option
 		self.multi = multi
 		menu_title = f'\n{title}\n\n'
-
-		if skip:
+		if header:
+			separator = '\n  '
+			if not isinstance(header,(list,tuple)):
+				header = [header,]
+			if skip:
+				menu_title += str(_("Use ESC to skip\n"))
+			menu_title += separator + separator.join(header)
+		elif skip:
 			menu_title += str(_("Use ESC to skip\n\n"))
-
+		print(menu_title)
+		input('yep')
 		if default_option:
 			# if a default value was specified we move that one
 			# to the top of the list and mark it as default as well

--- a/archinstall/lib/menu/menu.py
+++ b/archinstall/lib/menu/menu.py
@@ -117,8 +117,6 @@ class Menu(TerminalMenu):
 			menu_title += separator + separator.join(header)
 		elif skip:
 			menu_title += str(_("Use ESC to skip\n\n"))
-		print(menu_title)
-		input('yep')
 		if default_option:
 			# if a default value was specified we move that one
 			# to the top of the list and mark it as default as well


### PR DESCRIPTION
Several minor changes:
* The real marker that a btrfs subvolume is in place is the bracket notation for *bind mounts* not the at sign
* Ability for ListManager to have a list of default actions (action without a defined element) instead of a single element
* Ability for Menu and subclasses to define a header for the list, like in this screen
![header](https://user-images.githubusercontent.com/10762720/157510543-c5959aae-e32c-47b0-ade2-90ec2392359a.png)
In case you wonder this is a real menu, not a mockup (Real Soon Now in your repositories ;-))
 