### PR TITLE
Small enhacement to LIstManager

### DIFF
--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -158,6 +158,7 @@ class ListManager:
 				header=self.header).run()
 
 			if not target or target in self.bottom_list:
+				self.action = target
 				break
 			if target and target == self.separator:
 				continue


### PR DESCRIPTION
We make the last action available beyond the run loop, so we can check why run was exited
We have discovered that there are times where we might need to know why a ListManager object was exited. Originally, when one of the bottom_list action was checked, the `run`  method exited without any information why outside the method. (`self.action` was not updated. We have located at least two situations where it would be necessary to know.
* When processing after the list management has to be forked depending if it was cancelled or confirmed like 
```python
	lm = archinstall.ListManager('List processing',opciones,None,_('Add'),default_action=acciones,header=cabecera)
	result_list = lm.run()
	if lm.action == lm.confirm_action :
               process_list_contents(result_list)
        else:
              pass
```
* In other cases, we produce additional information during list management. For instance, we generate a sublist of partitions to be deleted before the rest can be processed. As it is obvious, if we cancel the list (return to the original values) the sublist has to be cleared. It was impossible to do till now, without heavy rewrite of the `run` method. Now it would be as simple as
```python
	# i need this overload because i have another parameter to return (partitions to delete)
	def run(self):
                result_list = super().run()
		if not self.action or self.action == self.cancel_action:
			self.partitions_to_delete = {}
		return result_list, self.partitions_to_delete
```


```