### PR TITLE
Correct exit when no disk is selected and we don't wish to continue

### DIFF
--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -99,6 +99,7 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Specify superuser account'),
 				lambda preset: self._create_superuser_account(),
+				default={},
 				exec_func=lambda n,v:self._users_resynch(),
 				dependencies_not=['!root-password'],
 				display_func=lambda x: self._display_superusers())
@@ -254,7 +255,8 @@ class GlobalMenu(GeneralMenu):
 			choice = Menu(prompt, ['yes', 'no'], default_option='yes').run()
 
 			if choice == 'no':
-				return self._select_harddrives(old_harddrives)
+				exit(1)
+
 
 		return harddrives
 


### PR DESCRIPTION
Corresponds to commit 03f339591ab649cfd7a83bbd77aa5b6817676e5d which had been left out due to the recent file split.
If you don't select a harddrive and said no to use it, the previous implementation was to return to the disk selection. With the patch you exit the installation process. A bit more cumbersone if you made a mistake, but if you wanted to really exit, there is no alternative