### PR TITLE
Autofilling harddrives

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -227,6 +227,8 @@ def post_process_arguments(arguments):
 		if not json_stream_to_structure('--disk_layouts',arguments['disk_layouts'],layout_storage):
 			exit(1)
 		else:
+			if arguments.get('harddrives') is None:
+				arguments['harddrives'] = [disk for disk in layout_storage]
 			# backward compatibility. Change partition.format for partition.wipe
 			for disk in layout_storage:
 				for i,partition in enumerate(layout_storage[disk].get('partitions',[])):


### PR DESCRIPTION
When using a `disk_layouts` argument, but no additional info, current implementation silently forgets the layout, unless we use an specific `--harddrives` argument. Good enough for me, but most user would find it difficult to use
With this change, we simply autofill the `harddrives` arguments from the contents of `disk_layouts`.
As an example if I call
`sudo python -m archinstall --disk_layout datos/btrfs_two_crypt.json`
without the change we get
![before](https://user-images.githubusercontent.com/10762720/161809153-9e910115-b6e0-46cf-b241-49399e549337.png)
and with  the change
![after](https://user-images.githubusercontent.com/10762720/161809233-469ad4d3-99bc-48d5-a504-130131fdd862.png)


