### PR TITLE
Remove unneeded packages from awesome profile?

### DIFF
--- a/profiles/awesome.py
+++ b/profiles/awesome.py
@@ -7,9 +7,6 @@ is_top_level_profile = False
 # New way of defining packages for a profile, which is iterable and can be used out side
 # of the profile to get a list of "what packages will be installed".
 __packages__ = [
-	"nemo",
-	"gpicview",
-	"maim",
 	"alacritty",
 ]
 


### PR DESCRIPTION
This profile currently installs a nemo - file manager, gpicview - image viewer, and maim - screenshot taker. all of these items do not typically come with awesome and aren't awesome specific and should be installed by the user. (also not required for the system to work). Especially since these are not even the most popular tools for each use.