### PR TITLE
Added PIN support for FIDO2 devices

### DIFF
--- a/archinstall/lib/hsm/fido.py
+++ b/archinstall/lib/hsm/fido.py
@@ -1,5 +1,6 @@
 import typing
 import pathlib
+import getpass
 from ..general import SysCommand, SysCommandWorker, clear_vt100_escape_codes
 from ..disk.partition import Partition
 
@@ -41,7 +42,12 @@ def get_fido2_devices() -> typing.Dict[str, typing.Dict[str, str]]:
 def fido2_enroll(hsm_device_path :pathlib.Path, partition :Partition, password :str) -> bool:
 	worker = SysCommandWorker(f"systemd-cryptenroll --fido2-device={hsm_device_path} {partition.real_device}", peak_output=True)
 	pw_inputted = False
+	pin_inputted = False
 	while worker.is_alive():
 		if pw_inputted is False and bytes(f"please enter current passphrase for disk {partition.real_device}", 'UTF-8') in worker._trace_log.lower():
 			worker.write(bytes(password, 'UTF-8'))
 			pw_inputted = True
+
+		elif pin_inputted is False and bytes(f"please enter security token pin") in worker._trace_log.lower():
+			worker.write(bytes(getpass.getpass(), 'UTF-8'))
+			pin_inputted = True

--- a/archinstall/lib/hsm/fido.py
+++ b/archinstall/lib/hsm/fido.py
@@ -1,8 +1,10 @@
 import typing
 import pathlib
 import getpass
+import logging
 from ..general import SysCommand, SysCommandWorker, clear_vt100_escape_codes
 from ..disk.partition import Partition
+from ..general import log
 
 def get_fido2_devices() -> typing.Dict[str, typing.Dict[str, str]]:
 	"""
@@ -48,6 +50,8 @@ def fido2_enroll(hsm_device_path :pathlib.Path, partition :Partition, password :
 			worker.write(bytes(password, 'UTF-8'))
 			pw_inputted = True
 
-		elif pin_inputted is False and bytes(f"please enter security token pin") in worker._trace_log.lower():
-			worker.write(bytes(getpass.getpass(), 'UTF-8'))
+		elif pin_inputted is False and bytes(f"please enter security token pin", 'UTF-8') in worker._trace_log.lower():
+			worker.write(bytes(getpass.getpass(" "), 'UTF-8'))
 			pin_inputted = True
+
+			log(f"You might need to touch the FIDO2 device to unlock it if no prompt comes up after 3 seconds.", level=logging.INFO, fg="yellow")


### PR DESCRIPTION
This enables PIN support for FIDO2 devices.
I've only tested with the same hardware I tested the initial FIDO2 support with, but added a pin.

Other hardware might be different.