### PR TITLE
Fixed issue where secondary encrypted volumes didn't unlock

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -253,8 +253,8 @@ class Installer:
 
 			# note that we DON'T auto_unmount (i.e. close the encrypted device so it can be used
 			with (luks_handle := luks2(partition['device_instance'], loopdev, password, auto_unmount=False)) as unlocked_device:
-				if partition.get('generate-encryption-key-file',False) and not self._has_root(partition):
-					list_luks_handles.append([luks_handle,partition,password])
+				if partition.get('generate-encryption-key-file', False) and not self._has_root(partition):
+					list_luks_handles.append([luks_handle, partition, password])
 				# this way all the requesrs will be to the dm_crypt device and not to the physical partition
 				partition['device_instance'] = unlocked_device
 

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -215,6 +215,11 @@ class GlobalMenu(GeneralMenu):
 							partition['encrypted'] = True
 							partition['!password'] = storage['arguments']['!encryption-password']
 
+							# We make sure generate-encryption-key-file is set on additional partitions
+							# other than the root partition. Otherwise they won't unlock properly #1279
+							if partition['mountpoint'] != '/':
+								partition['generate-encryption-key-file'] = True
+
 	def _install_text(self):
 		missing = len(self._missing_configs())
 		if missing > 0:


### PR DESCRIPTION
Made sure generate-encryption-key-file is set for supplementary partitions to /

* Closes https://github.com/archlinux/archinstall/issues/1279