### PR TITLE
Flexible order of menu options

### DIFF
--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -42,8 +42,7 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Select Archinstall language'),
 				lambda x: self._select_archinstall_language('English'),
-				default='English',
-				enabled=True)
+				default='English')
 		self._menu_options['keyboard-layout'] = \
 			Selector(_('Select keyboard layout'), lambda preset: select_language('us',preset), default='us')
 		self._menu_options['mirror-region'] = \
@@ -152,24 +151,20 @@ class GlobalMenu(GeneralMenu):
 				lambda preset: self._select_ntp(preset),
 				default=True)
 		self._menu_options['__separator__'] = \
-			Selector(
-				'',
-				enabled=True)
+			Selector('')
 		self._menu_options['save_config'] = \
 			Selector(
 				_('Save configuration'),
 				lambda preset: save_config(self._data_store),
-				enabled=True,
 				no_store=True)
 		self._menu_options['install'] = \
 			Selector(
 				self._install_text(),
 				exec_func=lambda n,v: True if len(self._missing_configs()) == 0 else False,
 				preview_func=self._prev_install_missing_config,
-				enabled=True,
 				no_store=True)
 
-		self._menu_options['abort'] = Selector(_('Abort'), exec_func=lambda n,v:exit(1), enabled=True)
+		self._menu_options['abort'] = Selector(_('Abort'), exec_func=lambda n,v:exit(1))
 
 	def _update_install_text(self, name :str = None, result :Any = None):
 		text = self._install_text()

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -380,9 +380,9 @@ class GeneralMenu:
 
 		# sort the enabled menu by the order we enabled them in
 		# we'll add the entries that have been enabled via the selector constructor at the top
-		# enabled_keys = [i for i in enabled_menus.keys() if i not in self._enabled_order]
+		enabled_keys = [i for i in enabled_menus.keys() if i not in self._enabled_order]
 		# and then we add the ones explicitly enabled by the enable function
-		enabled_keys = [i for i in self._enabled_order if i in enabled_menus.keys()]
+		enabled_keys += [i for i in self._enabled_order if i in enabled_menus.keys()]
 
 		ordered_menus = {k: enabled_menus[k] for k in enabled_keys}
 

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -181,6 +181,7 @@ class GeneralMenu:
 		;type preview_size: float (range 0..1)
 
 		"""
+		self._enabled_order = []
 		self._translation = Translation.load_nationalization()
 		self.is_context_mgr = False
 		self._data_store = data_store if data_store is not None else {}
@@ -239,10 +240,15 @@ class GeneralMenu:
 		if arg is not None:
 			self._menu_options[selector_name].set_current_selection(arg)
 
+	def _update_enabled_order(self, selector_name: str):
+		self._enabled_order.append(selector_name)
+
 	def enable(self, selector_name :str, omit_if_set :bool = False , mandatory :bool = False):
 		""" activates menu options """
 		if self._menu_options.get(selector_name, None):
 			self._menu_options[selector_name].set_enabled(True)
+			self._update_enabled_order(selector_name)
+
 			if mandatory:
 				self._menu_options[selector_name].set_mandatory(True)
 			self.synch(selector_name,omit_if_set)
@@ -372,7 +378,15 @@ class GeneralMenu:
 			if self._verify_selection_enabled(name):
 				enabled_menus[name] = selection
 
-		return enabled_menus
+		# sort the enabled menu by the order we enabled them in
+		# we'll add the entries that have been enabled via the selector constructor at the top
+		# enabled_keys = [i for i in enabled_menus.keys() if i not in self._enabled_order]
+		# and then we add the ones explicitly enabled by the enable function
+		enabled_keys = [i for i in self._enabled_order if i in enabled_menus.keys()]
+
+		ordered_menus = {k: enabled_menus[k] for k in enabled_keys}
+
+		return ordered_menus
 
 	def option(self,name :str) -> Selector:
 		# TODO check inexistent name

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -38,6 +38,9 @@ def ask_user_questions():
 	archinstall.SysCommand('timedatectl set-ntp true')
 
 	global_menu = archinstall.GlobalMenu(data_store=archinstall.arguments)
+
+	global_menu.enable('archinstall-language')
+
 	global_menu.enable('keyboard-layout')
 
 	# Set which region to download packages from during the installation
@@ -89,6 +92,12 @@ def ask_user_questions():
 	global_menu.enable('ntp')
 
 	global_menu.enable('additional-repositories')
+
+	global_menu.enable('__separator__')
+
+	global_menu.enable('save_config')
+	global_menu.enable('install')
+	global_menu.enable('abort')
 
 	global_menu.run()
 


### PR DESCRIPTION
Make the menu entries more flexible by applying a custom order option. 
When calling the `enable(...)` function the order of the calls is saved and applied when building the menu. 
If the menu entries have been enabled via the `Selector(enabled=True)` constructor parameter then those will be placed on top of the menu, but the order can as well be overridden again by calling enable again on that already enabled entry.  