### PR TITLE
Handle cyrillic characters

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -15,4 +15,4 @@ jobs:
             # one day this will be enabled
               # run: mypy --strict --module archinstall || exit 0
             - name: run mypy
-              run: mypy --follow-imports=silent archinstall/lib/menu/selection_menu.py archinstall/lib/menu/global_menu.py archinstall/lib/models/network_configuration.py archinstall/lib/menu/list_manager.py archinstall/lib/user_interaction/network_conf.py archinstall/lib/models/users.py
+              run: mypy --follow-imports=silent archinstall/lib/menu/selection_menu.py archinstall/lib/menu/global_menu.py archinstall/lib/models/network_configuration.py archinstall/lib/menu/list_manager.py archinstall/lib/user_interaction/network_conf.py archinstall/lib/models/users.py archinstall/lib/translation.py

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -58,10 +58,6 @@ storage['__version__'] = __version__
 DeferredTranslation.install()
 
 
-def set_unicode_font():
-	SysCommand('setfont UniCyr_8x16')
-
-
 def define_arguments():
 	"""
 	Define which explicit arguments do we allow.
@@ -248,9 +244,6 @@ def post_process_arguments(arguments):
 
 	load_config()
 
-
-# to ensure that cyrillic characters work in the installer
-# set_unicode_font()
 
 define_arguments()
 arguments = get_arguments()

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -456,7 +456,6 @@ class GeneralMenu:
 		from ... import select_archinstall_language
 		language = select_archinstall_language(preset_value)
 		if language is not None:
-			print(language)
 			self._translation.activate(language)
 			return language
 

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -15,15 +15,6 @@ if TYPE_CHECKING:
 	_: Any
 
 
-def select_archinstall_language(preset_value: str) -> Optional[Any]:
-	"""
-	copied from user_interaction/general_conf.py as a temporary measure
-	"""
-	languages = Translation.get_available_lang()
-	language = Menu(_('Archinstall language'), languages, preset_values=preset_value).run()
-	return language.value
-
-
 class Selector:
 	def __init__(
 		self,
@@ -462,8 +453,10 @@ class GeneralMenu:
 		return mandatory_fields, mandatory_waiting
 
 	def _select_archinstall_language(self, preset_value: str) -> str:
+		from ... import select_archinstall_language
 		language = select_archinstall_language(preset_value)
 		if language is not None:
+			print(language)
 			self._translation.activate(language)
 			return language
 

--- a/archinstall/lib/translation.py
+++ b/archinstall/lib/translation.py
@@ -19,7 +19,7 @@ class LanguageDefinitions:
 
 	def __init__(self):
 		self._mappings = self._get_language_mappings()
-		self._cyrillic_languages = self._cyrillic_languages()
+		self._cyrillic_languages = self._get_cyrillic_languages()
 
 	def is_cyrillic(self, language: str) -> bool:
 		return language in self._cyrillic_languages
@@ -38,7 +38,7 @@ class LanguageDefinitions:
 
 		raise ValueError(f'No language with abbreviation "{abbr}" found')
 
-	def _cyrillic_languages(self) -> List[str]:
+	def _get_cyrillic_languages(self) -> List[str]:
 		locales_dir = Translation.get_locales_dir()
 		languages = Path.joinpath(locales_dir, self._cyrillic)
 

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -118,10 +118,13 @@ def select_mirror_regions(preset_values: Dict[str, Any] = {}) -> Dict[str, Any]:
 		case _: return {selected: mirrors[selected] for selected in selected_mirror.value}
 
 
-def select_archinstall_language(default='English'):
+def select_archinstall_language(preset_values: str):
 	languages = Translation.get_available_lang()
-	language = Menu(_('Archinstall language'), languages, default_option=default).run()
-	return language
+	choice = Menu(_('Archinstall language'), languages, default_option=preset_values).run()
+
+	match choice.type_:
+		case MenuSelectionType.Esc: return preset_values
+		case MenuSelectionType.Selection: return choice.value
 
 
 def select_profile(preset) -> Optional[Profile]:

--- a/archinstall/locales/cyrillic.json
+++ b/archinstall/locales/cyrillic.json
@@ -1,0 +1,19 @@
+{
+  "languages": [
+    "Abkhazian",
+    "Azerbaijani",
+    "Bashkir",
+    "Belarusian",
+    "Bulgarian",
+    "Chuvash",
+    "Komi",
+    "Macedonian",
+    "Mongolian",
+    "Russian",
+    "Serbo-Croatian",
+    "Tajik",
+    "Tatar",
+    "Ukrainian",
+    "Uzbek"
+  ]
+}


### PR DESCRIPTION
This should fix #1138 now in a safe way :) 

When choosing a cyrillic languages we'll set the `UniCyr_8x16` language, when a non cyrillic language is set we'll reset the font to a default font