### PR TITLE
Optimized a bunch of partprobe calls. 

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 from .partition import Partition
 from .validators import valid_fs_type
-from ..exceptions import DiskError
+from ..exceptions import DiskError, SysCallError
 from ..general import SysCommand
 from ..output import log
 from ..storage import storage
@@ -49,7 +49,7 @@ class Filesystem:
 	def partuuid_to_index(self, uuid :str) -> Optional[int]:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(5)
+			time.sleep(storage['DISK_TIMEOUTS'] * (i-1))
 
 			# We'll use unreliable lbslk to grab children under the /dev/<device>
 			output = json.loads(SysCommand(f"lsblk --json {self.blockdevice.device}").decode('UTF-8'))
@@ -60,8 +60,6 @@ class Filesystem:
 					partition_uuid = SysCommand(f"blkid -s PARTUUID -o value /dev/{partition.get('name')}").decode().strip()
 					if partition_uuid.lower() == uuid.lower():
 						return index
-
-			time.sleep(storage['DISK_TIMEOUTS'])
 
 		raise DiskError(f"Failed to convert PARTUUID {uuid} to a partition index number on blockdevice {self.blockdevice.device}")
 
@@ -162,11 +160,11 @@ class Filesystem:
 				return partition
 
 	def partprobe(self) -> bool:
-		result = SysCommand(f'partprobe {self.blockdevice.device}')
-
-		if result.exit_code != 0:
-			log(f"Could not execute partprobe: {result!r}", level=logging.ERROR, fg="red")
-			raise DiskError(f"Could not run partprobe: {result!r}")
+		try:
+			SysCommand(f'partprobe {self.blockdevice.device}')
+		except SysCallError as error:
+			log(f"Could not execute partprobe: {error!r}", level=logging.ERROR, fg="red")
+			raise DiskError(f"Could not run partprobe on {self.blockdevice.device}: {error!r}")
 
 		return True
 

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -49,7 +49,7 @@ class Filesystem:
 	def partuuid_to_index(self, uuid :str) -> Optional[int]:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(storage['DISK_TIMEOUTS'] * (i - 1))
+			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * (i - 1)))
 
 			# We'll use unreliable lbslk to grab children under the /dev/<device>
 			output = json.loads(SysCommand(f"lsblk --json {self.blockdevice.device}").decode('UTF-8'))

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -49,7 +49,7 @@ class Filesystem:
 	def partuuid_to_index(self, uuid :str) -> Optional[int]:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(storage['DISK_TIMEOUTS'] * (i-1))
+			time.sleep(storage['DISK_TIMEOUTS'] * (i - 1))
 
 			# We'll use unreliable lbslk to grab children under the /dev/<device>
 			output = json.loads(SysCommand(f"lsblk --json {self.blockdevice.device}").decode('UTF-8'))

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -49,7 +49,7 @@ class Filesystem:
 	def partuuid_to_index(self, uuid :str) -> Optional[int]:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * i))
+			time.sleep(max(0.1, storage['DISK_TIMEOUTS'] * i))
 
 			# We'll use unreliable lbslk to grab children under the /dev/<device>
 			output = json.loads(SysCommand(f"lsblk --json {self.blockdevice.device}").decode('UTF-8'))

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -49,7 +49,7 @@ class Filesystem:
 	def partuuid_to_index(self, uuid :str) -> Optional[int]:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * (i - 1)))
+			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * i))
 
 			# We'll use unreliable lbslk to grab children under the /dev/<device>
 			output = json.loads(SysCommand(f"lsblk --json {self.blockdevice.device}").decode('UTF-8'))

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -431,7 +431,7 @@ def convert_device_to_uuid(path :str) -> str:
 
 	for i in range(storage['DISK_RETRY_ATTEMPTS']):
 		partprobe(device_name)
-		time.sleep(storage['DISK_TIMEOUTS'] * (i-1)) # TODO: Remove, we should be relying on blkid instead of lsblk
+		time.sleep(storage['DISK_TIMEOUTS'] * (i - 1)) # TODO: Remove, we should be relying on blkid instead of lsblk
 
 		# TODO: Convert lsblk to blkid
 		# (lsblk supports BlockDev and Partition UUID grabbing, blkid requires you to pick PTUUID and PARTUUID)

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -431,7 +431,7 @@ def convert_device_to_uuid(path :str) -> str:
 
 	for i in range(storage['DISK_RETRY_ATTEMPTS']):
 		partprobe(device_name)
-		time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * (i - 1))) # TODO: Remove, we should be relying on blkid instead of lsblk
+		time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * i)) # TODO: Remove, we should be relying on blkid instead of lsblk
 
 		# TODO: Convert lsblk to blkid
 		# (lsblk supports BlockDev and Partition UUID grabbing, blkid requires you to pick PTUUID and PARTUUID)

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -431,7 +431,7 @@ def convert_device_to_uuid(path :str) -> str:
 
 	for i in range(storage['DISK_RETRY_ATTEMPTS']):
 		partprobe(device_name)
-		time.sleep(storage['DISK_TIMEOUTS'] * (i - 1)) # TODO: Remove, we should be relying on blkid instead of lsblk
+		time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * (i - 1))) # TODO: Remove, we should be relying on blkid instead of lsblk
 
 		# TODO: Convert lsblk to blkid
 		# (lsblk supports BlockDev and Partition UUID grabbing, blkid requires you to pick PTUUID and PARTUUID)

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -431,7 +431,7 @@ def convert_device_to_uuid(path :str) -> str:
 
 	for i in range(storage['DISK_RETRY_ATTEMPTS']):
 		partprobe(device_name)
