### PR TITLE
Fix dual-booting

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -293,6 +293,7 @@ class BlockDevice:
 		count = 0
 		while count < 5:
 			for partition_uuid, partition in self.partitions.items():
+				print('Comparing:', [partition.part_uuid.lower(), uuid.lower()])
 				if partition.part_uuid.lower() == uuid.lower():
 					return partition
 			else:

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -306,7 +306,7 @@ class BlockDevice:
 				except DiskError as error:
 					# Most likely a blockdevice that doesn't support or use UUID's
 					# (like Microsoft recovery partition)
-					log(f"Could not get UUID/PARTUUID of {partition}: {error}", level=logging.INFO, fg="gray")
+					log(f"Could not get UUID/PARTUUID of {partition}: {error}", level=logging.DEBUG, fg="gray")
 					pass
 
 			log(f"uuid {uuid} or {partuuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -293,15 +293,12 @@ class BlockDevice:
 		if not uuid and not partuuid:
 			raise ValueError(f"BlockDevice.get_partition() requires either a UUID or a PARTUUID for lookups.")
 
-		print(f'Looking for {uuid}/{partuuid}')
 		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5)):
 			for partition_index, partition in self.partitions.items():
 				try:
 					if uuid and partition.uuid.lower() == uuid.lower():
-						print(f'Found UUID: {partition}')
 						return partition
 					elif partuuid and partition.part_uuid.lower() == partuuid.lower():
-						print(f'Found PARTUUID: {partition}')
 						return partition
 				except DiskError as error:
 					# Most likely a blockdevice that doesn't support or use UUID's
@@ -312,7 +309,7 @@ class BlockDevice:
 			log(f"uuid {uuid} or {partuuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)
 			time.sleep(storage.get('DISK_TIMEOUTS', 1) * count)
 				
-		log(f"Could not find {uuid}/{partuuid} in disk after 5 retries",level=logging.INFO)
-		print(f"Cache: {self.part_cache}")
-		print(f"Partitions: {self.partitions.items()}")
+		log(f"Could not find {uuid}/{partuuid} in disk after 5 retries", level=logging.INFO)
+		log(f"Cache: {self.part_cache}")
+		log(f"Partitions: {self.partitions.items()}")
 		raise DiskError(f"New partition {uuid}/{partuuid} never showed up after adding new partition on {self}")

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -299,9 +299,9 @@ class BlockDevice:
 				log(f"uuid {uuid} not found. Waiting for {count +1} time",level=logging.DEBUG)
 				time.sleep(float(storage['arguments'].get('disk-sleep', 0.2)))
 				count += 1
-		else:
-			log(f"Could not find {uuid} in disk after 5 retries",level=logging.INFO)
-			print(f"Cache: {self.part_cache}")
-			print(f"Partitions: {self.partitions.items()}")
-			print(f"UUID: {[uuid]}")
-			raise DiskError(f"New partition {uuid} never showed up after adding new partition on {self}")
+				
+		log(f"Could not find {uuid} in disk after 5 retries",level=logging.INFO)
+		print(f"Cache: {self.part_cache}")
+		print(f"Partitions: {self.partitions.items()}")
+		print(f"UUID: {[uuid]}")
+		raise DiskError(f"New partition {uuid} never showed up after adding new partition on {self}")

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -289,19 +289,22 @@ class BlockDevice:
 	def flush_cache(self) -> None:
 		self.part_cache = {}
 
-	def get_partition(self, uuid :str) -> Partition:
-		if not uuid:
-			return None
-			
+	def get_partition(self, uuid :Optional[str] = None, partuuid :Optional[str] = None) -> Partition:
+		if not uuid and not partuuid:
+			raise ValueError(f"BlockDevice.get_partition() requires either a UUID or a PARTUUID for lookups.")
+
 		print(f'Looking for {uuid}')
 		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5)):
