### PR TITLE
Removes btrfs subvolume warnings on incorrect subvolume locations

### DIFF
--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -114,6 +114,8 @@ def subvolume_info_from_path(path :pathlib.Path) -> Optional[BtrfsSubvolume]:
 
 	except SysCallError as error:
 		log(f"Could not retrieve subvolume information from {path}: {error}", level=logging.WARNING, fg="orange")
+		if '@' in path:
+			raise ValueError(f"mooo")
 
 	return None
 

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -95,6 +95,9 @@ def setup_subvolumes(installation, partition_dict):
 			del subvol_options[subvol_options.index('compress')]
 
 def subvolume_info_from_path(path :pathlib.Path) -> Optional[BtrfsSubvolume]:
+	if '/boot' in str(path):
+		raise ValueError(f"moo")
+
 	try:
 		subvolume_name = None
 		result = {}
@@ -114,8 +117,6 @@ def subvolume_info_from_path(path :pathlib.Path) -> Optional[BtrfsSubvolume]:
 
 	except SysCallError as error:
 		log(f"Could not retrieve subvolume information from {path}: {error}", level=logging.WARNING, fg="orange")
-		if '@' in str(path):
-			raise ValueError(f"mooo")
 
 	return None
 

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -95,9 +95,6 @@ def setup_subvolumes(installation, partition_dict):
 			del subvol_options[subvol_options.index('compress')]
 
 def subvolume_info_from_path(path :pathlib.Path) -> Optional[BtrfsSubvolume]:
-	if '/boot' in str(path):
-		raise ValueError(f"moo")
-
 	try:
 		subvolume_name = None
 		result = {}

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -114,7 +114,7 @@ def subvolume_info_from_path(path :pathlib.Path) -> Optional[BtrfsSubvolume]:
 
 	except SysCallError as error:
 		log(f"Could not retrieve subvolume information from {path}: {error}", level=logging.WARNING, fg="orange")
-		if '@' in path:
+		if '@' in str(path):
 			raise ValueError(f"mooo")
 
 	return None

--- a/archinstall/lib/disk/btrfs/btrfspartition.py
+++ b/archinstall/lib/disk/btrfs/btrfspartition.py
@@ -110,9 +110,13 @@ class BTRFSPartition(Partition):
 
 		if glob.glob(str(subvolume / '*')):
 			raise DiskError(f"Cannot create subvolume at {subvolume} because it contains data (non-empty folder target is not supported by BTRFS)")
-		elif subvolinfo := subvolume_info_from_path(subvolume):
-			raise DiskError(f"Destination {subvolume} is already a subvolume: {subvolinfo}")
+		# Ideally we would like to check if the destination is already a subvolume.
+		# But then we would need the mount-point at this stage as well.
+		# So we'll comment out this check:
+		# elif subvolinfo := subvolume_info_from_path(subvolume):
+		# 	raise DiskError(f"Destination {subvolume} is already a subvolume: {subvolinfo}")
 
+		# And deal with it here:
 		SysCommand(f"btrfs subvolume create {subvolume}")
 
 		return subvolume_info_from_path(subvolume)

--- a/archinstall/lib/disk/btrfs/btrfspartition.py
+++ b/archinstall/lib/disk/btrfs/btrfspartition.py
@@ -62,6 +62,8 @@ class BTRFSPartition(Partition):
 		if not installation:
 			installation = storage.get('installation_session')
 
+		print('Creating:', subvolume)
+
 		# Determain if the path given, is an absolute path or a releative path.
 		# We do this by checking if the path contains a known mountpoint.
 		if str(subvolume)[0] == '/':

--- a/archinstall/lib/disk/btrfs/btrfspartition.py
+++ b/archinstall/lib/disk/btrfs/btrfspartition.py
@@ -62,8 +62,6 @@ class BTRFSPartition(Partition):
 		if not installation:
 			installation = storage.get('installation_session')
 
-		print('Creating:', subvolume)
-
 		# Determain if the path given, is an absolute path or a releative path.
 		# We do this by checking if the path contains a known mountpoint.
 		if str(subvolume)[0] == '/':

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -310,9 +310,9 @@ class Partition:
 		def iterate_children_recursively(information):
 			for child in information.get('children', []):
 				if target := child.get('target'):
-					print(child)
-					if subvolume := subvolume_info_from_path(pathlib.Path(target)):
-						yield subvolume
+					if child.get('fstype') == 'btrfs':
+						if subvolume := subvolume_info_from_path(pathlib.Path(target)):
+							yield subvolume
 
 					if child.get('children'):
 						for subchild in iterate_children_recursively(child):
@@ -321,9 +321,9 @@ class Partition:
 		for mountpoint in self.mount_information:
 			if result := findmnt(pathlib.Path(mountpoint['target'])):
 				for filesystem in result.get('filesystems', []):
-					print(filesystem)
-					if subvolume := subvolume_info_from_path(pathlib.Path(mountpoint['target'])):
-						yield subvolume
+					if mountpoint.get('fstype') == 'btrfs':
+						if subvolume := subvolume_info_from_path(pathlib.Path(mountpoint['target'])):
+							yield subvolume
 
 					for child in iterate_children_recursively(filesystem):
 						yield child

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -310,6 +310,7 @@ class Partition:
 		def iterate_children_recursively(information):
 			for child in information.get('children', []):
 				if target := child.get('target'):
+					print(child)
 					if subvolume := subvolume_info_from_path(pathlib.Path(target)):
 						yield subvolume
 
@@ -320,6 +321,7 @@ class Partition:
 		for mountpoint in self.mount_information:
 			if result := findmnt(pathlib.Path(mountpoint['target'])):
 				for filesystem in result.get('filesystems', []):
+					print(filesystem)
 					if subvolume := subvolume_info_from_path(pathlib.Path(mountpoint['target'])):
 						yield subvolume
 


### PR DESCRIPTION
This fixes #1245

 * Removed a unnecessary check if a subvolume path is a subvolume already. The check would need to have the mountpoint as well as the subvolume path can be different from the subvolume name/location.
 * Made sure `Partition.subvolumes()` only attempts to retrieve btrfs subvolume information on a location if the target is of `fstype==btrfs`.