### PR TITLE
Fix mixup of mount options and fstype during mount

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -90,7 +90,7 @@ class Filesystem:
 																	start=start,
 																	end=partition.get('size', '100%'),
 																	partition_format=partition.get('filesystem', {}).get('format', 'btrfs'),
-																	skip_mklabel=layout.get('wipe', False) is False)
+																	skip_mklabel=layout.get('wipe', False) is not False)
 
 			elif (partition_uuid := partition.get('PARTUUID')):
 				# We try to deal with both UUID and PARTUUID of a partition when it's being re-used.

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -89,7 +89,8 @@ class Filesystem:
 				partition['device_instance'] = self.add_partition(partition.get('type', 'primary'),
 																	start=start,
 																	end=partition.get('size', '100%'),
-																	partition_format=partition.get('filesystem', {}).get('format', 'btrfs'))
+																	partition_format=partition.get('filesystem', {}).get('format', 'btrfs'),
+																	skip_mklabel=layout.get('wipe', False) is False)
 
 			elif (partition_uuid := partition.get('PARTUUID')):
 				# We try to deal with both UUID and PARTUUID of a partition when it's being re-used.
@@ -209,10 +210,10 @@ class Filesystem:
 		# TODO: Implement this with declarative profiles instead.
 		raise ValueError("Installation().use_entire_disk() has to be re-worked.")
 
-	def add_partition(self, partition_type :str, start :str, end :str, partition_format :Optional[str] = None) -> Partition:
+	def add_partition(self, partition_type :str, start :str, end :str, partition_format :Optional[str] = None, skip_mklabel :bool = False) -> Partition:
 		log(f'Adding partition to {self.blockdevice}, {start}->{end}', level=logging.INFO)
 
-		if len(self.blockdevice.partitions) == 0:
+		if len(self.blockdevice.partitions) == 0 and skip_mklabel is False:
 			# If it's a completely empty drive, and we're about to add partitions to it
 			# we need to make sure there's a filesystem label.
 			if self.mode == GPT:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -486,6 +486,7 @@ class Partition:
 					raise DiskError(f'Need to format (or define) the filesystem on {self} before mounting.')
 				fs = self.filesystem
 
+			print('**** fs:', fs)
 			fs_type = get_mount_fs_type(fs)
 			print('**** fstype:', fs_type)
 

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -56,6 +56,8 @@ class Partition:
 		if self.filesystem == 'crypto_LUKS':
 			self.encrypted = True
 
+		print('*****', self.filesystem)
+
 	def __lt__(self, left_comparitor :BlockDevice) -> bool:
 		if type(left_comparitor) == Partition:
 			left_comparitor = left_comparitor.path

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -36,6 +36,7 @@ class Partition:
 		self.path = path
 		self.part_id = part_id
 		self.target_mountpoint = mountpoint
+		print('*****', self.filesystem)
 		self.filesystem = filesystem
 		self._encrypted = None
 		self.encrypted = encrypted

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -36,7 +36,7 @@ class Partition:
 		self.path = path
 		self.part_id = part_id
 		self.target_mountpoint = mountpoint
-		print('*****', self.filesystem)
+		print('*****', filesystem)
 		self.filesystem = filesystem
 		self._encrypted = None
 		self.encrypted = encrypted

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -481,6 +481,7 @@ class Partition:
 	def mount(self, target :str, fs :Optional[str] = None, options :str = '') -> bool:
 		if not self.mountpoint:
 			log(f'Mounting {self} to {target}', level=logging.INFO)
+			print('-----', fs)
 			if not fs:
 				if not self.filesystem:
 					raise DiskError(f'Need to format (or define) the filesystem on {self} before mounting.')

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -481,8 +481,6 @@ class Partition:
 	def mount(self, target :str, fs :Optional[str] = None, options :str = '') -> bool:
 		if not self.mountpoint:
 			log(f'Mounting {self} to {target}', level=logging.INFO)
-			if 'compress=zstd' in fs:
-				raise ValueError(f"what?")
 
 			if not fs:
 				if not self.filesystem:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -481,15 +481,15 @@ class Partition:
 	def mount(self, target :str, fs :Optional[str] = None, options :str = '') -> bool:
 		if not self.mountpoint:
 			log(f'Mounting {self} to {target}', level=logging.INFO)