-			for partition_uuid, partition in self.partitions.items():
-				if partition.uuid.lower() == uuid.lower():
-					print(f'Found: {partition}')
+			for partition_index, partition in self.partitions.items():
+				if uuid and partition.uuid.lower() == uuid.lower():
+					print(f'Found UUID: {partition}')
 					return partition
-			else:
-				log(f"uuid {uuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)
-				time.sleep(storage.get('DISK_TIMEOUTS', 1) * count)
+				elif partuuid and partition.part_uuid.lower() == uuid.lower()::
+					print(f'Found PARTUUID: {partition}')
+					return partition
+				else:
+					log(f"uuid {uuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)
+					time.sleep(storage.get('DISK_TIMEOUTS', 1) * count)
 				
 		log(f"Could not find {uuid} in disk after 5 retries",level=logging.INFO)
 		print(f"Cache: {self.part_cache}")

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -296,6 +296,7 @@ class BlockDevice:
 		print(f'Looking for {uuid}/{partuuid}')
 		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5)):
 			for partition_index, partition in self.partitions.items():
+				print(partition, partition.uuid.lower(), partition.part_uuid.lower())
 				if uuid and partition.uuid.lower() == uuid.lower():
 					print(f'Found UUID: {partition}')
 					return partition

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -291,7 +291,7 @@ class BlockDevice:
 
 	def get_partition(self, uuid :str) -> Partition:
 		print(f'Looking for {uuid}')
-		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5))
+		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5)):
 			for partition_uuid, partition in self.partitions.items():
 				if partition.uuid.lower() == uuid.lower():
 					print(f'Found: {partition}')

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -299,7 +299,7 @@ class BlockDevice:
 				if uuid and partition.uuid.lower() == uuid.lower():
 					print(f'Found UUID: {partition}')
 					return partition
-				elif partuuid and partition.part_uuid.lower() == uuid.lower()::
+				elif partuuid and partition.part_uuid.lower() == uuid.lower():
 					print(f'Found PARTUUID: {partition}')
 					return partition
 				else:

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -290,6 +290,9 @@ class BlockDevice:
 		self.part_cache = {}
 
 	def get_partition(self, uuid :str) -> Partition:
+		if not uuid:
+			return None
+			
 		print(f'Looking for {uuid}')
 		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5)):
 			for partition_uuid, partition in self.partitions.items():

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -303,9 +303,9 @@ class BlockDevice:
 				elif partuuid and partition.part_uuid.lower() == partuuid.lower():
 					print(f'Found PARTUUID: {partition}')
 					return partition
-				else:
-					log(f"uuid {uuid} or {partuuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)
-					time.sleep(storage.get('DISK_TIMEOUTS', 1) * count)
+
+			log(f"uuid {uuid} or {partuuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)
+			time.sleep(storage.get('DISK_TIMEOUTS', 1) * count)
 				
 		log(f"Could not find {uuid}/{partuuid} in disk after 5 retries",level=logging.INFO)
 		print(f"Cache: {self.part_cache}")

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -294,7 +294,7 @@ class BlockDevice:
 		while count < 5:
 			for partition_uuid, partition in self.partitions.items():
 				print('Comparing:', [partition.part_uuid.lower(), uuid.lower()])
-				if partition.part_uuid.lower() == uuid.lower():
+				if partition.uuid.lower() == uuid.lower():
 					return partition
 			else:
 				log(f"uuid {uuid} not found. Waiting for {count +1} time",level=logging.DEBUG)

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -290,16 +290,15 @@ class BlockDevice:
 		self.part_cache = {}
 
 	def get_partition(self, uuid :str) -> Partition:
-		count = 0
-		while count < 5:
+		print(f'Looking for {uuid}')
+		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5))
 			for partition_uuid, partition in self.partitions.items():
-				print('Comparing:', [partition.part_uuid.lower(), uuid.lower()])
 				if partition.uuid.lower() == uuid.lower():
