### PR TITLE
Added more offline functionality, such as skipping package search

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -81,6 +81,8 @@ def define_arguments():
 	parser.add_argument("--script", default="guided", nargs="?", help="Script to run for installation", type=str)
 	parser.add_argument("--mount-point","--mount_point", nargs="?", type=str, help="Define an alternate mount point for installation")
 	parser.add_argument("--debug", action="store_true", default=False, help="Adds debug info into the log")
+	parser.add_argument("--offline", action="store_true", default=False, help="Disabled online upstream services such as package search and key-ring auto update.")
+	parser.add_argument("--no-pkg-lookups", action="store_true", default=False, help="Disabled package validation specifically prior to starting installation.")
 	parser.add_argument("--plugin", nargs="?", type=str)
 
 def parse_unspecified_argument_list(unknowns :list, multiple :bool = False, error :bool = False) -> dict:
@@ -172,6 +174,7 @@ def get_arguments() -> Dict[str, Any]:
 	# avoiding a compatibility issue
 	if 'dry-run' in config:
 		del config['dry-run']
+
 	return config
 
 def load_config():

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 from typing import List, Any, Optional, Dict, TYPE_CHECKING
 
-import archinstall
-
 from ..menu.menu import MenuSelectionType
 from ..menu.text_input import TextInput
 
@@ -16,6 +14,8 @@ from ..mirrors import list_mirrors
 
 from ..translation import Translation
 from ..packages.packages import validate_package_list
+
+from ..storage import storage
 
 if TYPE_CHECKING:
 	_: Any
@@ -155,11 +155,11 @@ def select_profile(preset) -> Optional[Profile]:
 		case MenuSelectionType.Selection:
 			return options[selection.value] if selection.value is not None else None
 		case MenuSelectionType.Ctrl_c:
-			archinstall.storage['profile_minimal'] = False
-			archinstall.storage['_selected_servers'] = []
-			archinstall.storage['_desktop_profile'] = None
-			archinstall.arguments['desktop-environment'] = None
-			archinstall.arguments['gfx_driver_packages'] = None
+			storage['profile_minimal'] = False
+			storage['_selected_servers'] = []
+			storage['_desktop_profile'] = None
+			storage['arguments']['desktop-environment'] = None
+			storage['arguments']['gfx_driver_packages'] = None
 			return None
 		case MenuSelectionType.Esc:
 			return None
@@ -178,17 +178,18 @@ def ask_additional_packages_to_install(pre_set_packages: List[str] = []) -> List
 	pre_set_packages = pre_set_packages if pre_set_packages else []
 	packages = read_packages(pre_set_packages)
 
-	while True:
-		if len(packages):
-			# Verify packages that were given
-			print(_("Verifying that additional packages exist (this might take a few seconds)"))
-			valid, invalid = validate_package_list(packages)
+	if not storage['arguments']['offline'] and not storage['arguments']['no_pkg_lookups']:
+		while True:
+			if len(packages):
+				# Verify packages that were given
+				print(_("Verifying that additional packages exist (this might take a few seconds)"))
+				valid, invalid = validate_package_list(packages)
 
-			if invalid:
-				log(f"Some packages could not be found in the repository: {invalid}", level=logging.WARNING, fg='red')
-				packages = read_packages(valid)
-				continue
-		break
+				if invalid:
+					log(f"Some packages could not be found in the repository: {invalid}", level=logging.WARNING, fg='red')
+					packages = read_packages(valid)
+					continue
+			break
 
 	return packages
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -274,7 +274,7 @@ if not (archinstall.check_mirror_reachable() or archinstall.arguments.get('skip-
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
-if not archinstall.arguments.get('offline', False):
+if not archinstall.arguments['offline']:
 	latest_version_archlinux_keyring = max([k.pkg_version for k in archinstall.find_package('archlinux-keyring')])
 
 	# If we want to check for keyring updates


### PR DESCRIPTION
This will allow users to skip "upstream" checks.
Certain packages that might be built locally or built into a offline medium won't be able to resolve against archlinux.org and that should be fine too :)