### PR TITLE
Change the logging text of CPU vendor check

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -775,7 +775,7 @@ class Installer:
 					elif vendor == "GenuineIntel":
 						entry.write("initrd /intel-ucode.img\n")
 					else:
-						self.log("unknow cpu vendor, not adding ucode to systemd-boot config")
+						self.log("Unknown CPU vendor, cancel adding ucode to systemd-boot config")
 				entry.write(f"initrd /initramfs-{kernel}.img\n")
 				# blkid doesn't trigger on loopback devices really well,
 				# so we'll use the old manual method until we get that sorted out.
@@ -879,7 +879,7 @@ class Installer:
 				elif vendor == "GenuineIntel":
 					kernel_parameters.append("initrd=\\intel-ucode.img")
 				else:
-					self.log("unknow cpu vendor, not adding ucode to firmware boot entry")
+					self.log("Unknown CPU vendor, cancel adding ucode to firmware boot entry")
 
 			kernel_parameters.append(f"initrd=\\initramfs-{kernel}.img")
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -775,7 +775,7 @@ class Installer:
 					elif vendor == "GenuineIntel":
 						entry.write("initrd /intel-ucode.img\n")
 					else:
-						self.log("Unknown CPU vendor, cancel adding ucode to systemd-boot config")
+						self.log(f"Unknown CPU vendor '{vendor}' detected. Archinstall won't add any ucode to systemd-boot config.", level=logging.DEBUG)
 				entry.write(f"initrd /initramfs-{kernel}.img\n")
 				# blkid doesn't trigger on loopback devices really well,
 				# so we'll use the old manual method until we get that sorted out.
@@ -879,7 +879,7 @@ class Installer:
 				elif vendor == "GenuineIntel":
 					kernel_parameters.append("initrd=\\intel-ucode.img")
 				else:
-					self.log("Unknown CPU vendor, cancel adding ucode to firmware boot entry")
+					self.log(f"Unknown CPU vendor '{vendor}' detected. Archinstall won't add any ucode to firmware boot entry.", level=logging.DEBUG)
 
 			kernel_parameters.append(f"initrd=\\initramfs-{kernel}.img")
 


### PR DESCRIPTION
This PR corrects the text with the typo, and also makes it unified according to [line 648](https://github.com/archlinux/archinstall/blob/master/archinstall/lib/installer.py#L648) in installer.py