### PR TITLE
Fix minor issues

### DIFF
--- a/archinstall/lib/menu/menu.py
+++ b/archinstall/lib/menu/menu.py
@@ -160,6 +160,7 @@ class Menu(TerminalMenu):
 			preview_command=preview_command,
 			preview_size=preview_size,
 			preview_title=preview_title,
+			multi_select_select_on_accept=False,
 			**kwargs,
 		)
 

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -309,8 +309,15 @@ class GeneralMenu:
 
 			if selection and self.auto_cursor:
 				cursor_pos = menu_options.index(selection) + 1  # before the strip otherwise fails
-				if cursor_pos >= len(menu_options):
-					cursor_pos = len(menu_options) - 1
+
+				# in case the new position lands on a "placeholder" we'll skip them as well
+				while True:
+					if cursor_pos >= len(menu_options):
+						cursor_pos = 0
+					if len(menu_options[cursor_pos]) > 0:
+						break
+					cursor_pos += 1
+
 				selection = selection.strip()
 			if selection:
 				# if this calls returns false, we exit the menu. We allow for an callback for special processing on realeasing control


### PR DESCRIPTION
- If not already selected, will not select an entry in a multi select anymore with enter  except when there's no other selection at all yet
- Skip over placeholders when automatically moving the cursor forward when exiting a submenu