### PR TITLE
unlocked luks2 partitions were missing a BlockDevice parameter.

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -141,7 +141,7 @@ class BlockDevice:
 				if part_id not in self.part_cache:
 					# TODO: Force over-write even if in cache?
 					if part_id not in self.part_cache or self.part_cache[part_id].size != part['size']:
-						self.part_cache[part_id] = Partition(root_path + part_id, self, part_id=part_id)
+						self.part_cache[part_id] = Partition(root_path + part_id, block_device=self, part_id=part_id)
 
 		return {k: self.part_cache[k] for k in sorted(self.part_cache)}
 

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -241,7 +241,7 @@ def all_blockdevices(mappers=False, partitions=False, error=False) -> Dict[str, 
 				instances[path] = DMCryptDev(dev_path=path)
 			elif path_info.get('PARTUUID') or path_info.get('PART_ENTRY_NUMBER'):
 				if partitions:
-					instances[path] = Partition(path, BlockDevice(get_parent_of_partition(pathlib.Path(path))))
+					instances[path] = Partition(path, block_device=BlockDevice(get_parent_of_partition(pathlib.Path(path))))
 			elif path_info.get('PTTYPE', False) is not False or path_info.get('TYPE') == 'loop':
 				instances[path] = BlockDevice(path, path_info)
 			elif path_info.get('TYPE') == 'squashfs':

--- a/archinstall/lib/disk/mapperdev.py
+++ b/archinstall/lib/disk/mapperdev.py
@@ -46,7 +46,7 @@ class MapperDev:
 					information = uevent(uevent_data)
 					block_device = BlockDevice(get_parent_of_partition('/dev/' / pathlib.Path(information['DEVNAME'])))
 
-					return Partition(information['DEVNAME'], block_device)
+					return Partition(information['DEVNAME'], block_device=block_device)
 
 		raise ValueError(f"Could not convert {self.mappername} to a real dm-crypt device")
 

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -15,6 +15,7 @@ from .general import SysCommand, SysCommandWorker
 from .output import log
 from .exceptions import SysCallError, DiskError
 from .storage import storage
+from .disk.mapperdev import MapperDev
 
 class luks2:
 	def __init__(self,
@@ -160,7 +161,14 @@ class luks2:
 		SysCommand(f'/usr/bin/cryptsetup open {partition.path} {mountpoint} --key-file {os.path.abspath(key_file)} --type luks2')
 		if os.path.islink(f'/dev/mapper/{mountpoint}'):
 			self.mapdev = f'/dev/mapper/{mountpoint}'
-			unlocked_partition = Partition(self.mapdev, None, encrypted=True, filesystem=get_filesystem_type(self.mapdev), autodetect_filesystem=False)
+
+			unlocked_partition = Partition(
+				self.mapdev,
+				block_device=MapperDev(mountpoint).partition.block_device,
+				encrypted=True,
+				filesystem=get_filesystem_type(self.mapdev),
+				autodetect_filesystem=False
+			)
 			return unlocked_partition
 
 	def close(self, mountpoint :Optional[str] = None) -> bool:


### PR DESCRIPTION
It's technically not the true block device, as the mapper dev belongs to a partition, but in this context blockdev means the harddrive/medium that the partition (unlocked or otherwise) lives on.

This will fix #1093 