-			print('-----', fs)
+			if 'compressed=zstd' in fs:
+				raise ValueError(f"what?")
+
 			if not fs:
 				if not self.filesystem:
 					raise DiskError(f'Need to format (or define) the filesystem on {self} before mounting.')
 				fs = self.filesystem
 
-			print('**** fs:', fs)
 			fs_type = get_mount_fs_type(fs)
-			print('**** fstype:', fs_type)
 
 			pathlib.Path(target).mkdir(parents=True, exist_ok=True)
 

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -36,7 +36,6 @@ class Partition:
 		self.path = path
 		self.part_id = part_id
 		self.target_mountpoint = mountpoint
-		print('*****', filesystem)
 		self.filesystem = filesystem
 		self._encrypted = None
 		self.encrypted = encrypted
@@ -55,8 +54,6 @@ class Partition:
 
 		if self.filesystem == 'crypto_LUKS':
 			self.encrypted = True
-
-		print('*****', self.filesystem)
 
 	def __lt__(self, left_comparitor :BlockDevice) -> bool:
 		if type(left_comparitor) == Partition:
@@ -490,6 +487,7 @@ class Partition:
 				fs = self.filesystem
 
 			fs_type = get_mount_fs_type(fs)
+			print('**** fstype:', fs_type)
 
 			pathlib.Path(target).mkdir(parents=True, exist_ok=True)
 

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -481,7 +481,7 @@ class Partition:
 	def mount(self, target :str, fs :Optional[str] = None, options :str = '') -> bool:
 		if not self.mountpoint:
 			log(f'Mounting {self} to {target}', level=logging.INFO)
-			if 'compressed=zstd' in fs:
+			if 'compress=zstd' in fs:
 				raise ValueError(f"what?")
 
 			if not fs:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -314,6 +314,7 @@ class Installer:
 
 			if partition.get('filesystem',{}).get('mount_options',[]):
 				mount_options = ','.join(partition['filesystem']['mount_options'])
+				print('****', mount_options)
 				mount_queue[mountpoint] = lambda instance=partition['device_instance'], target=f"{self.target}{mountpoint}", options=mount_options: instance.mount(target, options)
 			else:
 				mount_queue[mountpoint] = lambda instance=partition['device_instance'], target=f"{self.target}{mountpoint}": instance.mount(target)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -312,9 +312,10 @@ class Installer:
 			mountpoint = partition['mountpoint']
 			log(f"Mounting {mountpoint} to {self.target}{mountpoint} using {partition['device_instance']}", level=logging.INFO)
 
+			print(partition)
 			if partition.get('filesystem',{}).get('mount_options',[]):
 				mount_options = ','.join(partition['filesystem']['mount_options'])
-				print('****', mount_options)
+				print('****>> ', mount_options)
 				mount_queue[mountpoint] = lambda instance=partition['device_instance'], target=f"{self.target}{mountpoint}", options=mount_options: instance.mount(target, options)
 			else:
 				mount_queue[mountpoint] = lambda instance=partition['device_instance'], target=f"{self.target}{mountpoint}": instance.mount(target)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -312,11 +312,9 @@ class Installer:
 			mountpoint = partition['mountpoint']
 			log(f"Mounting {mountpoint} to {self.target}{mountpoint} using {partition['device_instance']}", level=logging.INFO)
 
-			print(partition)
 			if partition.get('filesystem',{}).get('mount_options',[]):
 				mount_options = ','.join(partition['filesystem']['mount_options'])
-				print('****>> ', mount_options)
-				mount_queue[mountpoint] = lambda instance=partition['device_instance'], target=f"{self.target}{mountpoint}", options=mount_options: instance.mount(target, options)
+				mount_queue[mountpoint] = lambda instance=partition['device_instance'], target=f"{self.target}{mountpoint}", options=mount_options: instance.mount(target, options=options)
 			else:
 				mount_queue[mountpoint] = lambda instance=partition['device_instance'], target=f"{self.target}{mountpoint}": instance.mount(target)
 


### PR DESCRIPTION
A faulty frozen `.mount()` call didn't put parameters in correct order.
This fix #1257 