+					print(f'Found: {partition}')
 					return partition
 			else:
-				log(f"uuid {uuid} not found. Waiting for {count +1} time",level=logging.DEBUG)
-				time.sleep(float(storage['arguments'].get('disk-sleep', 0.2)))
-				count += 1
+				log(f"uuid {uuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)
+				time.sleep(storage.get('DISK_TIMEOUTS', 1) * count)
 				
 		log(f"Could not find {uuid} in disk after 5 retries",level=logging.INFO)
 		print(f"Cache: {self.part_cache}")

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -296,13 +296,19 @@ class BlockDevice:
 		print(f'Looking for {uuid}/{partuuid}')
 		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5)):
 			for partition_index, partition in self.partitions.items():
-				print(partition, partition.uuid.lower(), partition.part_uuid.lower())
-				if uuid and partition.uuid.lower() == uuid.lower():
-					print(f'Found UUID: {partition}')
-					return partition
-				elif partuuid and partition.part_uuid.lower() == partuuid.lower():
-					print(f'Found PARTUUID: {partition}')
-					return partition
+				try:
+					print(partition, partition.uuid.lower(), partition.part_uuid.lower())
+					if uuid and partition.uuid.lower() == uuid.lower():
+						print(f'Found UUID: {partition}')
+						return partition
+					elif partuuid and partition.part_uuid.lower() == partuuid.lower():
+						print(f'Found PARTUUID: {partition}')
+						return partition
+				except DiskError as error:
+					# Most likely a blockdevice that doesn't support or use UUID's
+					# (like Microsoft recovery partition)
+					log(f"Could not get UUID/PARTUUID of {partition}: {error}", level=logging.INFO, fg="gray")
+					pass
 
 			log(f"uuid {uuid} or {partuuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)
 			time.sleep(storage.get('DISK_TIMEOUTS', 1) * count)

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -293,21 +293,20 @@ class BlockDevice:
 		if not uuid and not partuuid:
 			raise ValueError(f"BlockDevice.get_partition() requires either a UUID or a PARTUUID for lookups.")
 
-		print(f'Looking for {uuid}')
+		print(f'Looking for {uuid}/{partuuid}')
 		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5)):
 			for partition_index, partition in self.partitions.items():
 				if uuid and partition.uuid.lower() == uuid.lower():
 					print(f'Found UUID: {partition}')
 					return partition
-				elif partuuid and partition.part_uuid.lower() == uuid.lower():
+				elif partuuid and partition.part_uuid.lower() == partuuid.lower():
 					print(f'Found PARTUUID: {partition}')
 					return partition
 				else:
