### PR TITLE
Clarify info message about profile installation

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1019,7 +1019,7 @@ class Installer:
 		if type(profile) == str:
 			profile = Profile(self, profile)
 
-		self.log(f'Installing network profile {profile}', level=logging.INFO)
+		self.log(f'Installing archinstall profile {profile}', level=logging.INFO)
 		return profile.install()
 
 	def enable_sudo(self, entity: str, group :bool = False) -> bool:


### PR DESCRIPTION
Short and sweet :)
I was a bit confused about a message concerning "Installing **network profile** Profile{kde}".
I've replaced the word "network profile" with the word "archinstall profile"