### PR TITLE
SysCommand now sets working_directory on SysCommandWorker.

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -352,7 +352,6 @@ class SysCommandWorker:
 		#   only way to get the traceback without loosing it.
 
 		self.pid, self.child_fd = pty.fork()
-		os.chdir(old_dir)
 
 		# https://stackoverflow.com/questions/4022600/python-pty-fork-how-does-it-work
 		if not self.pid:
@@ -371,6 +370,9 @@ class SysCommandWorker:
 				log(f"{self.cmd[0]} does not exist.", level=logging.ERROR, fg="red")
 				self.exit_code = 1
 				return False
+		else:
+			# Only parent process moves back to the original working directory
+			os.chdir(old_dir)
 
 		self.started = time.time()
 		self.poll_object.register(self.child_fd, EPOLLIN | EPOLLHUP)
@@ -457,7 +459,14 @@ class SysCommand:
 		if self.session:
 			return self.session
 
-		with SysCommandWorker(self.cmd, callbacks=self._callbacks, peak_output=self.peak_output, environment_vars=self.environment_vars, remove_vt100_escape_codes_from_lines=self.remove_vt100_escape_codes_from_lines) as session:
+		with SysCommandWorker(
+			self.cmd,
+			callbacks=self._callbacks,
+			peak_output=self.peak_output,
+			environment_vars=self.environment_vars,
+			remove_vt100_escape_codes_from_lines=self.remove_vt100_escape_codes_from_lines,
+			working_directory=self.working_directory) as session:
+
 			if not self.session:
 				self.session = session
 


### PR DESCRIPTION
Also made it so the parent process moves back to the original working directory, leaving the child process in the target working directory.

Most of the time when we've needed to set a working directory, we've also needed full control of the process so we've used `SysCommandWorker` directly. But this ensures a unified behavior between the both on a superficial level.

Another thing that was a miss was that the working directory was set for both processes in `SysCommandWorker`, but both processes also changed back to the original working dir. This is not desirable since we want the child to continue in the spawned directory.