### PR TITLE
For a btrfs  partitions with a subvolume to be mounted on /, we will not generate a keyfile anymore

### DIFF
--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -442,3 +442,35 @@ def convert_device_to_uuid(path :str) -> str:
 		time.sleep(storage['DISK_TIMEOUTS'])
 
 	raise DiskError(f"Could not retrieve the UUID of {path} within a timely manner.")
+
+def has_mountpoint(partition: Union[dict,Partition,MapperDev], target: str, strict: bool = True) -> bool:
+	""" Determine if a certain partition is mounted (or has a mountpoint) as specific target (path)
+	Coded for clarity rather than performance
+
+	Input parms:
+	:parm partition the partition we check
+	:type Either a Partition object or a dict with the contents of a partition definiton in the disk_layouts schema
+
+	:parm target (a string representing a mount path we want to check for.
+	:type str
+
+	:parm strict if the check will be strict, target is exactly the mountpoint, or no, where the target is a leaf (f.i. to check if it is in /mnt/archinstall/). Not available for root check ('/') for obvious reasons
+
+	"""
+	# we create the mountpoint list
+	if isinstance(partition,dict):
+		subvols = partition.get('btrfs',{}).get('subvolumes',{})
+		mountpoints = [partition.get('mountpoint'),] + [subvols[subvol] if isinstance(subvols[subvol],str) or not subvols[subvol] else subvols[subvol].get('mountpoint') for subvol in subvols]
+	else:
+		mountpoints = [partition.mountpoint,] + [subvol.target for subvol in partition.subvolumes]
+	# we check
+	if strict or target == '/':
+		if target in mountpoints:
+			return True
+		else:
+			return False
+	else:
+		for mp in mountpoints:
+			if mp and mp.endswith(target):
+				return True
+		return False

--- a/archinstall/lib/user_interaction/partitioning_conf.py
+++ b/archinstall/lib/user_interaction/partitioning_conf.py
@@ -6,6 +6,7 @@ from ..menu import Menu
 from ..output import log
 
 from ..disk.validators import fs_types
+from ..disk.helpers import has_mountpoint
 
 if TYPE_CHECKING:
 	from ..disk import BlockDevice
@@ -298,7 +299,7 @@ def manage_new_and_existing_partitions(block_device: 'BlockDevice') -> Dict[str,
 
 			elif task == set_btrfs_subvolumes:
 				from .subvolume_config import SubvolumeList
-				
+
 				# TODO get preexisting partitions
 				title = _('{}\n\nSelect which partition to set subvolumes on').format(current_layout)
 				partition = select_partition(title, block_device_struct["partitions"],filter=lambda x:True if x.get('filesystem',{}).get('format') == 'btrfs' else False)
@@ -325,7 +326,7 @@ def select_encrypted_partitions(block_devices: dict, password: str) -> dict:
 				partition['encrypted'] = True
 				partition['!password'] = password
 
-				if partition['mountpoint'] != '/':
+				if not has_mountpoint(partition,'/'):
 					# Tell the upcoming steps to generate a key-file for non root mounts.
 					partition['generate-encryption-key-file'] = True
 


### PR DESCRIPTION
In encrypted setups, we used to generate a keyfile even when the subvolume holding `/` was in the partition. We have solved it.

For solve it and future extensions, we have added at `disk/helpers` a function called `has_mountpoint`, which, for a partition or mapperdev objects, or simply the `disk_layout` definition of a partition; checks if a determinate mountpoint is defined in it. For normal partitions if it is mounted under this name, and for btrfs if any subvolume is mounted with it.
A sample of use can be seen below  (use of argument `strict` is optional)
```python
def harware_map(mountpoint, strict = True):
	result = archinstall.all_blockdevices(partitions=True)
	for res in sorted(result):
		if isinstance(result[res],archinstall.Partition):
		       print(result[res].path,archinstall.has_mountpoint(result[res],mountpoint,strict))
		if isinstance(result[res],archinstall.DMCryptDev):
			print(result[res].MapperDev.path,archinstall.has_mountpoint(result[res].MapperDev,mountpoint,strict))

def layout_map(mountpoint = None, strict = True):
	layout = archinstall.arguments.get('disk_layouts',{})
	for disk in layout:
		parts = layout[disk]['partitions']
		for i,part in enumerate(parts):
			print(disk,i,archinstall.has_mountpoint(part,mountpoint,strict))

harware_map(None,'/home',True)
harware_map(None,'/home',False)
layout_map('/home',True)
```

