### PR TITLE
This allows us to set LANG= in vconsole for keymap negotiation during crypt-unlock

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -32,7 +32,11 @@ from .lib.packages.packages import (
 from .lib.profiles import *
 from .lib.services import *
 from .lib.storage import *
-from .lib.systemd import *
+from .lib.systemd import (
+	localectl_status,
+	Boot,
+	Ini
+)
 from .lib.user_interaction import *
 from .lib.menu import Menu
 from .lib.menu.list_manager import ListManager

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1075,6 +1075,11 @@ class Installer:
 		else:
 			self.log('Keyboard language was not changed from default (no language specified).', fg="yellow", level=logging.INFO)
 
+		# This needs to be explicitly set in some cases due to https://github.com/archlinux/archinstall/issues/596
+		if LANG := localectl_status().get('x11_layout'):
+			with open(f"{self.target}/etc/vconsole.conf", "a") as vconsole:
+				vconsole.write(f"LANG={LANG}\n")
+
 		return True
 
 	def set_x11_keyboard_language(self, language: str) -> bool:

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -138,3 +138,11 @@ class Boot:
 			cmd[0] = locate_binary(cmd[0])
 
 		return SysCommandWorker(["systemd-run", f"--machine={self.container_name}", "--pty", *cmd], *args, **kwargs)
+
+def localectl_status():
+	result = {}
+	for line in SysCommand(["localectl", "status"]):
+		key, value = line.strip().decode('UTF-8').split(': ', 1)
+		result[key.lower().replace(' ', '_')] = value
+
+	return result

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -254,6 +254,10 @@ def perform_installation(mountpoint):
 		if archinstall.arguments.get('custom-commands', None):
 			archinstall.run_custom_user_commands(archinstall.arguments['custom-commands'], installation)
 
+		# After certain locale's has been set, this needs
+		# to be re-run to avoid issues such as https://github.com/archlinux/archinstall/issues/596
+		installation.mkinitcpio('-P')
+
 		installation.log("For post-installation tips, see https://wiki.archlinux.org/index.php/Installation_guide#Post-installation", fg="yellow")
 		if not archinstall.arguments.get('silent'):
 			prompt = str(_('Would you like to chroot into the newly created installation and perform post-installation configuration?'))


### PR DESCRIPTION
This fixes #596 by explicitly setting `LANG=` in `/etc/vconsole.conf`.
Not sure why this is needed, but is apparently a known "weird" glitch.

And just to be clear, it's not always required. But it's hard to tell when it is.
And adding this shouldn't cause any other issues. The drawback is that we generate and run `mkinitcpio` twice.

I'm contemplating evaluating [sd-encrypt](https://wiki.archlinux.org/title/Dm-crypt/System_configuration#Using_sd-encrypt_hook) hook instead. But saving that for later.