### PR TITLE
Fix lengthy translations in Main Menu (Important)

### DIFF
--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -146,7 +146,7 @@ class GlobalMenu(GeneralMenu):
 				default=[])
 		self._menu_options['additional-repositories'] = \
 			Selector(
-				_('Additional repositories'),
+				_('Optional repositories'),
 				select_additional_repositories,
 				default=[])
 		self._menu_options['nic'] = \

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -42,33 +42,33 @@ class GlobalMenu(GeneralMenu):
 		# archinstall.Language will not use preset values
 		self._menu_options['archinstall-language'] = \
 			Selector(
-				_('Select Archinstall language'),
+				_('Archinstall language'),
 				lambda x: self._select_archinstall_language(x),
 				default='English')
 		self._menu_options['keyboard-layout'] = \
 			Selector(
-				_('Select keyboard layout'),
+				_('Keyboard layout'),
 				lambda preset: select_language(preset),
 				default='us')
 		self._menu_options['mirror-region'] = \
 			Selector(
-				_('Select mirror region'),
+				_('Mirror region'),
 				lambda preset: select_mirror_regions(preset),
 				display_func=lambda x: list(x.keys()) if x else '[]',
 				default={})
 		self._menu_options['sys-language'] = \
 			Selector(
-				_('Select locale language'),
+				_('Locale language'),
 				lambda preset: select_locale_lang(preset),
 				default='en_US')
 		self._menu_options['sys-encoding'] = \
 			Selector(
-				_('Select locale encoding'),
+				_('Locale encoding'),
 				lambda preset: select_locale_enc(preset),
 				default='UTF-8')
 		self._menu_options['harddrives'] = \
 			Selector(
-				_('Select harddrives'),
+				_('Drives'),
 				lambda preset: self._select_harddrives(preset))
 		self._menu_options['disk_layouts'] = \
 			Selector(
@@ -87,28 +87,28 @@ class GlobalMenu(GeneralMenu):
 				dependencies=['harddrives'])
 		self._menu_options['swap'] = \
 			Selector(
-				_('Use swap'),
+				_('Swap'),
 				lambda preset: ask_for_swap(preset),
 				default=True)
 		self._menu_options['bootloader'] = \
 			Selector(
-				_('Select bootloader'),
+				_('Bootloader'),
 				lambda preset: ask_for_bootloader(storage['arguments'].get('advanced', False),preset),
 				default="systemd-bootctl" if has_uefi() else "grub-install")
 		self._menu_options['hostname'] = \
 			Selector(
-				_('Specify hostname'),
+				_('Hostname'),
 				ask_hostname,
 				default='archlinux')
 		# root password won't have preset value
 		self._menu_options['!root-password'] = \
 			Selector(
-				_('Set root password'),
+				_('root password'),
 				lambda preset:self._set_root_password(),
 				display_func=lambda x: secret(x) if x else 'None')
 		self._menu_options['!superusers'] = \
 			Selector(
-				_('Specify superuser account'),
+				_('Superuser account'),
 				lambda preset: self._create_superuser_account(),
 				default={},
 				exec_func=lambda n,v:self._users_resynch(),
@@ -116,53 +116,53 @@ class GlobalMenu(GeneralMenu):
 				display_func=lambda x: self._display_superusers())
 		self._menu_options['!users'] = \
 			Selector(
-				_('Specify user account'),
+				_('User account'),
 				lambda x: self._create_user_account(),
 				default={},
 				exec_func=lambda n,v:self._users_resynch(),
 				display_func=lambda x: list(x.keys()) if x else '[]')
 		self._menu_options['profile'] = \
 			Selector(
-				_('Specify profile'),
+				_('Profile'),
 				lambda preset: self._select_profile(preset),
 				display_func=lambda x: x if x else 'None')
 		self._menu_options['audio'] = \
 			Selector(
-				_('Select audio'),
+				_('Audio'),
 				lambda preset: ask_for_audio_selection(is_desktop_profile(storage['arguments'].get('profile', None)),preset),
 				display_func=lambda x: x if x else 'None',
 				default=None
 			)
 		self._menu_options['kernels'] = \
 			Selector(
-				_('Select kernels'),
+				_('Kernels'),
 				lambda preset: select_kernel(preset),
 				default=['linux'])
 		self._menu_options['packages'] = \
 			Selector(
-				_('Additional packages to install'),
+				_('Additional packages'),
 				# lambda x: ask_additional_packages_to_install(storage['arguments'].get('packages', None)),
 				ask_additional_packages_to_install,
 				default=[])
 		self._menu_options['additional-repositories'] = \
 			Selector(
-				_('Additional repositories to enable'),
+				_('Additional repositories'),
 				select_additional_repositories,
 				default=[])
 		self._menu_options['nic'] = \
 			Selector(
-				_('Configure network'),
+				_('Network configuration'),
 				ask_to_configure_network,
 				display_func=lambda x: self._prev_network_configuration(x),
 				default={})
 		self._menu_options['timezone'] = \
 			Selector(
-				_('Select timezone'),
+				_('Timezone'),
 				lambda preset: ask_for_a_timezone(preset),
 				default='UTC')
 		self._menu_options['ntp'] = \
 			Selector(
-				_('Set automatic time sync (NTP)'),
+				_('Automatic time sync (NTP)'),
 				lambda preset: self._select_ntp(preset),
 				default=True)
 		self._menu_options['__separator__'] = \

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -68,7 +68,7 @@ class GlobalMenu(GeneralMenu):
 				default='UTF-8')
 		self._menu_options['harddrives'] = \
 			Selector(
-				_('Drives'),
+				_('Drive(s)'),
 				lambda preset: self._select_harddrives(preset))
 		self._menu_options['disk_layouts'] = \
 			Selector(

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -18,7 +18,7 @@ def select_archinstall_language(preset_value: str) -> Optional[str]:
 	copied from user_interaction/general_conf.py as a temporary measure
 	"""
 	languages = Translation.get_available_lang()
-	language = Menu(_('Select Archinstall language'), languages, preset_values=preset_value).run()
+	language = Menu(_('Archinstall language'), languages, preset_values=preset_value).run()
 	return language.value
 
 

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -79,7 +79,7 @@ def select_language(preset_value: str = None) -> str:
 	sorted_kb_lang = sorted(sorted(list(kb_lang)), key=len)
 
 	selected_lang = Menu(
-		_('Select Keyboard layout'),
+		_('Choose keyboard layout'),
 		sorted_kb_lang,
 		preset_values=preset_value,
 		sort=False
@@ -120,7 +120,7 @@ def select_mirror_regions(preset_values: Dict[str, Any] = {}) -> Dict[str, Any]:
 
 def select_archinstall_language(default='English'):
 	languages = Translation.get_available_lang()
-	language = Menu(_('Select Archinstall language'), languages, default_option=default).run()
+	language = Menu(_('Archinstall language'), languages, default_option=default).run()
 	return language
 
 

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -79,7 +79,7 @@ def select_language(preset_value: str = None) -> str:
 	sorted_kb_lang = sorted(sorted(list(kb_lang)), key=len)
 
 	selected_lang = Menu(
-		_('Choose keyboard layout'),
+		_('Select keyboard layout'),
 		sorted_kb_lang,
 		preset_values=preset_value,
 		sort=False

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -172,7 +172,7 @@ msgid ""
 "install things like desktop environments"
 msgstr ""
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr ""
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -511,7 +511,7 @@ msgstr ""
 msgid "are you sure you want to use it?"
 msgstr ""
 
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr ""
 
 msgid "Save configuration"

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -246,7 +246,7 @@ msgstr ""
 msgid "Locale encoding"
 msgstr ""
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr ""
 
 msgid "Select disk layout"

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr ""
 
-msgid "Select Archinstall language"
+msgid "Archinstall language"
 msgstr ""
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
@@ -172,7 +172,7 @@ msgid ""
 "install things like desktop environments"
 msgstr ""
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr ""
 
 msgid "Select one of the regions to download packages from"
@@ -234,19 +234,19 @@ msgstr ""
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr ""
 
-msgid "Select keyboard layout"
+msgid "Keyboard layout"
 msgstr ""
 
-msgid "Select mirror region"
+msgid "Mirror region"
 msgstr ""
 
-msgid "Select locale language"
+msgid "Locale language"
 msgstr ""
 
-msgid "Select locale encoding"
+msgid "Locale encoding"
 msgstr ""
 
-msgid "Select harddrives"
+msgid "Drives"
 msgstr ""
 
 msgid "Select disk layout"
@@ -255,37 +255,37 @@ msgstr ""
 msgid "Set encryption password"
 msgstr ""
 
-msgid "Use swap"
+msgid "Swap"
 msgstr ""
 
-msgid "Select bootloader"
+msgid "Bootloader"
 msgstr ""
 
-msgid "Set root password"
+msgid "root password"
 msgstr ""
 
-msgid "Specify superuser account"
+msgid "Superuser account"
 msgstr ""
 
-msgid "Specify user account"
+msgid "User account"
 msgstr ""
 
-msgid "Specify profile"
+msgid "Profile"
 msgstr ""
 
-msgid "Select audio"
+msgid "Audio"
 msgstr ""
 
-msgid "Select kernels"
+msgid "Kernels"
 msgstr ""
 
-msgid "Additional packages to install"
+msgid "Additional packages"
 msgstr ""
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr ""
 
-msgid "Set automatic time sync (NTP)"
+msgid "Automatic time sync (NTP)"
 msgstr ""
 
 msgid "Install ({} config(s) missing)"
@@ -328,13 +328,13 @@ msgstr ""
 msgid "Abort"
 msgstr ""
 
-msgid "Specify hostname"
+msgid "Hostname"
 msgstr ""
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr ""
 
-msgid "Select timezone"
+msgid "Timezone"
 msgstr ""
 
 msgid "Set/Modify the below options"
@@ -511,7 +511,7 @@ msgstr ""
 msgid "are you sure you want to use it?"
 msgstr ""
 
-msgid "Additional repositories to enable"
+msgid "Additional repositories"
 msgstr ""
 
 msgid "Save configuration"

--- a/archinstall/locales/de/LC_MESSAGES/base.po
+++ b/archinstall/locales/de/LC_MESSAGES/base.po
@@ -168,7 +168,7 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr "Bitte geben sie einen gewünschten Dateisystemtyp für die Partition ein: "
 
-msgid "Select Archinstall language"
+msgid "Archinstall language"
 msgstr "Sprache für Archinstall"
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
@@ -183,7 +183,7 @@ msgstr "Bitte wählen sie was mit dem ausgewählten Gerät geschehen soll"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Dies ist eine Liste von bereits programmierten Profilen, diese ermöglichen es einfacher Desktop Umgebungen einzustellen"
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr "Bitte wählen sie ein Tastaturlayout aus"
 
 msgid "Select one of the regions to download packages from"
@@ -240,20 +240,20 @@ msgstr "Fehler: Auflistung von Profilen mit URL \"{}\":"
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr "Fehler: \"{}\" konnte nicht in ein JSON format dekodiert werden:"
 
-msgid "Select keyboard layout"
-msgstr "Tastaturlayout auswählen"
+msgid "Keyboard layout"
+msgstr "Tastaturlayout"
 
-msgid "Select mirror region"
-msgstr "Mirror-region auswählen"
+msgid "Mirror region"
+msgstr "Mirror-region"
 
-msgid "Select locale language"
-msgstr "Lokale Sprache auswählen"
+msgid "Locale language"
+msgstr "Lokale Sprache"
 
-msgid "Select locale encoding"
-msgstr "Lokale Kodierung auswählen"
+msgid "Locale encoding"
+msgstr "Lokale Kodierung"
 
-msgid "Select harddrives"
-msgstr "Laufwerke auswählen"
+msgid "Drives"
+msgstr "Laufwerke"
 
 msgid "Select disk layout"
 msgstr "Laufwerke-layout auswählen"
@@ -261,37 +261,37 @@ msgstr "Laufwerke-layout auswählen"
 msgid "Set encryption password"
 msgstr "Verschlüsselungspasswort angeben"
 
-msgid "Use swap"
-msgstr "Swap benützen"
+msgid "Swap"
+msgstr "Swap"
 
-msgid "Select bootloader"
-msgstr "Bootloader auswählen"
+msgid "Bootloader"
+msgstr "Bootloader"
 
-msgid "Set root password"
-msgstr "Root Passwort wählen"
+msgid "root password"
+msgstr "Root Passwort"
 
-msgid "Specify superuser account"
-msgstr "Superuser Konto wählen"
+msgid "Superuser account"
+msgstr "Superuser Konto"
 
-msgid "Specify user account"
-msgstr "Benutzerkonto wählen"
+msgid "User account"
+msgstr "Benutzerkonto"
 
-msgid "Specify profile"
-msgstr "Profile auswählen"
+msgid "Profile"
+msgstr "Profile"
 
-msgid "Select audio"
-msgstr "Audio auswählen"
+msgid "Audio"
+msgstr "Audio"
 
-msgid "Select kernels"
-msgstr "Kernel auswählen"
+msgid "Kernels"
+msgstr "Kernels"
 
-msgid "Additional packages to install"
-msgstr "Zus. Packete für die Installation"
+msgid "Additional packages"
+msgstr "Zus. Packete"
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr "Netzwerkonfiguration"
 
-msgid "Set automatic time sync (NTP)"
+msgid "Automatic time sync (NTP)"
 msgstr "Autom. Zeitsynchronisierung (NTP)"
 
 msgid "Install ({} config(s) missing)"
@@ -338,14 +338,14 @@ msgstr "Bitte wählen Sie einen Dateisystemtyp für die Partition aus"
 msgid "Abort"
 msgstr "Abbrechen"
 
-msgid "Specify hostname"
-msgstr "Hostnamen wählen"
+msgid "Hostname"
+msgstr "Hostnamen"
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr "Nicht konfiguriert, unverfügbar wenn nicht selber eingestellt"
 
-msgid "Select timezone"
-msgstr "Zeitzone wählen"
+msgid "Timezone"
+msgstr "Zeitzone"
 
 msgid "Set/Modify the below options"
 msgstr "Setzen sie die unten stehenden Einstellungen"
@@ -526,8 +526,8 @@ msgstr "Das gewählte Passwort ist sehr schwach,"
 msgid "are you sure you want to use it?"
 msgstr "wollen sie dieses wirklich verwenden?"
 
-msgid "Additional repositories to enable"
-msgstr "Zus. Repositories einzuschalten"
+msgid "Additional repositories"
+msgstr "Zus. Repositories"
 
 msgid "Save configuration"
 msgstr "Konfiguration speichern"

--- a/archinstall/locales/de/LC_MESSAGES/base.po
+++ b/archinstall/locales/de/LC_MESSAGES/base.po
@@ -526,7 +526,7 @@ msgstr "Das gewählte Passwort ist sehr schwach,"
 msgid "are you sure you want to use it?"
 msgstr "wollen sie dieses wirklich verwenden?"
 
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr "Zus. Repositories"
 
 msgid "Save configuration"

--- a/archinstall/locales/de/LC_MESSAGES/base.po
+++ b/archinstall/locales/de/LC_MESSAGES/base.po
@@ -252,7 +252,7 @@ msgstr "Lokale Sprache"
 msgid "Locale encoding"
 msgstr "Lokale Kodierung"
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr "Laufwerke"
 
 msgid "Select disk layout"

--- a/archinstall/locales/de/LC_MESSAGES/base.po
+++ b/archinstall/locales/de/LC_MESSAGES/base.po
@@ -183,7 +183,7 @@ msgstr "Bitte wählen sie was mit dem ausgewählten Gerät geschehen soll"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Dies ist eine Liste von bereits programmierten Profilen, diese ermöglichen es einfacher Desktop Umgebungen einzustellen"
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr "Bitte wählen sie ein Tastaturlayout aus"
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/en/LC_MESSAGES/base.po
+++ b/archinstall/locales/en/LC_MESSAGES/base.po
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr ""
 
-msgid "Select Archinstall language"
+msgid "Archinstall language"
 msgstr ""
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
@@ -156,7 +156,7 @@ msgstr ""
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr ""
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr ""
 
 msgid "Select one of the regions to download packages from"
@@ -210,19 +210,19 @@ msgstr ""
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr ""
 
-msgid "Select keyboard layout"
+msgid "Keyboard layout"
 msgstr ""
 
-msgid "Select mirror region"
+msgid "Mirror region"
 msgstr ""
 
-msgid "Select locale language"
+msgid "Locale language"
 msgstr ""
 
-msgid "Select locale encoding"
+msgid "Locale encoding"
 msgstr ""
 
-msgid "Select harddrives"
+msgid "Drives"
 msgstr ""
 
 msgid "Select disk layout"
@@ -231,37 +231,37 @@ msgstr ""
 msgid "Set encryption password"
 msgstr ""
 
-msgid "Use swap"
+msgid "Swap"
 msgstr ""
 
-msgid "Select bootloader"
+msgid "Bootloader"
 msgstr ""
 
-msgid "Set root password"
+msgid "root password"
 msgstr ""
 
-msgid "Specify superuser account"
+msgid "Superuser account"
 msgstr ""
 
-msgid "Specify user account"
+msgid "User account"
 msgstr ""
 
-msgid "Specify profile"
+msgid "Profile"
 msgstr ""
 
-msgid "Select audio"
+msgid "Audio"
 msgstr ""
 
-msgid "Select kernels"
+msgid "Kernels"
 msgstr ""
 
-msgid "Additional packages to install"
+msgid "Additional packages"
 msgstr ""
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr ""
 
-msgid "Set automatic time sync (NTP)"
+msgid "Automatic time sync (NTP)"
 msgstr ""
 
 msgid "Install ({} config(s) missing)"
@@ -304,13 +304,13 @@ msgstr ""
 msgid "Abort"
 msgstr ""
 
-msgid "Specify hostname"
+msgid "Hostname"
 msgstr ""
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr ""
 
-msgid "Select timezone"
+msgid "Timezone"
 msgstr ""
 
 msgid "Set/Modify the below options"
@@ -479,7 +479,7 @@ msgstr ""
 msgid "are you sure you want to use it?"
 msgstr ""
 
-msgid "Additional repositories to enable"
+msgid "Additional repositories"
 msgstr ""
 
 msgid "Save configuration"

--- a/archinstall/locales/en/LC_MESSAGES/base.po
+++ b/archinstall/locales/en/LC_MESSAGES/base.po
@@ -479,7 +479,7 @@ msgstr ""
 msgid "are you sure you want to use it?"
 msgstr ""
 
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr ""
 
 msgid "Save configuration"

--- a/archinstall/locales/en/LC_MESSAGES/base.po
+++ b/archinstall/locales/en/LC_MESSAGES/base.po
@@ -156,7 +156,7 @@ msgstr ""
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr ""
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr ""
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/en/LC_MESSAGES/base.po
+++ b/archinstall/locales/en/LC_MESSAGES/base.po
@@ -222,7 +222,7 @@ msgstr ""
 msgid "Locale encoding"
 msgstr ""
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr ""
 
 msgid "Select disk layout"

--- a/archinstall/locales/es/LC_MESSAGES/base.po
+++ b/archinstall/locales/es/LC_MESSAGES/base.po
@@ -39,7 +39,7 @@ msgid "Should this user be a superuser (sudoer)?"
 msgstr "Debería este usuario ser un superusuario (sudoer)?"
 
 msgid "Select a timezone"
-msgstr "Selecciona una zona horaria"
+msgstr "Zona horaria"
 
 msgid "Would you like to use GRUB as a bootloader instead of systemd-boot?"
 msgstr "Te gustaría usar GRUB como gestor de arranque en lugar de systemd-boot?"
@@ -168,8 +168,8 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr "Escriba el tipo de sistema de archivos que desea para la partición: "
 
-msgid "Select Archinstall language"
-msgstr "Selecciona el idioma de Archinstall"
+msgid "Archinstall language"
+msgstr "Idioma de Archinstall"
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
 msgstr "Limpiar todos los discos seleccionados y usar una distribución de particiones por defecto"
@@ -183,7 +183,7 @@ msgstr "Selecciona qué quieres hacer con los dispositivos de bloque seleccionad
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Esta es una lista de perfiles pre-programados, pueden facilitar la instalación de aplicaciones como entornos de escritorio"
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr "Selecciona la distribución del teclado"
 
 msgid "Select one of the regions to download packages from"
@@ -240,20 +240,20 @@ msgstr "Error: Enlistar perfiles en la URL \"{}\" resultó en:"
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr "Error: No se pudo decodificar el resultado \"{}\" como JSON:"
 
-msgid "Select keyboard layout"
-msgstr "Selecciona la distribución del teclado"
+msgid "Keyboard layout"
+msgstr "Distribución del teclado"
 
-msgid "Select mirror region"
-msgstr "Selecciona la región del mirror"
+msgid "Mirror region"
+msgstr "Región del mirror"
 
-msgid "Select locale language"
-msgstr "Selecciona el idioma local"
+msgid "Locale language"
+msgstr "Idioma local"
 
-msgid "Select locale encoding"
-msgstr "Selecciona la codificación local"
+msgid "Locale encoding"
+msgstr "Codificación local"
 
-msgid "Select harddrives"
-msgstr "Selecciona los discos duros"
+msgid "Drives"
+msgstr "Discos duros"
 
 msgid "Select disk layout"
 msgstr "Selecciona la distribución de los discos"
@@ -261,38 +261,38 @@ msgstr "Selecciona la distribución de los discos"
 msgid "Set encryption password"
 msgstr "Establecer la contraseña de cifrado"
 
-msgid "Use swap"
-msgstr "Usar swap"
+msgid "Swap"
+msgstr "Swap"
 
-msgid "Select bootloader"
-msgstr "Selecciona el cargador de arranque"
+msgid "Bootloader"
+msgstr "Cargador de arranque"
 
-msgid "Set root password"
-msgstr "Establecer la contraseña de root"
+msgid "root password"
+msgstr "Contraseña de root"
 
-msgid "Specify superuser account"
-msgstr "Especificar la cuenta de superusuario"
+msgid "Superuser account"
+msgstr "Cuenta de superusuario"
 
-msgid "Specify user account"
-msgstr "Especificar la cuenta de usuario"
+msgid "User account"
+msgstr "Cuenta de usuario"
 
-msgid "Specify profile"
-msgstr "Especificar el perfil"
+msgid "Profile"
+msgstr "Perfil"
 
-msgid "Select audio"
-msgstr "Selecciona el audio"
+msgid "Audio"
+msgstr "Audio"
 
-msgid "Select kernels"
-msgstr "Selecciona los kernels"
+msgid "Kernels"
+msgstr "Kernels"
 
-msgid "Additional packages to install"
-msgstr "Paquetes adicionales a instalar"
+msgid "Additional packages"
+msgstr "Paquetes adicionales"
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr "Configurar la red"
 
-msgid "Set automatic time sync (NTP)"
-msgstr "Establecer la sincronización automática de hora (NTP)"
+msgid "Automatic time sync (NTP)"
+msgstr "Sincronización automática de hora (NTP)"
 
 msgid "Install ({} config(s) missing)"
 msgstr "Instalar ({} ajuste(s) faltantes)"
@@ -338,13 +338,13 @@ msgstr "Establecer el sistema de archivos deseado para una partición"
 msgid "Abort"
 msgstr "Cancelar"
 
-msgid "Specify hostname"
-msgstr "Especificar el nombre del host"
+msgid "Hostname"
+msgstr "Nombre del host"
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr "No configurado, no disponible a menos que se configure manualmente"
 
-msgid "Select timezone"
+msgid "Timezone"
 msgstr "Selecciona la zona horaria"
 
 msgid "Set/Modify the below options"
@@ -524,8 +524,8 @@ msgstr "La contraseña que está utilizando parece ser débil,"
 msgid "are you sure you want to use it?"
 msgstr "¿Estás seguro de que quieres usarlo?"
 
-msgid "Additional repositories to enable"
-msgstr "Repositorios adicionales para habilitar"
+msgid "Additional repositories"
+msgstr "Repositorios adicionales"
 
 msgid "Save configuration"
 msgstr "Guardar configuración"

--- a/archinstall/locales/es/LC_MESSAGES/base.po
+++ b/archinstall/locales/es/LC_MESSAGES/base.po
@@ -524,7 +524,7 @@ msgstr "La contraseña que está utilizando parece ser débil,"
 msgid "are you sure you want to use it?"
 msgstr "¿Estás seguro de que quieres usarlo?"
 
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr "Repositorios adicionales"
 
 msgid "Save configuration"

--- a/archinstall/locales/es/LC_MESSAGES/base.po
+++ b/archinstall/locales/es/LC_MESSAGES/base.po
@@ -183,7 +183,7 @@ msgstr "Selecciona qué quieres hacer con los dispositivos de bloque seleccionad
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Esta es una lista de perfiles pre-programados, pueden facilitar la instalación de aplicaciones como entornos de escritorio"
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr "Selecciona la distribución del teclado"
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/es/LC_MESSAGES/base.po
+++ b/archinstall/locales/es/LC_MESSAGES/base.po
@@ -252,7 +252,7 @@ msgstr "Idioma local"
 msgid "Locale encoding"
 msgstr "Codificación local"
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr "Discos duros"
 
 msgid "Select disk layout"

--- a/archinstall/locales/fr/LC_MESSAGES/base.po
+++ b/archinstall/locales/fr/LC_MESSAGES/base.po
@@ -623,7 +623,7 @@ msgstr "Le mot de passe que vous utilisez semble faible,"
 msgid "are you sure you want to use it?"
 msgstr "êtes-vous sûr de vouloir l'utiliser ?"
 
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr "Référentiels supplémentaires"
 
 msgid "Save configuration"

--- a/archinstall/locales/fr/LC_MESSAGES/base.po
+++ b/archinstall/locales/fr/LC_MESSAGES/base.po
@@ -212,8 +212,8 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr "Entrer un type de système de fichiers souhaité pour la partition : "
 
-msgid "Select Archinstall language"
-msgstr "Sélectionner la langue d'Archinstall"
+msgid "Archinstall language"
+msgstr "Langue d'Archinstall"
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
 msgstr ""
@@ -238,7 +238,7 @@ msgstr ""
 "Ceci est une liste de profils préprogrammés, ils pourraient faciliter "
 "l'installation d'outils comme les environnements de bureau"
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr "Sélectionner la disposition du clavier"
 
 msgid "Select one of the regions to download packages from"
@@ -313,20 +313,20 @@ msgstr "Erreur : la liste des profils sur l'URL \"{}\" a entraîné :"
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr "Erreur : Impossible de décoder le résultat \"{}\" en tant que JSON :"
 
-msgid "Select keyboard layout"
-msgstr "Sélectionner la disposition du clavier"
+msgid "Keyboard layout"
+msgstr "Disposition du clavier"
 
-msgid "Select mirror region"
-msgstr "Sélectionner la région miroir"
+msgid "Mirror region"
+msgstr "Région miroir"
 
-msgid "Select locale language"
-msgstr "Sélectionner la langue locale"
+msgid "Locale language"
+msgstr "Langue locale"
 
-msgid "Select locale encoding"
-msgstr "Sélectionner l'encodage des paramètres régionaux"
+msgid "Locale encoding"
+msgstr "Encodage des paramètres régionaux"
 
-msgid "Select harddrives"
-msgstr "Sélectionner les disques durs"
+msgid "Drives"
+msgstr "Disques durs"
 
 msgid "Select disk layout"
 msgstr "Sélectionner la disposition du disque"
@@ -334,38 +334,38 @@ msgstr "Sélectionner la disposition du disque"
 msgid "Set encryption password"
 msgstr "Définir le mot de passe de chiffrement"
 
-msgid "Use swap"
-msgstr "Utiliser swap (partition d'échange)"
+msgid "Swap"
+msgstr "Swap"
 
-msgid "Select bootloader"
-msgstr "Sélectionner le chargeur de démarrage"
+msgid "Bootloader"
+msgstr "Chargeur de démarrage"
 
-msgid "Set root password"
-msgstr "Définir le mot de passe root"
+msgid "root password"
+msgstr "Mot de passe root"
 
-msgid "Specify superuser account"
-msgstr "Spécifier le compte superutilisateur"
+msgid "Superuser account"
+msgstr "Compte superutilisateur"
 
-msgid "Specify user account"
-msgstr "Spécifier le compte utilisateur"
+msgid "User account"
+msgstr "Compte utilisateur"
 
-msgid "Specify profile"
-msgstr "Spécifier le profil"
+msgid "Profile"
+msgstr "Profil"
 
-msgid "Select audio"
-msgstr "Sélectionner l'audio"
+msgid "Audio"
+msgstr "Audio"
 
-msgid "Select kernels"
-msgstr "Sélectionner les noyaux"
+msgid "Kernels"
+msgstr "Noyaux"
 
-msgid "Additional packages to install"
-msgstr "Packages supplémentaires à installer"
+msgid "Additional packages"
+msgstr "Packages supplémentaires"
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr "Configurer le réseau"
 
-msgid "Set automatic time sync (NTP)"
-msgstr "Définir la synchronisation automatique de l'heure (NTP)"
+msgid "Automatic time sync (NTP)"
+msgstr "Synchronisation automatique de l'heure (NTP)"
 
 msgid "Install ({} config(s) missing)"
 msgstr "Installer ({} configuration(s) manquante(s))"
@@ -413,14 +413,14 @@ msgstr "Définir le système de fichiers souhaité pour une partition"
 msgid "Abort"
 msgstr "Abandonner"
 
-msgid "Specify hostname"
-msgstr "Spécifier le nom d'hôte"
+msgid "Hostname"
+msgstr "Nom d'hôte"
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr "Non configuré, indisponible sauf configuration manuelle"
 
-msgid "Select timezone"
-msgstr "Sélectionner le fuseau horaire"
+msgid "Timezone"
+msgstr "Fuseau horaire"
 
 msgid "Set/Modify the below options"
 msgstr "Définir/Modifier les options ci-dessous"
@@ -623,8 +623,8 @@ msgstr "Le mot de passe que vous utilisez semble faible,"
 msgid "are you sure you want to use it?"
 msgstr "êtes-vous sûr de vouloir l'utiliser ?"
 
-msgid "Additional repositories to enable"
-msgstr "Référentiels supplémentaires à activer"
+msgid "Additional repositories"
+msgstr "Référentiels supplémentaires"
 
 msgid "Save configuration"
 msgstr "Enregistrer la configuration"

--- a/archinstall/locales/fr/LC_MESSAGES/base.po
+++ b/archinstall/locales/fr/LC_MESSAGES/base.po
@@ -238,7 +238,7 @@ msgstr ""
 "Ceci est une liste de profils préprogrammés, ils pourraient faciliter "
 "l'installation d'outils comme les environnements de bureau"
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr "Sélectionner la disposition du clavier"
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/fr/LC_MESSAGES/base.po
+++ b/archinstall/locales/fr/LC_MESSAGES/base.po
@@ -325,7 +325,7 @@ msgstr "Langue locale"
 msgid "Locale encoding"
 msgstr "Encodage des paramètres régionaux"
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr "Disques durs"
 
 msgid "Select disk layout"

--- a/archinstall/locales/nl/LC_MESSAGES/base.po
+++ b/archinstall/locales/nl/LC_MESSAGES/base.po
@@ -169,8 +169,8 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr "Voer de naam in van het gewenste bestandssysteem: "
 
-msgid "Select Archinstall language"
-msgstr "Kies een Archinstall-taal"
+msgid "Archinstall language"
+msgstr "Archinstall-taal"
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
 msgstr "Alle geselecteerde schijven formatteren en best mogelijke partitie-indeling gebruiken"
@@ -184,7 +184,7 @@ msgstr "Geef aan wat er moet worden gedaan met de gekozen blokapparaten"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Dit is een vooraf opgestelde lijst met profielen, welke het installeren van zaken als werkomgevingen vereenvoudigt"
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr "Kies een toetsenbordindeling"
 
 msgid "Select one of the regions to download packages from"
@@ -241,20 +241,20 @@ msgstr "Foutmelding: het opsommen van de profielen op {} leidde tot"
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr "Foutmelding: ‘{}’ kan niet gedecodeerd worden als json:"
 
-msgid "Select keyboard layout"
-msgstr "Kies een toetsenbordindeling"
+msgid "Keyboard layout"
+msgstr "Toetsenbordindeling"
 
-msgid "Select mirror region"
-msgstr "Kies een spiegelserverregio"
+msgid "Mirror region"
+msgstr "Spiegelserverregio"
 
-msgid "Select locale language"
-msgstr "Kies een taal"
+msgid "Locale language"
+msgstr "Taal"
 
-msgid "Select locale encoding"
-msgstr "Kies een taalvariant"
+msgid "Locale encoding"
+msgstr "Taalvariant"
 
-msgid "Select harddrives"
-msgstr "Selecteer de harde schijven"
+msgid "Drives"
+msgstr "Harde schijven"
 
 msgid "Select disk layout"
 msgstr "Kies een schijfindeling"
@@ -262,38 +262,38 @@ msgstr "Kies een schijfindeling"
 msgid "Set encryption password"
 msgstr "Versleutelwachtwoord instellen"
 
-msgid "Use swap"
-msgstr "Wisselgeheugen gebruiken"
+msgid "Swap"
+msgstr "Wisselgeheugen"
 
-msgid "Select bootloader"
-msgstr "Kies een opstartlader"
+msgid "Bootloader"
+msgstr "Opstartlader"
 
-msgid "Set root password"
-msgstr "Rootwachtwoord instellen"
+msgid "root password"
+msgstr "Rootwachtwoord"
 
-msgid "Specify superuser account"
-msgstr "Geef aan welk account superuserrechten dient te hebben"
+msgid "Superuser account"
+msgstr "Superuserrechten"
 
-msgid "Specify user account"
-msgstr "Kies een gebruikersaccount"
+msgid "User account"
+msgstr "Gebruikersaccount"
 
-msgid "Specify profile"
-msgstr "Kies een profiel"
+msgid "Profile"
+msgstr "Profiel"
 
-msgid "Select audio"
-msgstr "Kies audio"
+msgid "Audio"
+msgstr "Audio"
 
-msgid "Select kernels"
-msgstr "Selecteer kernels"
+msgid "Kernels"
+msgstr "Kernels"
 
-msgid "Additional packages to install"
-msgstr "Aanvullende te installeren pakketten"
+msgid "Additional packages"
+msgstr "Aanvullende pakketten"
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr "Netwerk instellen"
 
-msgid "Set automatic time sync (NTP)"
-msgstr "Automatische tijdsynchronisatie (NTP) gebruiken"
+msgid "Automatic time sync (NTP)"
+msgstr "Automatische tijdsynchronisatie (NTP)"
 
 msgid "Install ({} config(s) missing)"
 msgstr "Installeren ({} confirguratie(s) ontbreekt/ontbreken)"
@@ -339,14 +339,14 @@ msgstr "Gewenste bestandssysteem van partitie instellen"
 msgid "Abort"
 msgstr "Afbreken"
 
-msgid "Specify hostname"
-msgstr "Hostnaam opgeven"
+msgid "Hostname"
+msgstr "Hostnaam"
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr "Niet ingesteld en dus niet beschikbaar, tenzij handmatig ingesteld"
 
-msgid "Select timezone"
-msgstr "Kies een tijdzone"
+msgid "Timezone"
+msgstr "Tijdzone"
 
 msgid "Set/Modify the below options"
 msgstr "Onderstaande opties instellen/aanpassen"
@@ -528,8 +528,8 @@ msgstr "Het gekozen wachtwoord is zwak."
 msgid "are you sure you want to use it?"
 msgstr "Weet u zeker dat u het wilt gebruiken?"
 
-msgid "Additional repositories to enable"
-msgstr "Aanvullende te gebruiken pakketbronnen"
+msgid "Additional repositories"
+msgstr "Aanvullende pakketbronnen"
 
 msgid "Save configuration"
 msgstr "Configuratie vastleggen"

--- a/archinstall/locales/nl/LC_MESSAGES/base.po
+++ b/archinstall/locales/nl/LC_MESSAGES/base.po
@@ -528,7 +528,7 @@ msgstr "Het gekozen wachtwoord is zwak."
 msgid "are you sure you want to use it?"
 msgstr "Weet u zeker dat u het wilt gebruiken?"
 
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr "Aanvullende pakketbronnen"
 
 msgid "Save configuration"

--- a/archinstall/locales/nl/LC_MESSAGES/base.po
+++ b/archinstall/locales/nl/LC_MESSAGES/base.po
@@ -184,7 +184,7 @@ msgstr "Geef aan wat er moet worden gedaan met de gekozen blokapparaten"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Dit is een vooraf opgestelde lijst met profielen, welke het installeren van zaken als werkomgevingen vereenvoudigt"
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr "Kies een toetsenbordindeling"
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/nl/LC_MESSAGES/base.po
+++ b/archinstall/locales/nl/LC_MESSAGES/base.po
@@ -253,7 +253,7 @@ msgstr "Taal"
 msgid "Locale encoding"
 msgstr "Taalvariant"
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr "Harde schijven"
 
 msgid "Select disk layout"

--- a/archinstall/locales/pl/LC_MESSAGES/base.po
+++ b/archinstall/locales/pl/LC_MESSAGES/base.po
@@ -251,7 +251,7 @@ msgstr "Locale języka"
 msgid "Locale encoding"
 msgstr "Locale kodowania"
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr "Dyski twarde"
 
 msgid "Select disk layout"

--- a/archinstall/locales/pl/LC_MESSAGES/base.po
+++ b/archinstall/locales/pl/LC_MESSAGES/base.po
@@ -182,7 +182,7 @@ msgstr "Wybierz, co chcesz zrobić z wybranymi urządzeniami blokowymi"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "To jest lista wstępnie zaprogramowanych profili, które mogą ułatwić instalację takich rzeczy jak środowiska graficzne"
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr "Wybierz układ klawiatury"
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/pl/LC_MESSAGES/base.po
+++ b/archinstall/locales/pl/LC_MESSAGES/base.po
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr "Wprowadź typ systemu plików dla partycji: "
 
-msgid "Select Archinstall language"
-msgstr "Wybierz język Archinstall"
+msgid "Archinstall language"
+msgstr "Język Archinstall"
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
 msgstr "Wymaż wszystkie wybrane dyski i użyj najlepszego domyślnego układu partycji"
@@ -182,7 +182,7 @@ msgstr "Wybierz, co chcesz zrobić z wybranymi urządzeniami blokowymi"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "To jest lista wstępnie zaprogramowanych profili, które mogą ułatwić instalację takich rzeczy jak środowiska graficzne"
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr "Wybierz układ klawiatury"
 
 msgid "Select one of the regions to download packages from"
@@ -239,20 +239,20 @@ msgstr "Błąd: Lista profili z URL \"{}\":"
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr "Błąd: Nie można dekodować \"{}\" jako JSON:"
 
-msgid "Select keyboard layout"
-msgstr "Wybierz układ klawiatury"
+msgid "Keyboard layout"
+msgstr "Układ klawiatury"
 
-msgid "Select mirror region"
-msgstr "Wybierz region lustra"
+msgid "Mirror region"
+msgstr "Region lustra"
 
-msgid "Select locale language"
-msgstr "Wybierz locale języka"
+msgid "Locale language"
+msgstr "Locale języka"
 
-msgid "Select locale encoding"
-msgstr "Wybierz locale kodowania"
+msgid "Locale encoding"
+msgstr "Locale kodowania"
 
-msgid "Select harddrives"
-msgstr "Wybierz dyski twarde"
+msgid "Drives"
+msgstr "Dyski twarde"
 
 msgid "Select disk layout"
 msgstr "Wybierz układ dysku"
@@ -260,38 +260,38 @@ msgstr "Wybierz układ dysku"
 msgid "Set encryption password"
 msgstr "Ustaw hasło szyfrowania"
 
-msgid "Use swap"
-msgstr "Użyj swap-u"
+msgid "Swap"
+msgstr "Swap"
 
-msgid "Select bootloader"
-msgstr "Wybierz program rozruchowy (bootloader)"
+msgid "Bootloader"
+msgstr "Program rozruchowy"
 
-msgid "Set root password"
-msgstr "Ustaw hasło administratora"
+msgid "root password"
+msgstr "Hasło root"
 
-msgid "Specify superuser account"
-msgstr "Określ konto superużytkownika"
+msgid "Superuser account"
+msgstr "Konto superużytkownika"
 
-msgid "Specify user account"
-msgstr "Określ konto użytkownika"
+msgid "User account"
+msgstr "Konto użytkownika"
 
-msgid "Specify profile"
-msgstr "Określ profil"
+msgid "Profile"
+msgstr "Profil"
 
-msgid "Select audio"
-msgstr "Wybierz audio"
+msgid "Audio"
+msgstr "Audio"
 
-msgid "Select kernels"
-msgstr "Wybierz jądra"
+msgid "Kernels"
+msgstr "Jądra"
 
-msgid "Additional packages to install"
-msgstr "Dodatkowe pakiety do instalacji"
+msgid "Additional packages"
+msgstr "Dodatkowe pakiety"
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr "Konfiguracja sieci"
 
-msgid "Set automatic time sync (NTP)"
-msgstr "Ustawianie automatycznej synchronizacji czasu (NTP)"
+msgid "Automatic time sync (NTP)"
+msgstr "Automatycznej synchronizacji czasu (NTP)"
 
 msgid "Install ({} config(s) missing)"
 msgstr "Zainstaluj ({} brakuje konfiguracji)"
@@ -337,14 +337,14 @@ msgstr "Ustaw system plików dla partycji"
 msgid "Abort"
 msgstr "Anuluj"
 
-msgid "Specify hostname"
-msgstr "Podaj nazwę hosta"
+msgid "Hostname"
+msgstr "Nazwę hosta"
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr "Nie skonfigurowana, niedostępna, chyba że zostanie skonfigurowana ręcznie"
 
-msgid "Select timezone"
-msgstr "Wybierz strefe czasową"
+msgid "Timezone"
+msgstr "Strefe czasową"
 
 msgid "Set/Modify the below options"
 msgstr "Ustaw/zmodyfikuj poniższe opcje"
@@ -523,8 +523,8 @@ msgstr "Używane przez Ciebie hasło wydaje się być słabe,"
 msgid "are you sure you want to use it?"
 msgstr "czy na pewno chcesz go używać?"
 
-msgid "Additional repositories to enable"
-msgstr "Dodatkowe repozytoria do włączenia"
+msgid "Additional repositories"
+msgstr "Dodatkowe repozytoria"
 
 msgid "Save configuration"
 msgstr "Zapisz konfiguracje"

--- a/archinstall/locales/pl/LC_MESSAGES/base.po
+++ b/archinstall/locales/pl/LC_MESSAGES/base.po
@@ -523,7 +523,7 @@ msgstr "Używane przez Ciebie hasło wydaje się być słabe,"
 msgid "are you sure you want to use it?"
 msgstr "czy na pewno chcesz go używać?"
 
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr "Dodatkowe repozytoria"
 
 msgid "Save configuration"

--- a/archinstall/locales/pt/LC_MESSAGES/base.po
+++ b/archinstall/locales/pt/LC_MESSAGES/base.po
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr "Escreve o tipo de sistema de ficheiros desejado para a partição: "
 
-msgid "Select Archinstall language"
-msgstr "Seleciona o idioma do Archinstall"
+msgid "Archinstall language"
+msgstr "Idioma do Archinstall"
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
 msgstr "Limpar todos os discos selecionados e usar um esquema de partições padrão de melhor desempenho"
@@ -182,7 +182,7 @@ msgstr "Seleciona o que desejas fazer com os dispositivos de bloco selecionados"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Esta é uma lista de perfis pré-programados, podem facilitar a instalação de ambientes de trabalho"
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr "Seleciona o esquema de teclado"
 
 msgid "Select one of the regions to download packages from"
@@ -239,20 +239,20 @@ msgstr "Erro: Listando os perfis em URL \"{}\" resulta em:"
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr "Erro: Não foi possível decodificar \"{}\" como JSON:"
 
-msgid "Select keyboard layout"
-msgstr "Seleciona o esquema do teclado"
+msgid "Keyboard layout"
+msgstr "Esquema do teclado"
 
-msgid "Select mirror region"
-msgstr "Seleciona a região do mirror"
+msgid "Mirror region"
+msgstr "Região do mirror"
 
-msgid "Select locale language"
-msgstr "Seleciona o idioma de localização"
+msgid "Locale language"
+msgstr "Idioma de localização"
 
-msgid "Select locale encoding"
-msgstr "Seleciona a codificação de localização"
+msgid "Locale encoding"
+msgstr "Codificação de localização"
 
-msgid "Select harddrives"
-msgstr "Seleciona os discos rígidos"
+msgid "Drives"
+msgstr "Discos rígidos"
 
 msgid "Select disk layout"
 msgstr "Seleciona o esquema de disco"
@@ -260,38 +260,38 @@ msgstr "Seleciona o esquema de disco"
 msgid "Set encryption password"
 msgstr "Define a palavra-passe de encriptação"
 
-msgid "Use swap"
-msgstr "Usar swap"
+msgid "Swap"
+msgstr "Swap"
 
-msgid "Select bootloader"
-msgstr "Seleciona o carregador de arranque (bootloader)"
+msgid "Bootloader"
+msgstr "Carregador de arranque"
 
-msgid "Set root password"
-msgstr "Define a palavra-passe de root"
+msgid "root password"
+msgstr "Palavra-passe de root"
 
-msgid "Specify superuser account"
-msgstr "Especifica a conta de superusuário"
+msgid "Superuser account"
+msgstr "Conta de superusuário"
 
-msgid "Specify user account"
-msgstr "Especifica a conta de usuário"
+msgid "User account"
+msgstr "Conta de usuário"
 
-msgid "Specify profile"
-msgstr "Especifica o perfil"
+msgid "Profile"
+msgstr "Perfil"
 
-msgid "Select audio"
-msgstr "Seleciona o áudio"
+msgid "Audio"
+msgstr "Áudio"
 
-msgid "Select kernels"
-msgstr "Seleciona os kernels"
+msgid "Kernels"
+msgstr "Kernels"
 
-msgid "Additional packages to install"
-msgstr "Pacotes adicionais para instalar"
+msgid "Additional packages"
+msgstr "Pacotes adicionais"
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr "Configuração de rede"
 
-msgid "Set automatic time sync (NTP)"
-msgstr "Define a sincronização automática de tempo (NTP)"
+msgid "Automatic time sync (NTP)"
+msgstr "Sincronização automática de tempo (NTP)"
 
 msgid "Install ({} config(s) missing)"
 msgstr "Instalar ({} configuração(s) em falta)"
@@ -337,14 +337,14 @@ msgstr "Definir o sistema de ficheiros desejado para uma partição"
 msgid "Abort"
 msgstr "Cancelar"
 
-msgid "Specify hostname"
-msgstr "Especificar nome do computador (hostname)"
+msgid "Hostname"
+msgstr "Nome do computador"
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr "Não configurado, indisponível a não ser que seja configurado manualmente"
 
-msgid "Select timezone"
-msgstr "Selecionar fuso horário"
+msgid "Timezone"
+msgstr "Fuso horário"
 
 msgid "Set/Modify the below options"
 msgstr "Definir/Modificar as opções abaixo"
@@ -541,8 +541,8 @@ msgid "are you sure you want to use it?"
 msgstr "tens a certeza que quer usar?"
 
 #, fuzzy
-msgid "Additional repositories to enable"
-msgstr "Repositórios adicionais a ativar"
+msgid "Additional repositories"
+msgstr "Repositórios adicionais"
 
 msgid "Save configuration"
 msgstr "Guardar configuração"

--- a/archinstall/locales/pt/LC_MESSAGES/base.po
+++ b/archinstall/locales/pt/LC_MESSAGES/base.po
@@ -182,7 +182,7 @@ msgstr "Seleciona o que desejas fazer com os dispositivos de bloco selecionados"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Esta é uma lista de perfis pré-programados, podem facilitar a instalação de ambientes de trabalho"
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr "Seleciona o esquema de teclado"
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/pt/LC_MESSAGES/base.po
+++ b/archinstall/locales/pt/LC_MESSAGES/base.po
@@ -251,7 +251,7 @@ msgstr "Idioma de localização"
 msgid "Locale encoding"
 msgstr "Codificação de localização"
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr "Discos rígidos"
 
 msgid "Select disk layout"

--- a/archinstall/locales/pt/LC_MESSAGES/base.po
+++ b/archinstall/locales/pt/LC_MESSAGES/base.po
@@ -541,7 +541,7 @@ msgid "are you sure you want to use it?"
 msgstr "tens a certeza que quer usar?"
 
 #, fuzzy
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr "Repositórios adicionais"
 
 msgid "Save configuration"

--- a/archinstall/locales/ru/LC_MESSAGES/base.po
+++ b/archinstall/locales/ru/LC_MESSAGES/base.po
@@ -253,7 +253,7 @@ msgstr "Язык локали"
 msgid "Locale encoding"
 msgstr "Кодировку локали"
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr "Жесткие диски"
 
 msgid "Select disk layout"

--- a/archinstall/locales/ru/LC_MESSAGES/base.po
+++ b/archinstall/locales/ru/LC_MESSAGES/base.po
@@ -169,8 +169,8 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr "Введите желаемый тип файловой системы для раздела: "
 
-msgid "Select Archinstall language"
-msgstr "Выберите язык Archinstall"
+msgid "Archinstall language"
+msgstr "Язык Archinstall"
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
 msgstr "Стереть все выбранные диски и использовать оптимальную схему разделов по умолчанию"
@@ -184,7 +184,7 @@ msgstr "Выберите, что вы хотите сделать с выбра�
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Это список предварительно запрограммированных профилей, они могут облегчить установку таких вещей, как окружения рабочего стола"
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr "Выберите раскладку клавиатуры"
 
 msgid "Select one of the regions to download packages from"
@@ -241,20 +241,20 @@ msgstr "Ошибка: Перечисление профилей по URL \"{}\" 
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr "Ошибка: Не удалось декодировать результат \"{}\" как JSON:"
 
-msgid "Select keyboard layout"
-msgstr "Выберите раскладку клавиатуры"
+msgid "Keyboard layout"
+msgstr "Раскладку клавиатуры"
 
-msgid "Select mirror region"
-msgstr "Выберите регион зеркала"
+msgid "Mirror region"
+msgstr "Регион зеркала"
 
-msgid "Select locale language"
-msgstr "Выберите язык локали"
+msgid "Locale language"
+msgstr "Язык локали"
 
-msgid "Select locale encoding"
-msgstr "Выберите кодировку локали"
+msgid "Locale encoding"
+msgstr "Кодировку локали"
 
-msgid "Select harddrives"
-msgstr "Выберите жесткие диски"
+msgid "Drives"
+msgstr "Жесткие диски"
 
 msgid "Select disk layout"
 msgstr "Выберите разметку диска"
@@ -262,38 +262,38 @@ msgstr "Выберите разметку диска"
 msgid "Set encryption password"
 msgstr "Установите пароль шифрования"
 
-msgid "Use swap"
-msgstr "Использовать подкачку"
+msgid "Swap"
+msgstr "Подкачку"
 
-msgid "Select bootloader"
-msgstr "Выберите загрузчик"
+msgid "Bootloader"
+msgstr "Загрузчик"
 
-msgid "Set root password"
-msgstr "Установите пароль root"
+msgid "root password"
+msgstr "Пароль root"
 
-msgid "Specify superuser account"
-msgstr "Укажите учетную запись суперпользователя"
+msgid "Superuser account"
+msgstr "Учетную запись суперпользователя"
 
-msgid "Specify user account"
-msgstr "Укажите учетную запись пользователя"
+msgid "User account"
+msgstr "Учетную запись пользователя"
 
-msgid "Specify profile"
-msgstr "Укажите профиль"
+msgid "Profile"
+msgstr "Профиль"
 
-msgid "Select audio"
-msgstr "Выберите аудиоустройство"
+msgid "Audio"
+msgstr "Аудиоустройство"
 
-msgid "Select kernels"
-msgstr "Выберите ядра"
+msgid "Kernels"
+msgstr "Ядра"
 
-msgid "Additional packages to install"
-msgstr "Дополнительные пакеты для установки"
+msgid "Additional packages"
+msgstr "Дополнительные пакеты"
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr "Настройте сеть"
 
-msgid "Set automatic time sync (NTP)"
-msgstr "Установить автоматическую синхронизацию времени (NTP)"
+msgid "Automatic time sync (NTP)"
+msgstr "Автоматическая синхронизация времени (NTP)"
 
 msgid "Install ({} config(s) missing)"
 msgstr "Установить ({} конфигурация(и) отсутствует)"
@@ -339,14 +339,14 @@ msgstr "Установите желаемую файловую систему д
 msgid "Abort"
 msgstr "Прервать"
 
-msgid "Specify hostname"
-msgstr "Укажите имя хоста"
+msgid "Hostname"
+msgstr "Имя хоста"
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr "Не настроен, недоступен, если не настроен вручную"
 
-msgid "Select timezone"
-msgstr "Выберите часовой пояс"
+msgid "Timezone"
+msgstr "Часовой пояс"
 
 msgid "Set/Modify the below options"
 msgstr "Установить/изменить следующие параметры"
@@ -527,8 +527,8 @@ msgstr "Пароль, который вы используете, кажется
 msgid "are you sure you want to use it?"
 msgstr "вы уверены, что хотите его использовать?"
 
-msgid "Additional repositories to enable"
-msgstr "Включить дополнительные репозитории"
+msgid "Additional repositories"
+msgstr "Дополнительные репозитории"
 
 msgid "Save configuration"
 msgstr "Сохранить конфигурацию"

--- a/archinstall/locales/ru/LC_MESSAGES/base.po
+++ b/archinstall/locales/ru/LC_MESSAGES/base.po
@@ -184,7 +184,7 @@ msgstr "Выберите, что вы хотите сделать с выбра�
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Это список предварительно запрограммированных профилей, они могут облегчить установку таких вещей, как окружения рабочего стола"
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr "Выберите раскладку клавиатуры"
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/ru/LC_MESSAGES/base.po
+++ b/archinstall/locales/ru/LC_MESSAGES/base.po
@@ -527,7 +527,7 @@ msgstr "Пароль, который вы используете, кажется
 msgid "are you sure you want to use it?"
 msgstr "вы уверены, что хотите его использовать?"
 
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr "Дополнительные репозитории"
 
 msgid "Save configuration"

--- a/archinstall/locales/sv/LC_MESSAGES/base.po
+++ b/archinstall/locales/sv/LC_MESSAGES/base.po
@@ -253,7 +253,7 @@ msgstr "Språk du vill använda"
 msgid "Locale encoding"
 msgstr "Teckenuppsättning du vill använda"
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr "Hårddiskar"
 
 msgid "Select disk layout"

--- a/archinstall/locales/sv/LC_MESSAGES/base.po
+++ b/archinstall/locales/sv/LC_MESSAGES/base.po
@@ -538,7 +538,7 @@ msgid "are you sure you want to use it?"
 msgstr "Vill du verkligen avbryta?"
 
 #, fuzzy
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr "Extra förråden"
 
 msgid "Save configuration"

--- a/archinstall/locales/sv/LC_MESSAGES/base.po
+++ b/archinstall/locales/sv/LC_MESSAGES/base.po
@@ -169,8 +169,8 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr "Mata in ett önskat filsystem för partitionen: "
 
-msgid "Select Archinstall language"
-msgstr "Välj språk för detta gränssnitt"
+msgid "Archinstall language"
+msgstr "Språk för detta gränssnitt"
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
 msgstr "Töm alla partitioner och använd en generiskt rekommenderad partitionslayout."
@@ -184,7 +184,7 @@ msgstr "Välj vad du önskar göra med valda hårddiskarna"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Detta är en lista med förprogrammerade profiler, dom kan göra installation av exempelvis skrivbordsmiljöer lite enklare."
 
-msgid "Select Keyboard layout"
+msgid "Choose keyboard layout"
 msgstr "Välj tangentbordslayout"
 
 msgid "Select one of the regions to download packages from"
@@ -241,20 +241,20 @@ msgstr "Fel: Listning av profiler på \"{}\" resulterade i: "
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr "Fel: Kunde inte tyda \"{}\" resultatet som JSON:"
 
-msgid "Select keyboard layout"
-msgstr "Välj en tangentbordslayout"
+msgid "Keyboard layout"
+msgstr "Tangentbordslayout"
 
-msgid "Select mirror region"
-msgstr "Välj en region för paketsynk"
+msgid "Mirror region"
+msgstr "Region för paketsynk"
 
-msgid "Select locale language"
-msgstr "Välj vilket språk du vill använda"
+msgid "Locale language"
+msgstr "Språk du vill använda"
 
-msgid "Select locale encoding"
-msgstr "Välj vilken teckenuppsättning du vill använda"
+msgid "Locale encoding"
+msgstr "Teckenuppsättning du vill använda"
 
-msgid "Select harddrives"
-msgstr "Välj hårddiskar"
+msgid "Drives"
+msgstr "Hårddiskar"
 
 msgid "Select disk layout"
 msgstr "Välj hårddisk-layout"
@@ -262,38 +262,38 @@ msgstr "Välj hårddisk-layout"
 msgid "Set encryption password"
 msgstr "Välj ett krypterings-lösenord"
 
-msgid "Use swap"
-msgstr "Använda 'swap'?"
+msgid "Swap"
+msgstr "Swap"
 
-msgid "Select bootloader"
-msgstr "Välj en boot-loader"
+msgid "Bootloader"
+msgstr "Boot-loader"
 
-msgid "Set root password"
-msgstr "Välj ett root-lösenord"
+msgid "root password"
+msgstr "Root-lösenord"
 
-msgid "Specify superuser account"
-msgstr "Skapa superanvändar-konto"
+msgid "Superuser account"
+msgstr "Superanvändar-konto"
 
-msgid "Specify user account"
-msgstr "Skapa användarkonto"
+msgid "User account"
+msgstr "Användarkonto"
 
-msgid "Specify profile"
-msgstr "Välj en profil"
+msgid "Profile"
+msgstr "Profil"
 
-msgid "Select audio"
-msgstr "Välj ljud mjukvara"
+msgid "Audio"
+msgstr "Ljud mjukvara"
 
-msgid "Select kernels"
-msgstr "Välj Linux-kernel"
+msgid "Kernels"
+msgstr "Linux-kernels"
 
-msgid "Additional packages to install"
-msgstr "Välj extra paket att installera"
+msgid "Additional packages"
+msgstr "Extra paket"
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr "Konfigurera nätverk"
 
-msgid "Set automatic time sync (NTP)"
-msgstr "Aktivera automatisk tidssynk (NTP)"
+msgid "Automatic time sync (NTP)"
+msgstr "Automatisk tidssynk (NTP)"
 
 msgid "Install ({} config(s) missing)"
 msgstr "Installera ({} inställningar saknas)"
@@ -339,14 +339,14 @@ msgstr "Sätt önskat filsystem för partitionen"
 msgid "Abort"
 msgstr "Avbryt"
 
-msgid "Specify hostname"
-msgstr "Sätt ett önskat 'hostname'"
+msgid "Hostname"
+msgstr "Hostname"
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr "Inte konfigurerad, otillgängligt utan manuell konfigurering"
 
-msgid "Select timezone"
-msgstr "Välj en tidszon"
+msgid "Timezone"
+msgstr "Tidszon"
 
 msgid "Set/Modify the below options"
 msgstr "Sätt eller modifiera nedan alternativ"
@@ -538,8 +538,8 @@ msgid "are you sure you want to use it?"
 msgstr "Vill du verkligen avbryta?"
 
 #, fuzzy
-msgid "Additional repositories to enable"
-msgstr "Välj extra paket att installera"
+msgid "Additional repositories"
+msgstr "Extra förråden"
 
 msgid "Save configuration"
 msgstr ""

--- a/archinstall/locales/sv/LC_MESSAGES/base.po
+++ b/archinstall/locales/sv/LC_MESSAGES/base.po
@@ -184,7 +184,7 @@ msgstr "Välj vad du önskar göra med valda hårddiskarna"
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "Detta är en lista med förprogrammerade profiler, dom kan göra installation av exempelvis skrivbordsmiljöer lite enklare."
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr "Välj tangentbordslayout"
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/ur/LC_MESSAGES/base.po
+++ b/archinstall/locales/ur/LC_MESSAGES/base.po
@@ -253,7 +253,7 @@ msgstr "مقامی زبان"
 msgid "Locale encoding"
 msgstr "مقامی انکوڈنگ"
 
-msgid "Drives"
+msgid "Drive(s)"
 msgstr "ہارڈ ڈرائیوز"
 
 msgid "Select disk layout"

--- a/archinstall/locales/ur/LC_MESSAGES/base.po
+++ b/archinstall/locales/ur/LC_MESSAGES/base.po
@@ -183,7 +183,7 @@ msgstr "انتخاب کریں کہ آپ منتخب بلاک ڈیوائسز کے 
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "یہ پہلے سے پروگرام شدہ پروفائلز کی فہرست ہے، وہ ڈیسک ٹاپ انسٹالیشن جیسی چیزوں کو آسان بناتے ہیں"
 
-msgid "Choose keyboard layout"
+msgid "Select keyboard layout"
 msgstr "کی بورڈ لے آؤٹ"
 
 msgid "Select one of the regions to download packages from"

--- a/archinstall/locales/ur/LC_MESSAGES/base.po
+++ b/archinstall/locales/ur/LC_MESSAGES/base.po
@@ -168,8 +168,8 @@ msgstr ""
 msgid "Enter a desired filesystem type for the partition: "
 msgstr "اس پارٹیشن کے لیے مطلوبہ فائل سسٹم درج کریں"
 
-msgid "Select Archinstall language"
-msgstr "آرچ انسٹال کے لیے زبان کا انتخاب کریں"
+msgid "Archinstall language"
+msgstr "آرچ انسٹال کے لیے زبان"
 
 msgid "Wipe all selected drives and use a best-effort default partition layout"
 msgstr "تمام منتخب ڈرائیوز کو صاف کریں اور ایک بہترین ڈیفالٹ پارٹیشن لے آؤٹ استعمال کریں"
@@ -183,8 +183,8 @@ msgstr "انتخاب کریں کہ آپ منتخب بلاک ڈیوائسز کے 
 msgid "This is a list of pre-programmed profiles, they might make it easier to install things like desktop environments"
 msgstr "یہ پہلے سے پروگرام شدہ پروفائلز کی فہرست ہے، وہ ڈیسک ٹاپ انسٹالیشن جیسی چیزوں کو آسان بناتے ہیں"
 
-msgid "Select Keyboard layout"
-msgstr "کی بورڈ لے آؤٹ کو منتخب کریں"
+msgid "Choose keyboard layout"
+msgstr "کی بورڈ لے آؤٹ"
 
 msgid "Select one of the regions to download packages from"
 msgstr "پیکیجز ڈاؤن لوڈ کرنے کے لیے علاقوں میں سے ایک کو منتخب کریں"
@@ -241,20 +241,20 @@ msgstr "خرابی: URL \"{}\" پر پروفائلز کی فہرست بنانے 
 msgid "Error: Could not decode \"{}\" result as JSON:"
 msgstr "خرابی: \"{}\" نتیجہ کو JSON کے بطور ڈی کوڈ نہیں کیا جا سکا:"
 
-msgid "Select keyboard layout"
+msgid "Keyboard layout"
 msgstr "کی بورڈ لے آؤٹ کو منتخب کریں"
 
-msgid "Select mirror region"
-msgstr "متبادل علاقہ منتخب کریں"
+msgid "Mirror region"
+msgstr "متبادل علاقہ"
 
-msgid "Select locale language"
-msgstr "منتخب کریں کہ کون سی مقامی زبان استعمال کرنی ہے"
+msgid "Locale language"
+msgstr "مقامی زبان"
 
-msgid "Select locale encoding"
-msgstr "منتخب کریں کہ کون سا مقامی انکوڈنگ استعمال کرنا ہے"
+msgid "Locale encoding"
+msgstr "مقامی انکوڈنگ"
 
-msgid "Select harddrives"
-msgstr "ہارڈ ڈرائیوز کو منتخب کریں"
+msgid "Drives"
+msgstr "ہارڈ ڈرائیوز"
 
 msgid "Select disk layout"
 msgstr "ڈسک لے آؤٹ کو منتخب کریں"
@@ -262,38 +262,38 @@ msgstr "ڈسک لے آؤٹ کو منتخب کریں"
 msgid "Set encryption password"
 msgstr "انکرپشن پاس ورڈ سیٹ کریں"
 
-msgid "Use swap"
-msgstr "سواپ کا استعمال کریں"
+msgid "Swap"
+msgstr "سواپ"
 
-msgid "Select bootloader"
-msgstr "بوٹ لوڈرکا انتخاب کریں"
+msgid "Bootloader"
+msgstr "بوٹ لوڈر"
 
-msgid "Set root password"
-msgstr "روٹ پاس ورڈ سیٹ کریں"
+msgid "root password"
+msgstr "روٹ پاس ورڈ"
 
-msgid "Specify superuser account"
-msgstr "سپر یوزر اکاؤنٹ کی وضاحت کریں"
+msgid "Superuser account"
+msgstr "سپر یوزر اکاؤنٹ"
 
-msgid "Specify user account"
-msgstr "یوزر اکاؤنٹ کی وضاحت کریں"
+msgid "User account"
+msgstr "یوزر اکاؤنٹ"
 
-msgid "Specify profile"
-msgstr "پروفائل کی وضاحت کریں"
+msgid "Profile"
+msgstr "پروفائل"
 
-msgid "Select audio"
-msgstr "آڈیو کا انتخاب کریں"
+msgid "Audio"
+msgstr "آڈیو"
 
-msgid "Select kernels"
-msgstr "کرنلز منتخب کریں"
+msgid "Kernels"
+msgstr "کرنلز"
 
-msgid "Additional packages to install"
-msgstr "انسٹال کرنے کے لیے اضافی پیکجز"
+msgid "Additional packages"
+msgstr "اضافی پیکجز"
 
-msgid "Configure network"
+msgid "Network configuration"
 msgstr "نیٹ ورک ترتیب دیں"
 
-msgid "Set automatic time sync (NTP)"
-msgstr "خودکار وقت کی مطابقت  سیٹ کریں (NTP)"
+msgid "Automatic time sync (NTP)"
+msgstr "خودکار وقت کی مطابقت (NTP)"
 
 msgid "Install ({} config(s) missing)"
 msgstr "انسٹال کریں ({} کنفیگریشنز غائب ہیں)"
@@ -339,14 +339,14 @@ msgstr "اس پارٹیشن کے لیے مطلوبہ فائل سسٹم درج ک
 msgid "Abort"
 msgstr "ختم کریں"
 
-msgid "Specify hostname"
-msgstr "میزبان نام کی وضاحت کریں"
+msgid "Hostname"
+msgstr "میزبان نام"
 
 msgid "Not configured, unavailable unless setup manually"
 msgstr "کنفیگر نہیں، دستیاب نہیں جب تک کہ دستی طور پر سیٹ اپ نہ کیا جائے"
 
-msgid "Select timezone"
-msgstr "ٹائم زون کا انتخاب کریں"
+msgid "Timezone"
+msgstr "ٹائم زون"
 
 msgid "Set/Modify the below options"
 msgstr "ذیل کے اختیارات کو سیٹ/ترمیم کریں"
@@ -528,8 +528,8 @@ msgstr "آپ جو پاس ورڈ استعمال کر رہے ہیں وہ کمزو�
 msgid "are you sure you want to use it?"
 msgstr "کیا آپ واقعی اسے استعمال کرنا چاہتے ہیں؟"
 
-msgid "Additional repositories to enable"
-msgstr "اضافی ریپوزٹریزکو فعال"
+msgid "Additional repositories"
+msgstr "اضافی ریپوزٹریز"
 
 msgid "Save configuration"
 msgstr "ترتیب کو محفوظ کریں"

--- a/archinstall/locales/ur/LC_MESSAGES/base.po
+++ b/archinstall/locales/ur/LC_MESSAGES/base.po
@@ -528,7 +528,7 @@ msgstr "آپ جو پاس ورڈ استعمال کر رہے ہیں وہ کمزو�
 msgid "are you sure you want to use it?"
 msgstr "کیا آپ واقعی اسے استعمال کرنا چاہتے ہیں؟"
 
-msgid "Additional repositories"
+msgid "Optional repositories"
 msgstr "اضافی ریپوزٹریز"
 
 msgid "Save configuration"

--- a/examples/swiss.py
+++ b/examples/swiss.py
@@ -160,7 +160,7 @@ class SetupMenu(archinstall.GeneralMenu):
 	def _setup_selection_menu_options(self):
 		self.set_option('archinstall-language',
 			archinstall.Selector(
-				_('Select Archinstall language'),
+				_('Archinstall language'),
 				lambda x: self._select_archinstall_language(x),
 				default='English',
 				enabled=True))


### PR DESCRIPTION
The motivation behind this cumbersome PR were:
1. In a YouTube video,  that archinstall was being reviewed, the person was complaining that menu items are very long. This is actually very true even more so for romantic languages. Entries go to next line which makes it not great to look at, especially on smaller screens!
2. Locating setting easier. There are a lot of entries that start with 'Select' or 'Specify'. These words are redundant. If I am looking, say for mirrors or network config, I would like the entry to start with Mirror and Netwok.