### PR TITLE
Fix mypy complaints in models.dataclasses.py

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -15,4 +15,4 @@ jobs:
             # one day this will be enabled
               # run: mypy --strict --module archinstall || exit 0
             - name: run mypy
-              run: mypy --follow-imports=skip archinstall/lib/menu/selection_menu.py archinstall/lib/models/network_configuration.py archinstall/lib/menu/list_manager.py archinstall/lib/user_interaction/network_conf.py
+              run: mypy --follow-imports=skip archinstall/lib/menu/selection_menu.py archinstall/lib/models/network_configuration.py archinstall/lib/menu/list_manager.py archinstall/lib/user_interaction/network_conf.py archinstall/lib/models/dataclasses.py

--- a/archinstall/lib/models/dataclasses.py
+++ b/archinstall/lib/models/dataclasses.py
@@ -110,13 +110,13 @@ class PackageSearchResult:
 		if not isinstance(other, PackageSearchResult):
 			return NotImplemented
 
-		return VersionDef(self.pkgver) == VersionDef(other.pkgver)
+		return self.pkg_version == other.pkg_version
 
 	def __lt__(self, other :object) -> bool:
 		if not isinstance(other, PackageSearchResult):
 			return NotImplemented
 
-		return VersionDef(self.pkgver) < VersionDef(other.pkgver)
+		return self.pkg_version < other.pkg_version
 
 
 @dataclass
@@ -161,10 +161,10 @@ class LocalPackage:
 		if not isinstance(other, LocalPackage):
 			return NotImplemented
 
-		return VersionDef(self.version) == VersionDef(other.version)
+		return self.pkg_version == other.pkg_version
 
 	def __lt__(self, other :object) -> bool:
 		if not isinstance(other, LocalPackage):
 			return NotImplemented
 
-		return VersionDef(self.version) < VersionDef(other.version)
+		return self.pkg_version < other.pkg_version

--- a/archinstall/lib/models/dataclasses.py
+++ b/archinstall/lib/models/dataclasses.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional, List
 
@@ -5,7 +7,6 @@ from typing import Optional, List
 class VersionDef:
 	version_string: str
 
-	@classmethod
 	def parse_version(self) -> List[str]:
 		if '.' in self.version_string:
 			versions = self.version_string.split('.')
@@ -14,38 +15,60 @@ class VersionDef:
 
 		return versions
 
-	@classmethod
 	def major(self) -> str:
 		return self.parse_version()[0]
 
-	@classmethod
 	def minor(self) -> str:
 		versions = self.parse_version()
 		if len(versions) >= 2:
 			return versions[1]
 
-	@classmethod
+		return ""
+
 	def patch(self) -> str:
 		versions = self.parse_version()
 		if '-' in versions[-1]:
 			_, patch_version = versions[-1].split('-', 1)
 			return patch_version
 
-	def __eq__(self, other :'VersionDef') -> bool:
-		if other.major == self.major and \
-			other.minor == self.minor and \
-			other.patch == self.patch:
+		return ""
+
+	def __eq__(self, other :object) -> bool:
+		if not isinstance(other, VersionDef):
+			return NotImplemented
+
+		if other.major() == self.major() and \
+			other.minor() == self.minor() and \
+			other.patch() == self.patch():
 
 			return True
 		return False
 		
-	def __lt__(self, other :'VersionDef') -> bool:
-		if self.major > other.major:
+	def __lt__(self, other :object) -> bool:
+		if not isinstance(other, VersionDef):
+			return NotImplemented
+
+		if self.major() < other.major():
 			return False
-		elif self.minor and other.minor and self.minor > other.minor:
+		elif self.minor() and other.minor() and self.minor() > other.minor():
 			return False
-		elif self.patch and other.patch and self.patch > other.patch:
+		elif self.patch() and other.patch() and self.patch() > other.patch():
 			return False
+		else:
+			return True
+
+	def __gt__(self, other :object) -> bool:
+		if not isinstance(other, VersionDef):
+			return NotImplemented
+
+		if self.major() < other.major():
+			return False
+		elif self.minor() and other.minor() and self.minor() < other.minor():
+			return False
+		elif self.patch() and other.patch() and self.patch() < other.patch():
+			return False
+		else:
+			return True
 
 	def __str__(self) -> str:
 		return self.version_string
@@ -83,11 +106,18 @@ class PackageSearchResult:
 	def pkg_version(self) -> str:
 		return self.pkgver
 
