### PR TITLE
Fix MapperDev.subvolumes

### DIFF
--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -112,8 +112,8 @@ def subvolume_info_from_path(path :pathlib.Path) -> Optional[BtrfsSubvolume]:
 
 		return BtrfsSubvolume(**{'full_path' : path, 'name' : subvolume_name, **result})
 
-	except SysCallError:
-		pass
+	except SysCallError as error:
+		log(f"Could not retrieve subvolume information from {path}: {error}", level=logging.WARNING, fg="orange")
 
 	return None
 

--- a/archinstall/lib/disk/mapperdev.py
+++ b/archinstall/lib/disk/mapperdev.py
@@ -78,9 +78,7 @@ class MapperDev:
 	def subvolumes(self) -> Iterator['BtrfsSubvolume']:
 		from .btrfs import subvolume_info_from_path
 
-		print(self.mount_information)
-		
 		for mountpoint in self.mount_information:
 			if target := mountpoint.get('target'):
-				if subvolume := subvolume_info_from_path(target):
+				if subvolume := subvolume_info_from_path(pathlib.Path(target)):
 					yield subvolume

--- a/archinstall/lib/disk/mapperdev.py
+++ b/archinstall/lib/disk/mapperdev.py
@@ -81,5 +81,6 @@ class MapperDev:
 		print(self.mount_information)
 		
 		for mountpoint in self.mount_information:
-			if subvolume := subvolume_info_from_path(mountpoint):
-				yield subvolume
+			if target := mountpoint.get('target'):
+				if subvolume := subvolume_info_from_path(target):
+					yield subvolume

--- a/archinstall/lib/disk/mapperdev.py
+++ b/archinstall/lib/disk/mapperdev.py
@@ -77,6 +77,8 @@ class MapperDev:
 	@property
 	def subvolumes(self) -> Iterator['BtrfsSubvolume']:
 		from .btrfs import subvolume_info_from_path
+
+		print(self.mount_information)
 		
 		for mountpoint in self.mount_information:
 			if subvolume := subvolume_info_from_path(mountpoint):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -868,8 +868,10 @@ class Installer:
 				else:
 					options_entry = f'rw intel_pstate=no_hwp {" ".join(self.KERNEL_PARAMS)}\n'
 
+				print('Root partition:', root_partition)
+
 				for subvolume in root_partition.subvolumes:
-					print(subvolume, subvolume.root)
+					print('Subvolume:', subvolume, subvolume.root)
 					if subvolume.root is True:
 						options_entry = f"rootflags=subvol={subvolume.name} " + options_entry
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -868,14 +868,9 @@ class Installer:
 				else:
 					options_entry = f'rw intel_pstate=no_hwp {" ".join(self.KERNEL_PARAMS)}\n'
 
-				print('Root partition:', root_partition)
-
 				for subvolume in root_partition.subvolumes:
-					print('Subvolume:', subvolume, subvolume.root)
 					if subvolume.root is True:
 						options_entry = f"rootflags=subvol={subvolume.name} " + options_entry
-
-				exit(1)
 
 				# Zswap should be disabled when using zram.
 				#

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -869,8 +869,11 @@ class Installer:
 					options_entry = f'rw intel_pstate=no_hwp {" ".join(self.KERNEL_PARAMS)}\n'
 
 				for subvolume in root_partition.subvolumes:
+					print(subvolume, subvolume.root)
 					if subvolume.root is True:
 						options_entry = f"rootflags=subvol={subvolume.name} " + options_entry
+
+				exit(1)
 
 				# Zswap should be disabled when using zram.
 				#


### PR DESCRIPTION
This fix #1248.
The reason was a silent `try/except` that was getting fed a dictionary instead of a `pathlib.Path` as it was expecting. So `btrfs subvolume show <dict here>` was executed.

This allows `subvolume.root` to be properly found and detected during boot loader entry creation, setting the missing `rootflags=subvol=<name>`.