### PR TITLE
Enabling retry for package downloads

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -365,19 +365,28 @@ class Installer:
 
 		self.log(f'Installing packages: {packages}', level=logging.INFO)
 
-		if (sync_mirrors := run_pacman('-Syy', default_cmd='/usr/bin/pacman')).exit_code == 0:
-			try:
-				return SysCommand(f'/usr/bin/pacstrap -C /etc/pacman.conf {self.target} {" ".join(packages)} --noconfirm', peak_output=True).exit_code == 0
-			except SysCallError as error:
-				self.log(f'Could not strap in packages: {error}', level=logging.ERROR, fg="red")
+		# TODO: We technically only need to run the -Syy once.
+		try:
+			run_pacman('-Syy', default_cmd='/usr/bin/pacman')
+		except SysCallError as error:
+			self.log(f'Could not sync a new package databse: {error}', level=logging.ERROR, fg="red")
 
-				if storage['arguments'].get('silent', False) is False:
-					if input('Would you like to re-try this download? (Y/n): ').lower().strip() in ('', 'y'):
-						return self.pacstrap(*packages, **kwargs)
-				
-				raise RequirementError("Pacstrap failed. See /var/log/archinstall/install.log or above message for error details.")
-		else:
-			self.log(f'Could not sync mirrors: {sync_mirrors.exit_code}', level=logging.INFO)
+			if storage['arguments'].get('silent', False) is False:
+				if input('Would you like to re-try this download? (Y/n): ').lower().strip() in ('', 'y'):
+					return self.pacstrap(*packages, **kwargs)
+
+			raise RequirementError(f'Could not sync mirrors: {error}', level=logging.ERROR, fg="red")
+
+		try:
+			return SysCommand(f'/usr/bin/pacstrap -C /etc/pacman.conf {self.target} {" ".join(packages)} --noconfirm', peak_output=True).exit_code == 0
+		except SysCallError as error:
+			self.log(f'Could not strap in packages: {error}', level=logging.ERROR, fg="red")
+
+			if storage['arguments'].get('silent', False) is False:
+				if input('Would you like to re-try this download? (Y/n): ').lower().strip() in ('', 'y'):
+					return self.pacstrap(*packages, **kwargs)
+			
+			raise RequirementError("Pacstrap failed. See /var/log/archinstall/install.log or above message for error details.")
 
 	def set_mirrors(self, mirrors :Mapping[str, Iterator[str]]) -> None:
 		for plugin in plugins.values():


### PR DESCRIPTION
This implements retry-functionality to `installation.pacstrap()` calls.
It will respect `--silent`, and it is a bit rudimentary. But it appears to do the trick.

This fixes #576