-		time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * i)) # TODO: Remove, we should be relying on blkid instead of lsblk
+		time.sleep(max(0.1, storage['DISK_TIMEOUTS'] * i)) # TODO: Remove, we should be relying on blkid instead of lsblk
 
 		# TODO: Convert lsblk to blkid
 		# (lsblk supports BlockDev and Partition UUID grabbing, blkid requires you to pick PTUUID and PARTUUID)

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -418,16 +418,20 @@ def find_partition_by_mountpoint(block_devices :List[BlockDevice], relative_moun
 			if partition.get('mountpoint', None) == relative_mountpoint:
 				return partition
 
-def partprobe() -> bool:
-	if SysCommand(f'bash -c "partprobe"').exit_code == 0:
-		time.sleep(5) # TODO: Remove, we should be relying on blkid instead of lsblk
-		return True
+def partprobe(path :str = '') -> bool:
+	try:
+		if SysCommand(f'bash -c "partprobe {path}"').exit_code == 0:
+			return True
+	except SysCallError:
+		pass
 	return False
 
 def convert_device_to_uuid(path :str) -> str:
 	device_name, bind_name = split_bind_name(path)
+
 	for i in range(storage['DISK_RETRY_ATTEMPTS']):
-		partprobe()
+		partprobe(device_name)
+		time.sleep(storage['DISK_TIMEOUTS'] * (i-1)) # TODO: Remove, we should be relying on blkid instead of lsblk
 
 		# TODO: Convert lsblk to blkid
 		# (lsblk supports BlockDev and Partition UUID grabbing, blkid requires you to pick PTUUID and PARTUUID)
@@ -436,8 +440,6 @@ def convert_device_to_uuid(path :str) -> str:
 		for device in output['blockdevices']:
 			if (dev_uuid := device.get('uuid', None)):
 				return dev_uuid
-
-		time.sleep(storage['DISK_TIMEOUTS'])
 
 	raise DiskError(f"Could not retrieve the UUID of {path} within a timely manner.")
 

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -142,7 +142,7 @@ class Partition:
 	def size(self) -> Optional[float]:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(storage['DISK_TIMEOUTS'] * (i-1))
+			time.sleep(storage['DISK_TIMEOUTS'] * (i - 1))
 
 			try:
 				lsblk = json.loads(SysCommand(f"lsblk --json -b -o+SIZE {self.device_path}").decode())
@@ -193,7 +193,7 @@ class Partition:
 		"""
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(storage['DISK_TIMEOUTS'] * (i-1))
+			time.sleep(storage['DISK_TIMEOUTS'] * (i - 1))
 
 			partuuid = self._safe_uuid
 			if partuuid:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -142,7 +142,7 @@ class Partition:
 	def size(self) -> Optional[float]:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * (i - 1)))
+			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * i))
 
 			try:
 				lsblk = json.loads(SysCommand(f"lsblk --json -b -o+SIZE {self.device_path}").decode())
@@ -193,7 +193,7 @@ class Partition:
 		"""
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * (i - 1)))
+			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * i))
 
 			partuuid = self._safe_uuid
 			if partuuid:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -142,7 +142,7 @@ class Partition:
 	def size(self) -> Optional[float]:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * i))
+			time.sleep(max(0.1, storage['DISK_TIMEOUTS'] * i))
 
 			try:
 				lsblk = json.loads(SysCommand(f"lsblk --json -b -o+SIZE {self.device_path}").decode())
@@ -193,7 +193,7 @@ class Partition:
 		"""
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * i))
+			time.sleep(max(0.1, storage['DISK_TIMEOUTS'] * i))
 
 			partuuid = self._safe_uuid
 			if partuuid:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -142,7 +142,7 @@ class Partition:
 	def size(self) -> Optional[float]:
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(storage['DISK_TIMEOUTS'] * (i - 1))
+			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * (i - 1)))
 
 			try:
 				lsblk = json.loads(SysCommand(f"lsblk --json -b -o+SIZE {self.device_path}").decode())
@@ -193,7 +193,7 @@ class Partition:
 		"""
 		for i in range(storage['DISK_RETRY_ATTEMPTS']):
 			self.partprobe()
-			time.sleep(storage['DISK_TIMEOUTS'] * (i - 1))
+			time.sleep(min(0.1, storage['DISK_TIMEOUTS'] * (i - 1)))
 
 			partuuid = self._safe_uuid
 			if partuuid:


### PR DESCRIPTION
Namely fixed sleep calls, added optional path to the general archinstall.partprobe() call. And fixed some error handling in a few places which should tell us where #1083 might be going wrong.

This will fix #1083

I need to figure out the order of why this is even called:
```
Getting mount information for device path /mnt/archinstall/boot
Could not get block device information using blkid() using command blkid -p -o export /dev/sr0
Could not get block device information using blkid() using command blkid -p -o export /dev/sr0
Could not get block device information using blkid() using command blkid -p -o export /dev/sr0
Could not get block device information using blkid() using command blkid -p -o export /dev/sr0
Could not get block device information using blkid() using command blkid -p -o export /dev/sr0
['/usr/bin/partprobe', '/dev/sdb'] exited with abnormal exit code [256]: b'Error: Partition(s) 1 on /dev/sdb have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use.  As a result, the old partition(s) will remain in use.  You should reboot now before making further changes.\r\n'
```
There really shouldn't be a need for archinstall to call partprobe on `/dev/sdb` at all.
But I'm guessing it's due to listing of partitions, in which case we would be fine ignoring it or omitting the need to have mint-fresh data for the listing. Unless it's input option based (where the user needs to supply critical actions such as changing partition layouts or something).