### PR TITLE
Require superuser or root password fixed.

### DIFF
--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -141,7 +141,7 @@ class Selector:
 		self._current_selection = current
 
 	def has_selection(self) -> bool:
-		if self._current_selection is None:
+		if not self._current_selection:
 			return False
 		return True
 


### PR DESCRIPTION
Previous `is None` check does not include `{}` and other empty objects.