### PR TITLE
Fix blockdevice key error

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -7,11 +7,12 @@ from typing import Optional, Dict, Any, Iterator, Tuple, List, TYPE_CHECKING
 # https://stackoverflow.com/a/39757388/929999
 if TYPE_CHECKING:
 	from .partition import Partition
-	
+
 from ..exceptions import DiskError, SysCallError
 from ..output import log
 from ..general import SysCommand
 from ..storage import storage
+
 
 class BlockDevice:
 	def __init__(self, path :str, info :Optional[Dict[str, Any]] = None):
@@ -38,7 +39,9 @@ class BlockDevice:
 			yield self.partitions[partition]
 
 	def __getitem__(self, key :str, *args :str, **kwargs :str) -> Any:
-		if key not in self.info:
+		if hasattr(self, key):
+			return getattr(self, key)
+		elif key not in self.info:
 			raise KeyError(f'{self} does not contain information: "{key}"')
 		return self.info[key]
 

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -221,10 +221,8 @@ def all_blockdevices(mappers=False, partitions=False, error=False) -> Dict[str, 
 		device_path = f"/dev/{pathlib.Path(block_device).readlink().name}"
 		try:
 			information = blkid(f'blkid -p -o export {device_path}')
-
-		# TODO: No idea why F841 is raised here:
-		except SysCallError as error: # noqa: F841
-			if error.exit_code in (512, 2):
+		except SysCallError as ex:
+			if ex.exit_code in (512, 2):
 				# Assume that it's a loop device, and try to get info on it
 				try:
 					information = get_loop_info(device_path)
@@ -234,7 +232,7 @@ def all_blockdevices(mappers=False, partitions=False, error=False) -> Dict[str, 
 				except SysCallError:
 					information = get_blockdevice_uevent(pathlib.Path(block_device).readlink().name)
 			else:
-				raise error
+				raise ex
 
 		information = enrich_blockdevice_information(information)
 


### PR DESCRIPTION
Fixes #1076

This should fix the problem with the key error, we're now first looking if there's a dedicated attribute/property in the class and only if not we're looking up the key in the info dictionary