### PR TITLE
Reworking select_encrypted_partitions() to use the new Menu system, 

### DIFF
--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -201,7 +201,7 @@ class GlobalMenu(GeneralMenu):
 
 						partition = storage['arguments']['disk_layouts'][blockdevice]['partitions'][partition_index]
 						partition['encrypted'] = True
-						partition['!password'] = password
+						partition['!password'] = storage['arguments']['!encryption-password']
 
 	def _install_text(self):
 		missing = len(self._missing_configs())

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -193,8 +193,15 @@ class GlobalMenu(GeneralMenu):
 			# If no partitions was marked as encrypted, but a password was supplied and we have some disks to format..
 			# Then we need to identify which partitions to encrypt. This will default to / (root).
 			if len(list(encrypted_partitions(storage['arguments'].get('disk_layouts', [])))) == 0:
-				storage['arguments']['disk_layouts'] = select_encrypted_partitions(
-					storage['arguments']['disk_layouts'], storage['arguments']['!encryption-password'])
+				for blockdevice in storage['arguments']['disk_layouts']:
+					for partition_index in select_encrypted_partitions(
+							title="Select which partitions to encrypt:",
+							partitions=storage['arguments']['disk_layouts'][blockdevice]['partitions']
+						):
+
+						partition = storage['arguments']['disk_layouts'][blockdevice]['partitions'][partition_index]
+						partition['encrypted'] = True
+						partition['!password'] = password
 
 	def _install_text(self):
 		missing = len(self._missing_configs())

--- a/archinstall/lib/user_interaction/partitioning_conf.py
+++ b/archinstall/lib/user_interaction/partitioning_conf.py
@@ -360,19 +360,42 @@ def manage_new_and_existing_partitions(block_device: 'BlockDevice') -> Dict[str,
 
 	return block_device_struct
 
+def select_encrypted_partitions(
+	title :str,
+	partitions :List[Partition],
+	multiple :bool = True,
+	filter_ :Callable = None
+) -> Optional[int, List[int]]:
+	partition_indexes = _get_partitions(partitions, filter_)
 
-def select_encrypted_partitions(block_devices: dict, password: str) -> dict:
-	for device in block_devices:
-		for partition in block_devices[device]['partitions']:
-			if partition.get('mountpoint', None) != '/boot':
-				partition['encrypted'] = True
-				partition['!password'] = password
+	if len(partition_indexes) == 0:
+		return None
 
-				if not has_mountpoint(partition,'/'):
-					# Tell the upcoming steps to generate a key-file for non root mounts.
-					partition['generate-encryption-key-file'] = True
+	choice = Menu(title, partitions, multi=multiple).run()
 
-	return block_devices
+	if choice.type_ == MenuSelectionType.Esc:
+		return None
 
-	# TODO: Next version perhaps we can support mixed multiple encrypted partitions
-	# Users might want to single out a partition for non-encryption to share between dualboot etc.
+	if isinstance(choice.value, list):
+		for partition in choice.value:
+			print(partition)
+	else:
+		print(choice.value)
+
+	exit(0)
+
+# def select_encrypted_partitions(block_devices: dict, password: str) -> dict:
+# 	for device in block_devices:
+# 		for partition in block_devices[device]['partitions']:
+# 			if partition.get('mountpoint', None) != '/boot':
+# 				partition['encrypted'] = True
+# 				partition['!password'] = password
+
+# 				if not has_mountpoint(partition,'/'):
+# 					# Tell the upcoming steps to generate a key-file for non root mounts.
+# 					partition['generate-encryption-key-file'] = True
+
+# 	return block_devices
+
+# 	# TODO: Next version perhaps we can support mixed multiple encrypted partitions
+# 	# Users might want to single out a partition for non-encryption to share between dualboot etc.

--- a/archinstall/lib/user_interaction/partitioning_conf.py
+++ b/archinstall/lib/user_interaction/partitioning_conf.py
@@ -8,7 +8,6 @@ from ..menu.menu import MenuSelectionType
 from ..output import log
 
 from ..disk.validators import fs_types
-from ..disk.helpers import has_mountpoint
 
 if TYPE_CHECKING:
 	from ..disk import BlockDevice

--- a/archinstall/lib/user_interaction/partitioning_conf.py
+++ b/archinstall/lib/user_interaction/partitioning_conf.py
@@ -271,6 +271,7 @@ def manage_new_and_existing_partitions(block_device: 'BlockDevice') -> Dict[str,
 						block_device_struct["partitions"][partition]["filesystem"]["mount_options"].append("compress=zstd")
 			elif task == delete_all_partitions:
 				block_device_struct["partitions"] = []
+				block_device_struct["wipe"] = True
 			elif task == assign_mount_point:
 				title = _('{}\n\nSelect by index which partition to mount where').format(current_layout)
 				partition = select_partition(title, block_device_struct["partitions"])
@@ -371,18 +372,22 @@ def select_encrypted_partitions(
 	if len(partition_indexes) == 0:
 		return None
 
-	choice = Menu(title, partitions, multi=multiple).run()
+	title = _('Select which partitions to mark for formatting:')
+
+	# show current partition layout:
+	if len(partitions):
+		title += _current_partition_layout(partitions) + '\n'
+
+	choice = Menu(title, partition_indexes, multi=multiple).run()
 
 	if choice.type_ == MenuSelectionType.Esc:
 		return None
 
 	if isinstance(choice.value, list):
-		for partition in choice.value:
-			print(partition)
+		for partition_index in choice.value:
+			yield int(partition_index)
 	else:
-		print(choice.value)
-
-	exit(0)
+		yield (partition_index)
 
 # def select_encrypted_partitions(block_devices: dict, password: str) -> dict:
 # 	for device in block_devices:

--- a/archinstall/lib/user_interaction/partitioning_conf.py
+++ b/archinstall/lib/user_interaction/partitioning_conf.py
@@ -387,19 +387,3 @@ def select_encrypted_partitions(
 			yield int(partition_index)
 	else:
 		yield (partition_index)
-
-# def select_encrypted_partitions(block_devices: dict, password: str) -> dict:
-# 	for device in block_devices:
-# 		for partition in block_devices[device]['partitions']:
-# 			if partition.get('mountpoint', None) != '/boot':
-# 				partition['encrypted'] = True
-# 				partition['!password'] = password
-
-# 				if not has_mountpoint(partition,'/'):
-# 					# Tell the upcoming steps to generate a key-file for non root mounts.
-# 					partition['generate-encryption-key-file'] = True
-
-# 	return block_devices
-
-# 	# TODO: Next version perhaps we can support mixed multiple encrypted partitions
-# 	# Users might want to single out a partition for non-encryption to share between dualboot etc.


### PR DESCRIPTION
This will allow granularity and not blindly marking all partitions to be encrypted.
Note: This code only happens if the guided partitioning tool was used and manual partitions were set-up, but no partitions were marked for encryption BUT in the main menu a encryption password was set.

This fix #1197 