### PR TITLE
Add `packagekit-qt5` for kde

### DIFF
--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -13,6 +13,7 @@ __packages__ = [
 	"sddm",
 	"plasma-wayland-session",
 	"egl-wayland",
+	"packagekit-qt5",
 ]
 
 


### PR DESCRIPTION
Fix #1041: Discover is missing `packagekit-qt5`