### PR TITLE
Issues with Network Management and user management in menu

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -149,7 +149,7 @@ class Installer:
 
 			# We avoid printing /mnt/<log path> because that might confuse people if they note it down
 			# and then reboot, and a identical log file will be found in the ISO medium anyway.
-			print(_("[!] A log file has been created here: {} {}").format(os.path.join(storage['LOG_PATH'], storage['LOG_FILE'])))
+			print(_("[!] A log file has been created here: {}").format(os.path.join(storage['LOG_PATH'], storage['LOG_FILE'])))
 			print(_("    Please submit this issue (and file) to https://github.com/archlinux/archinstall/issues"))
 			raise args[1]
 
@@ -956,9 +956,9 @@ class Installer:
 
 	def enable_sudo(self, entity: str, group :bool = False) -> bool:
 		self.log(f'Enabling sudo permissions for {entity}.', level=logging.INFO)
-		
+
 		sudoers_dir = f"{self.target}/etc/sudoers.d"
-		
+
 		# Creates directory if not exists
 		if not (sudoers_path := pathlib.Path(sudoers_dir)).exists():
 			sudoers_path.mkdir(parents=True)
@@ -967,7 +967,7 @@ class Installer:
 			# Appends a reference to the sudoers file, because if we are here sudoers.d did not exist yet
 			with open(f'{self.target}/etc/sudoers', 'a') as sudoers:
 				sudoers.write('@includedir /etc/sudoers.d\n')
-		
+
 		# We count how many files are there already so we know which number to prefix the file with
 		num_of_rules_already = len(os.listdir(sudoers_dir))
 		file_num_str = "{:02d}".format(num_of_rules_already) # We want 00_user1, 01_user2, etc
@@ -977,10 +977,10 @@ class Installer:
 		safe_entity_file_name = re.sub(r'(\\|\/|:|\*|\?|"|<|>|\|)', '', entity)
 
 		rule_file_name = f"{sudoers_dir}/{file_num_str}_{safe_entity_file_name}"
-		
+
 		with open(rule_file_name, 'a') as sudoers:
 			sudoers.write(f'{"%" if group else ""}{entity} ALL=(ALL) ALL\n')
-		
+
 		# Guarantees sudoer conf file recommended perms
 		os.chmod(pathlib.Path(rule_file_name), 0o440)
 

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -657,7 +657,7 @@ class GlobalMenu(GeneralMenu):
 			choice = Menu(prompt, ['yes', 'no'], default_option='yes').run()
 
 			if choice == 'no':
-				return self._select_harddrives()
+				exit(1)
 
 		return harddrives
 

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -502,6 +502,7 @@ class GlobalMenu(GeneralMenu):
 				_('Specify superuser account'),
 				lambda preset: self._create_superuser_account(),
 				exec_func=lambda n,v:self._users_resynch(),
+				default={},
 				dependencies_not=['!root-password'],
 				display_func=lambda x: self._display_superusers())
 		self._menu_options['!users'] = \

--- a/archinstall/lib/models/network_configuration.py
+++ b/archinstall/lib/models/network_configuration.py
@@ -40,11 +40,32 @@ class NetworkConfiguration:
 		return self.__dict__
 
 	@classmethod
-	def parse_arguments(cls, config: Dict[str, str]) -> Optional["NetworkConfiguration"]:
+	def parse_arguments(cls, config: Union[str,Dict[str, str]]) -> Optional["NetworkConfiguration"]:
 		nic_type = config.get('type', None)
 
 		if not nic_type:
-			return None
+			# old style definitions
+			if isinstance(config,str): # is a ISO network
+				return NetworkConfiguration(NicType.ISO)
+			elif config.get('NetworkManager'): # is a network manager configuration
+				return NetworkConfiguration(NicType.NM)
+			elif 'ip' in config:
+				return NetworkConfiguration(
+					NicType.MANUAL,
+					iface=config.get('nic', ''),
+					ip=config.get('ip'),
+					gateway=config.get('gateway', ''),
+					dns=config.get('dns', []),
+					dhcp=False
+				)
+			elif 'nic' in config:
+				return NetworkConfiguration(
+					NicType.MANUAL,
+					iface=config.get('nic', ''),
+					dhcp=True
+				)
+			else:  # not recognized
+				return None
 
 		try:
 			type = NicType(nic_type)
