### PR TITLE
Unsafe build command?

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you want to test a commit, branch or bleeding edge release from the repositor
 you can replace the version of archinstall with a new version and run that with the steps described below:
 
 1. You need a working network connection
-2. Install the build requirements with `pacman -Sy; pacman -S git python-pip`
+2. Install the build requirements with `pacman -Syu && pacman -S git python-pip`
    *(note that this may or may not work depending on your RAM and current state of the squashfs maximum filesystem free space)*
 3. Uninstall the previous version of archinstall with `pip uninstall archinstall`
 4. Now clone the latest repository with `git clone https://github.com/archlinux/archinstall`


### PR DESCRIPTION
1. Warning: When installing packages in Arch, avoid refreshing the package list without upgrading the system (for example, when a package is no longer found in the official repositories). In practice, do not run pacman -Sy package_name instead of pacman -Syu package_name, as this could lead to dependency issues. See System maintenance#Partial upgrades are unsupported and BBS#89328.

2. Also the command uses ";" which could cause problems if the first argument of the command fails, (it will go onto the installing without updating, could cause download without update). Using && would fix this because if the first one fails the second wont run.

3. You probably have it like this for a reason, but just want to make sure.