### PR TITLE
Add how to pass declarative configuration files as arguments to archinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Prequisites:
 
 Assuming you are on a Arch Linux live-ISO and booted into EFI mode.
 
-    # archinstall --config <path to config file or URL>
+    # archinstall --config <path to user config file or URL> --disk-layout <path to disk layout config file or URL> --creds <path to user credentials config file or URL>
 
 # Help?
 


### PR DESCRIPTION
🚨 PR Guidelines:

# Describe your PR

Just an update to README.md to firmly mention how --config, --disk-layout and --creds work. There are misleading tutorials and videos online that just use --config for all three types of config files and mentioning in the readme file will help minimize further confusions and errors.