### PR TITLE
Don't generate any backup locales files

### DIFF
--- a/archinstall/locales/locales_generator.sh
+++ b/archinstall/locales/locales_generator.sh
@@ -7,6 +7,6 @@ find . -type f -iname "*.py" | xargs xgettext --join-existing --no-location --om
 for file in $(find locales/ -name "base.po"); do
 	echo "Updating: $file"
 	path=$(dirname $file)
-	msgmerge --quiet --no-location --width 512 --update $file locales/base.pot
+	msgmerge --quiet --no-location --width 512 --backup none --update $file locales/base.pot
 	msgfmt -o $path/base.mo $file
 done


### PR DESCRIPTION
Fixes #1252 

So far when running the `locales_generator.sh` script there where files with a `~` suffix generated. These came from the `msgmerge` command that automatically generates these backup files. As we're using git and have fancy git history we will not have much use for them and they only caused confusion for people. 

