### PR TITLE
Divide Chinese locales into 2 variants

### DIFF
--- a/archinstall/locales/languages.json
+++ b/archinstall/locales/languages.json
@@ -180,5 +180,6 @@
  {"abbr": "yi", "lang": "Yiddish"},
  {"abbr": "yo", "lang": "Yoruba"},
  {"abbr": "za", "lang": "Zhuang"},
- {"abbr": "zh", "lang": "Chinese"},
+ {"abbr": "zh-TW", "lang": "Traditional Chinese"},
+ {"abbr": "zh-CN", "lang": "Simplified Chinese"},
  {"abbr": "zu", "lang": "Zulu"}]


### PR DESCRIPTION
# Describe your PR

Change Chinese language code to its two popular variants to avoid future renaming once translation of 2 variants are submitted.