-	def __eq__(self, other :'VersionDef') -> bool:
-		return self.pkg_version == other.pkg_version
+	def __eq__(self, other :object) -> bool:
+		if not isinstance(other, PackageSearchResult):
+			return NotImplemented
 
-	def __lt__(self, other :'VersionDef') -> bool:
-		return self.pkg_version < other.pkg_version
+		return VersionDef(self.pkgver) == VersionDef(other.pkgver)
+
+	def __lt__(self, other :object) -> bool:
+		if not isinstance(other, PackageSearchResult):
+			return NotImplemented
+
+		return VersionDef(self.pkgver) < VersionDef(other.pkgver)
+
 
 @dataclass
 class PackageSearch:
@@ -98,8 +128,6 @@ class PackageSearch:
 	page: int
 	results: List[PackageSearchResult]
 
-	def __post_init__(self):
-		self.results = [PackageSearchResult(**x) for x in self.results]
 
 @dataclass
 class LocalPackage:
@@ -129,8 +157,14 @@ class LocalPackage:
 	def pkg_version(self) -> str:
 		return self.version
 
-	def __eq__(self, other :'VersionDef') -> bool:
-		return self.pkg_version == other.pkg_version
+	def __eq__(self, other :object) -> bool:
+		if not isinstance(other, LocalPackage):
+			return NotImplemented
 
-	def __lt__(self, other :'VersionDef') -> bool:
-		return self.pkg_version < other.pkg_version
+		return VersionDef(self.version) == VersionDef(other.version)
+
+	def __lt__(self, other :object) -> bool:
+		if not isinstance(other, LocalPackage):
+			return NotImplemented
+
+		return VersionDef(self.version) < VersionDef(other.version)

--- a/archinstall/lib/models/dataclasses.py
+++ b/archinstall/lib/models/dataclasses.py
@@ -23,7 +23,7 @@ class VersionDef:
 		if len(versions) >= 2:
 			return versions[1]
 
-		return ""
+		return "0"
 
 	def patch(self) -> str:
 		versions = self.parse_version()
@@ -31,7 +31,7 @@ class VersionDef:
 			_, patch_version = versions[-1].split('-', 1)
 			return patch_version
 
-		return ""
+		return "0"
 
 	def __eq__(self, other :object) -> bool:
 		if not isinstance(other, VersionDef):

--- a/tests/test_version_def.py
+++ b/tests/test_version_def.py
@@ -1,0 +1,36 @@
+from archinstall.lib.models.dataclasses import VersionDef
+
+def test_version_def_equality() -> None:
+	version_a = VersionDef("1.0")
+	version_b = VersionDef("1.0")
+
+	assert version_a == version_b
+
+def test_version_def_greater_than_major() -> None:
+	version_a = VersionDef("2.0")
+	version_b = VersionDef("1.0")
+
+	assert version_a > version_b
+
+def test_version_def_greater_than_minor() -> None:
+	version_a = VersionDef("1.1")
+	version_b = VersionDef("1.0")
+
+	assert version_a > version_b
+
+def test_version_def_less_than_major() -> None:
+	version_a = VersionDef("1.0")
+	version_b = VersionDef("2.0")
+
+	assert version_a < version_b
+
+def test_version_def_less_than_minor() -> None:
+	version_a = VersionDef("1.0")
+	version_b = VersionDef("1.1")
+
+	assert version_a < version_b
+
+def test_version_def_patch() -> None:
+	version = VersionDef("1.0-35")
+
+	assert version.patch() == "35"


### PR DESCRIPTION
🚨 PR Guidelines:

# New features *(v2.2.0)*

All future work towards *`v2.2.0`* is done against `master` now.<br>
Any patch work to existing versions will have to create a new branch against the tagged versions.

# Describe your PR

I fixed all of the complaints from mypy in models.dataclasses.py. This was in attempt to help the library be more compliant with PEP 561 as discussed in issue #114.

You'll notice that in the comparison dunder functions, I replaced the type from `VersionDef` to `object`. This is because these methods can expect any type of object, which is why I raise `NotImplemeted` if it gets compared with any other type than itself. Inspired by this: https://stackoverflow.com/questions/54801832/mypy-eq-incompatible-with-supertype-object

# Testing

In another commit I wrote a few unit tests for the VersionDef class. That being said I noticed that there isn't a preexisting test suite yet (that's in another branch, presumably coming soon). So feel free to disregard that commit if you want.