-					log(f"uuid {uuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)
+					log(f"uuid {uuid} or {partuuid} not found. Waiting {storage.get('DISK_TIMEOUTS', 1) * count}s for next attempt",level=logging.DEBUG)
 					time.sleep(storage.get('DISK_TIMEOUTS', 1) * count)
 				
-		log(f"Could not find {uuid} in disk after 5 retries",level=logging.INFO)
+		log(f"Could not find {uuid}/{partuuid} in disk after 5 retries",level=logging.INFO)
 		print(f"Cache: {self.part_cache}")
 		print(f"Partitions: {self.partitions.items()}")
-		print(f"UUID: {[uuid]}")
-		raise DiskError(f"New partition {uuid} never showed up after adding new partition on {self}")
+		raise DiskError(f"New partition {uuid}/{partuuid} never showed up after adding new partition on {self}")

--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -297,7 +297,6 @@ class BlockDevice:
 		for count in range(storage.get('DISK_RETRY_ATTEMPTS', 5)):
 			for partition_index, partition in self.partitions.items():
 				try:
-					print(partition, partition.uuid.lower(), partition.part_uuid.lower())
 					if uuid and partition.uuid.lower() == uuid.lower():
 						print(f'Found UUID: {partition}')
 						return partition

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -208,7 +208,12 @@ class Filesystem:
 	def add_partition(self, partition_type :str, start :str, end :str, partition_format :Optional[str] = None) -> Partition:
 		log(f'Adding partition to {self.blockdevice}, {start}->{end}', level=logging.INFO)
 
-		previous_partition_uuids = {partition.uuid for partition in self.blockdevice.partitions.values()}
+		previous_partition_uuids = []
+		for partition in self.blockdevice.partitions.values():
+			try:
+				previous_partition_uuids.append(partition.uuid)
+			except DiskError:
+				pass
 
 		if self.mode == MBR:
 			if len(self.blockdevice.partitions) > 3:
@@ -225,7 +230,13 @@ class Filesystem:
 			count = 0
 			while count < 10:
 				new_partuuid = None
-				new_partuuid_set = (previous_partition_uuids ^ {partition.uuid for partition in self.blockdevice.partitions.values()})
+				new_partition_uuids = []
+				for partition in self.blockdevice.partitions.values():
+					try:
+						new_partition_uuids.append(partition.uuid)
+					except DiskError:
+						pass
+				new_partuuid_set = (set(previous_partition_uuids) ^ set(new_partition_uuids))
 
 				if len(new_partuuid_set) > 0:
 					new_partuuid = new_partuuid_set.pop()

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -97,7 +97,7 @@ class Filesystem:
 				print(_("Re-using partition instance: {}").format(partition_instance))
 				partition['device_instance'] = partition_instance
 			else:
-				log(f"{self}.load_layout() doesn't know how to work without 'wipe' being set or UUID ({partition.get('PARTUUID')}) was given and found"., fg="yellow", level=logging.WARNING)
+				log(f"{self}.load_layout() doesn't know how to work without 'wipe' being set or UUID ({partition.get('PARTUUID')}) was given and found.", fg="yellow", level=logging.WARNING)
 				continue
 		#		raise ValueError(f"{self}.load_layout() doesn't know how to continue without a new partition definition or a UUID ({partition.get('PARTUUID')}) on the device ({self.blockdevice.get_partition(uuid=partition.get('PARTUUID'))}).")
 

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -93,7 +93,7 @@ class Filesystem:
 				# TODO: device_instance some times become None
 				# print('Device instance:', partition['device_instance'])
 
-			elif (partition_uuid := partition.get('PARTUUID')) and (partition_instance := self.blockdevice.get_partition(uuid=partition_uuid)):
+			elif (partition_uuid := partition.get('PARTUUID')) and (partition_instance := self.blockdevice.get_partition(partuuid=partition_uuid)):
 				print(_("Re-using partition instance: {}").format(partition_instance))
 				partition['device_instance'] = partition_instance
 			else:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -82,7 +82,6 @@ class Filesystem:
 		# We then iterate the partitions in order
 		for partition in layout.get('partitions', []):
 			# We don't want to re-add an existing partition (those containing a UUID already)
-			print(partition)
 			if partition.get('wipe', False) and not partition.get('PARTUUID', None):
 				print(_("Adding partition...."))
 				start = partition.get('start') or (
@@ -98,7 +97,9 @@ class Filesystem:
 				print(_("Re-using partition instance: {}").format(partition_instance))
 				partition['device_instance'] = partition_instance
 			else:
-				raise ValueError(f"{self}.load_layout() doesn't know how to continue without a new partition definition or a UUID ({partition.get('PARTUUID')}) on the device ({self.blockdevice.get_partition(uuid=partition.get('PARTUUID'))}).")
+				log(f"{self}.load_layout() doesn't know how to work without 'wipe' being set or UUID ({partition.get('PARTUUID')}) was given and found"., fg="yellow", level=logging.WARNING)
+				continue
+		#		raise ValueError(f"{self}.load_layout() doesn't know how to continue without a new partition definition or a UUID ({partition.get('PARTUUID')}) on the device ({self.blockdevice.get_partition(uuid=partition.get('PARTUUID'))}).")
 
 			if partition.get('filesystem', {}).get('format', False):
 

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -208,10 +208,10 @@ class Filesystem:
 	def add_partition(self, partition_type :str, start :str, end :str, partition_format :Optional[str] = None) -> Partition:
 		log(f'Adding partition to {self.blockdevice}, {start}->{end}', level=logging.INFO)
 
-		previous_partition_uuids = []
+		previous_partuuids = []
 		for partition in self.blockdevice.partitions.values():
 			try:
-				previous_partition_uuids.append(partition.uuid)
+				previous_partuuids.append(partition.part_uuid)
 			except DiskError:
 				pass
 
@@ -233,17 +233,17 @@ class Filesystem:
 				new_partition_uuids = []
 				for partition in self.blockdevice.partitions.values():
 					try:
-						new_partition_uuids.append(partition.uuid)
+						new_partition_uuids.append(partition.part_uuid)
 					except DiskError:
 						pass
 
-				new_partuuid_set = (set(previous_partition_uuids) ^ set(new_partition_uuids))
+				new_partuuid_set = (set(previous_partuuids) ^ set(new_partition_uuids))
 
-				print(previous_partition_uuids, new_partition_uuids, new_partuuid_set)
+				print(previous_partuuids, new_partition_uuids, new_partuuid_set)
 
 				if len(new_partuuid_set) and (new_partuuid := new_partuuid_set.pop()):
 					try:
-						return self.blockdevice.get_partition(uuid=new_partuuid)
+						return self.blockdevice.get_partition(partuuid=new_partuuid)
 					except Exception as err:
 						log(f'Blockdevice: {self.blockdevice}', level=logging.ERROR, fg="red")
 						log(f'Partitions: {self.blockdevice.partitions}', level=logging.ERROR, fg="red")
@@ -260,8 +260,8 @@ class Filesystem:
 
 		# TODO: This should never be able to happen
 		log(f"Could not find the new PARTUUID after adding the partition.", level=logging.ERROR, fg="red")
-		log(f"Previous partitions: {previous_partition_uuids}", level=logging.ERROR, fg="red")
-		log(f"New partitions: {(previous_partition_uuids ^ {partition.part_uuid for partition in self.blockdevice.partitions.values()})}", level=logging.ERROR, fg="red")
+		log(f"Previous partitions: {previous_partuuids}", level=logging.ERROR, fg="red")
+		log(f"New partitions: {(previous_partuuids ^ {partition.part_uuid for partition in self.blockdevice.partitions.values()})}", level=logging.ERROR, fg="red")
 		raise DiskError(f"Could not add partition using: {parted_string}")
 
 	def set_name(self, partition: int, name: str) -> bool:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -93,7 +93,7 @@ class Filesystem:
 				# TODO: device_instance some times become None
 				# print('Device instance:', partition['device_instance'])
 
-			elif (partition_uuid := partition.get('PARTUUID')) and (partition_instance := self.blockdevice.get_partition(partuuid=partition_uuid)):
+			elif (partition_uuid := partition.get('PARTUUID')) and (partition_instance := self.blockdevice.get_partition(uuid=partition_uuid)):
 				print(_("Re-using partition instance: {}").format(partition_instance))
 				partition['device_instance'] = partition_instance
 			else:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -99,7 +99,7 @@ class Filesystem:
 			else:
 				log(f"{self}.load_layout() doesn't know how to work without 'wipe' being set or UUID ({partition.get('PARTUUID')}) was given and found.", fg="yellow", level=logging.WARNING)
 				continue
-		#		raise ValueError(f"{self}.load_layout() doesn't know how to continue without a new partition definition or a UUID ({partition.get('PARTUUID')}) on the device ({self.blockdevice.get_partition(uuid=partition.get('PARTUUID'))}).")
+				# raise ValueError(f"{self}.load_layout() doesn't know how to continue without a new partition definition or a UUID ({partition.get('PARTUUID')}) on the device ({self.blockdevice.get_partition(uuid=partition.get('PARTUUID'))}).")
 
 			if partition.get('filesystem', {}).get('format', False):
 

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -208,7 +208,7 @@ class Filesystem:
 	def add_partition(self, partition_type :str, start :str, end :str, partition_format :Optional[str] = None) -> Partition:
 		log(f'Adding partition to {self.blockdevice}, {start}->{end}', level=logging.INFO)
 
-		previous_partition_uuids = {partition.part_uuid for partition in self.blockdevice.partitions.values()}
+		previous_partition_uuids = {partition.uuid for partition in self.blockdevice.partitions.values()}
 
 		if self.mode == MBR:
 			if len(self.blockdevice.partitions) > 3:
@@ -224,20 +224,20 @@ class Filesystem:
 		if self.parted(parted_string):
 			count = 0
 			while count < 10:
-				new_uuid = None
-				new_uuid_set = (previous_partition_uuids ^ {partition.part_uuid for partition in self.blockdevice.partitions.values()})
+				new_partuuid = None
+				new_partuuid_set = (previous_partition_uuids ^ {partition.uuid for partition in self.blockdevice.partitions.values()})
 
-				if len(new_uuid_set) > 0:
-					new_uuid = new_uuid_set.pop()
+				if len(new_partuuid_set) > 0:
+					new_partuuid = new_partuuid_set.pop()
 
-				if new_uuid:
+				if new_partuuid:
 					try:
-						return self.blockdevice.get_partition(new_uuid)
+						return self.blockdevice.get_partition(partuuid=new_partuuid)
 					except Exception as err:
 						log(f'Blockdevice: {self.blockdevice}', level=logging.ERROR, fg="red")
 						log(f'Partitions: {self.blockdevice.partitions}', level=logging.ERROR, fg="red")
-						log(f'Partition set: {new_uuid_set}', level=logging.ERROR, fg="red")
-						log(f'New UUID: {[new_uuid]}', level=logging.ERROR, fg="red")
+						log(f'Partition set: {new_partuuid_set}', level=logging.ERROR, fg="red")
+						log(f'New UUID: {[new_partuuid]}', level=logging.ERROR, fg="red")
 						log(f'get_partition(): {self.blockdevice.get_partition}', level=logging.ERROR, fg="red")
 						raise err
 				else:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -229,7 +229,7 @@ class Filesystem:
 		if self.parted(parted_string):
 			for count in range(storage.get('DISK_RETRY_ATTEMPTS', 3)):
 				self.partprobe()
-				
+
 				new_partition_uuids = []
 				for partition in self.blockdevice.partitions.values():
 					try:
@@ -239,7 +239,7 @@ class Filesystem:
 
 				new_partuuid_set = (set(previous_partition_uuids) ^ set(new_partition_uuids))
 
-				print(previous_partition_uuids, new_partuuid_set)
+				print(previous_partition_uuids, new_partition_uuids, new_partuuid_set)
 
 				if len(new_partuuid_set) and (new_partuuid := new_partuuid_set.pop()):
 					try:

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -82,6 +82,7 @@ class Filesystem:
 		# We then iterate the partitions in order
 		for partition in layout.get('partitions', []):
 			# We don't want to re-add an existing partition (those containing a UUID already)
+			print(partition)
 			if partition.get('wipe', False) and not partition.get('PARTUUID', None):
 				print(_("Adding partition...."))
 				start = partition.get('start') or (

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -228,6 +228,8 @@ class Filesystem:
 
 		if self.parted(parted_string):
 			for count in range(storage.get('DISK_RETRY_ATTEMPTS', 3)):
+				self.partprobe()
+				
 				new_partition_uuids = []
 				for partition in self.blockdevice.partitions.values():
 					try:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -101,7 +101,7 @@ class Partition:
 
 		except SysCallError as error:
 			# Not mounted anywhere most likely
-			log(f"Could not locate mount information for {self.path}: {error}", level=logging.DEBUG)
+			log(f"Could not locate mount information for {self.path}: {error}", level=logging.DEBUG, fg="grey")
 			pass
 
 		return None

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -216,7 +216,7 @@ class Partition:
 			if not self.partprobe():
 				raise DiskError(f"Could not perform partprobe on {self.device_path}")
 
-			time.sleep(max(0.1, storage['DISK_TIMEOUTS'] * i))
+			time.sleep(storage.get('DISK_TIMEOUTS', 1) * i)
 
 			partuuid = self._safe_uuid
 			if partuuid:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -318,6 +318,8 @@ class Installer:
 			else:
 				mount_queue[mountpoint] = lambda target=f"{self.target}{mountpoint}": partition['device_instance'].mount(target)
 
+		log(f"Using mount order: {list(sorted(mount_queue.items(), key=lambda item: item[0]))}", level=logging.INFO, fg="white")
+
 		# We mount everything by sorting on the mountpoint itself.
 		for mountpoint, frozen_func in sorted(mount_queue.items(), key=lambda item: item[0]):
 			frozen_func()

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -314,9 +314,9 @@ class Installer:
 
 			if partition.get('filesystem',{}).get('mount_options',[]):
 				mount_options = ','.join(partition['filesystem']['mount_options'])
-				mount_queue[mountpoint] = lambda target=f"{self.target}{mountpoint}", options=mount_options: partition['device_instance'].mount(target, options)
+				mount_queue[mountpoint] = lambda instance=partition['device_instance'], target=f"{self.target}{mountpoint}", options=mount_options: instance.mount(target, options)
 			else:
-				mount_queue[mountpoint] = lambda target=f"{self.target}{mountpoint}": partition['device_instance'].mount(target)
+				mount_queue[mountpoint] = lambda instance=partition['device_instance'], target=f"{self.target}{mountpoint}": instance.mount(target)
 
 		log(f"Using mount order: {list(sorted(mount_queue.items(), key=lambda item: item[0]))}", level=logging.INFO, fg="white")
 

--- a/archinstall/lib/storage.py
+++ b/archinstall/lib/storage.py
@@ -23,7 +23,7 @@ storage: Dict[str, Any] = {
 	'MOUNT_POINT': '/mnt/archinstall',
 	'ENC_IDENTIFIER': 'ainst',
 	'DISK_TIMEOUTS' : 1, # seconds
-	'DISK_RETRY_ATTEMPTS' : 20, # RETRY_ATTEMPTS * DISK_TIMEOUTS is used in disk operations
+	'DISK_RETRY_ATTEMPTS' : 5, # RETRY_ATTEMPTS * DISK_TIMEOUTS is used in disk operations
 	'CMD_LOCALE':{'LC_ALL':'C'}, # default locale for execution commands. Can be overriden with set_cmd_locale()
 	'CMD_LOCALE_DEFAULT':{'LC_ALL':'C'}, # should be the same as the former. Not be used except in reset_cmd_locale()
 }


### PR DESCRIPTION
# Fixes

 * Optimized partition lookups
 * Fixed re-use of partition UUID's
 * `BlockDevice().get_partition()` now supports looking up both `PARTUUID` and `UUID` for a partition under itself
 * Partitions listed in `--disk-layout` that doesn't have a PARTUUID/UUID should no longer cause an exception, but instead logs a warning and they will simply be ignored
 * `Filesystem().add_partition()` now handles `DiskError` raised by `partition.part_uuid`
 * Fixed issue on normal partitions where the device was not properly frozen in `lambda` calls, meaning two or more mount-points shared the same `device_instance`.
 * Lowered global `DISK_RETRY_ATTEMPTS` to 5, as the timeouts are linear *(`range(DISK_RETRY_ATTEMPTS) * DISK_TIMEOUTS`)*