@@ -95,3 +116,24 @@ class NetworkConfiguration:
 			installation.configure_nic(self)
 			installation.enable_service('systemd-networkd')
 			installation.enable_service('systemd-resolved')
+
+	def get(self, key :str, default_value :Any = None) -> Any:
+		result = self.__getitem__(key)
+		if result is None:
+			return default_value
+		else:
+			return result
+
+	def __getitem__(self, key :str) -> Any:
+		if key == 'type':
+			return self.type
+		elif key == 'iface':
+			return self.iface
+		elif key == 'gateway':
+			return self.gateway
+		elif key == 'dns':
+			return self.dns
+		elif key == 'dhcp':
+			return self.dhcp
+		else:
+			raise KeyError(f"key {key} not available at NetworkConfiguration")

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -185,11 +185,13 @@ def perform_installation(mountpoint):
 			if archinstall.arguments.get('profile', None):
 				installation.install_profile(archinstall.arguments.get('profile', None))
 
-			for user, user_info in archinstall.arguments.get('!users', {}).items():
-				installation.user_create(user, user_info["!password"], sudo=False)
+			if archinstall.arguments.get('!users',{}):
+				for user, user_info in archinstall.arguments.get('!users', {}).items():
+					installation.user_create(user, user_info["!password"], sudo=False)
 
-			for superuser, user_info in archinstall.arguments.get('!superusers', {}).items():
-				installation.user_create(superuser, user_info["!password"], sudo=True)
+			if archinstall.arguments.get('!superusers',{}):
+				for superuser, user_info in archinstall.arguments.get('!superusers', {}).items():
+					installation.user_create(superuser, user_info["!password"], sudo=True)
 
 			if timezone := archinstall.arguments.get('timezone', None):
 				installation.set_timezone(timezone)

--- a/examples/swiss.py
+++ b/examples/swiss.py
@@ -415,11 +415,13 @@ def os_setup(installation):
 		if archinstall.arguments.get('profile', None):
 			installation.install_profile(archinstall.arguments.get('profile', None))
 
-		for user, user_info in archinstall.arguments.get('!users', {}).items():
-			installation.user_create(user, user_info["!password"], sudo=False)
+		if archinstall.arguments.get('!users',{}):
+			for user, user_info in archinstall.arguments.get('!users', {}).items():
+				installation.user_create(user, user_info["!password"], sudo=False)
 
-		for superuser, user_info in archinstall.arguments.get('!superusers', {}).items():
-			installation.user_create(superuser, user_info["!password"], sudo=True)
+		if archinstall.arguments.get('!superusers',{}):
+			for superuser, user_info in archinstall.arguments.get('!superusers', {}).items():
+				installation.user_create(superuser, user_info["!password"], sudo=True)
 
 		if timezone := archinstall.arguments.get('timezone', None):
 			installation.set_timezone(timezone)


### PR DESCRIPTION
Solves issue #1035
-> Compatibility with current stable version (v2.3) of the config file.
-> Reediting the network interface entry crashed
And solves an issue with default values (lack of) in the (super)user management lists at the menu, not prevously documented.

@svartkanin 
The solution is coded at the `NetworkConfiguration` level. 
For the first issue, I put  compatibility code at `parse_arguments`. Only remaining hook is that it is executed twice before entering the Menu. still have to pin where.
For the second issue i gave up trying to change `ask_to_configure_network`, where the problem lies (in many lines it still expect a dictionary and not a class), and went to add `__getitem__`  and `get` methods at NetworkConfiguration, to achieve a compatible interface. I went for the shortest line of resistence, i know.

**Updated**
One correction to the message error at `Installer.__exit__` (issue #1039) and

Another which performs an ordered exit when after not selecting a drive we decide not to continue (previous implementation, looped there, a good idea on paper -giving the user the possibility of selecting drives- but gave no possibility to escape. The new implementation is a bit cumbersone (return to the start of the process) but more flexible