### PR TITLE
Fix spacing "The password you are using seems to be weak,"

### DIFF
--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -505,7 +505,7 @@ msgstr ""
 msgid "Not a valid directory: {}"
 msgstr ""
 
-msgid "The password you are using seems to be weak,"
+msgid "The password you are using seems to be weak, "
 msgstr ""
 
 msgid "are you sure you want to use it?"

--- a/archinstall/locales/cs/LC_MESSAGES/base.po
+++ b/archinstall/locales/cs/LC_MESSAGES/base.po
@@ -515,8 +515,8 @@ msgstr "Zadejte adresář pro uložení konfigurace (konfigurací): "
 msgid "Not a valid directory: {}"
 msgstr "Adresář není validní: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "Vaše heslo se zdá být slabé,"
+msgid "The password you are using seems to be weak, "
+msgstr "Vaše heslo se zdá být slabé, "
 
 msgid "are you sure you want to use it?"
 msgstr "přejete si ho skutečně použít?"

--- a/archinstall/locales/de/LC_MESSAGES/base.po
+++ b/archinstall/locales/de/LC_MESSAGES/base.po
@@ -523,8 +523,8 @@ msgstr "Geben sie eine Ordner an wo die Konfigurationen gespeichert werden solle
 msgid "Not a valid directory: {}"
 msgstr "Ordner existiert nicht: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "Das gewählte Passwort ist sehr schwach,"
+msgid "The password you are using seems to be weak, "
+msgstr "Das gewählte Passwort ist sehr schwach, "
 
 msgid "are you sure you want to use it?"
 msgstr "wollen sie dieses wirklich verwenden?"

--- a/archinstall/locales/en/LC_MESSAGES/base.po
+++ b/archinstall/locales/en/LC_MESSAGES/base.po
@@ -480,7 +480,7 @@ msgstr ""
 msgid "Not a valid directory: {}"
 msgstr ""
 
-msgid "The password you are using seems to be weak,"
+msgid "The password you are using seems to be weak, "
 msgstr ""
 
 msgid "are you sure you want to use it?"

--- a/archinstall/locales/es/LC_MESSAGES/base.po
+++ b/archinstall/locales/es/LC_MESSAGES/base.po
@@ -518,8 +518,8 @@ msgstr "Introduzca un directorio para guardar la(s) configuración(es): "
 msgid "Not a valid directory: {}"
 msgstr "No es un directorio válido: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "La contraseña que está utilizando parece ser débil,"
+msgid "The password you are using seems to be weak, "
+msgstr "La contraseña que está utilizando parece ser débil, "
 
 msgid "are you sure you want to use it?"
 msgstr "¿Estás seguro de que quieres usarlo?"

--- a/archinstall/locales/fr/LC_MESSAGES/base.po
+++ b/archinstall/locales/fr/LC_MESSAGES/base.po
@@ -520,8 +520,8 @@ msgstr "Saisir un répertoire pour la ou les configuration(s) à enregistrer : "
 msgid "Not a valid directory: {}"
 msgstr "Répertoire non valide : {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "Le mot de passe que vous utilisez semble faible,"
+msgid "The password you are using seems to be weak, "
+msgstr "Le mot de passe que vous utilisez semble faible, "
 
 msgid "are you sure you want to use it?"
 msgstr "êtes-vous sûr de vouloir l'utiliser ?"

--- a/archinstall/locales/it/LC_MESSAGES/base.po
+++ b/archinstall/locales/it/LC_MESSAGES/base.po
@@ -520,8 +520,8 @@ msgstr "Immettere una directory per le configurazioni da salvare: "
 msgid "Not a valid directory: {}"
 msgstr "Directory non valida: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "La password che stai utilizzando sembra essere debole,"
+msgid "The password you are using seems to be weak, "
+msgstr "La password che stai utilizzando sembra essere debole, "
 
 msgid "are you sure you want to use it?"
 msgstr "sei sicuro di volerla usare?"

--- a/archinstall/locales/nl/LC_MESSAGES/base.po
+++ b/archinstall/locales/nl/LC_MESSAGES/base.po
@@ -525,8 +525,8 @@ msgstr "Voer de naam in van de map waarin de configuratie(s) moet(en) worden vas
 msgid "Not a valid directory: {}"
 msgstr "Ongeldige map: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "Het gekozen wachtwoord is zwak."
+msgid "The password you are using seems to be weak, "
+msgstr "Het gekozen wachtwoord is zwak. "
 
 msgid "are you sure you want to use it?"
 msgstr "Weet u zeker dat u het wilt gebruiken?"

--- a/archinstall/locales/pl/LC_MESSAGES/base.po
+++ b/archinstall/locales/pl/LC_MESSAGES/base.po
@@ -521,8 +521,8 @@ msgstr "Wprowadź katalog, w którym ma zostać zapisana konfiguracja: "
 msgid "Not a valid directory: {}"
 msgstr "Nie jest to prawidłowy katalog: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "Używane przez Ciebie hasło wydaje się być słabe,"
+msgid "The password you are using seems to be weak, "
+msgstr "Używane przez Ciebie hasło wydaje się być słabe, "
 
 msgid "are you sure you want to use it?"
 msgstr "czy na pewno chcesz go używać?"

--- a/archinstall/locales/pt/LC_MESSAGES/base.po
+++ b/archinstall/locales/pt/LC_MESSAGES/base.po
@@ -536,8 +536,8 @@ msgstr "Introduz um diretório para as configurações a serem guardadas: "
 msgid "Not a valid directory: {}"
 msgstr "Não é uma diretoria válida: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "A palavra-passe que estás a usar parece ser fraca,"
+msgid "The password you are using seems to be weak, "
+msgstr "A palavra-passe que estás a usar parece ser fraca, "
 
 #, fuzzy
 msgid "are you sure you want to use it?"

--- a/archinstall/locales/pt_BR/LC_MESSAGES/base.po
+++ b/archinstall/locales/pt_BR/LC_MESSAGES/base.po
@@ -515,8 +515,8 @@ msgstr "Digite um diretório para as configurações serem salvas: "
 msgid "Not a valid directory: {}"
 msgstr "Não é um diretorio válido: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "A senha que está usando parece ser fraca,"
+msgid "The password you are using seems to be weak, "
+msgstr "A senha que está usando parece ser fraca, "
 
 msgid "are you sure you want to use it?"
 msgstr "tem certeza que deseja usá-la?"

--- a/archinstall/locales/ru/LC_MESSAGES/base.po
+++ b/archinstall/locales/ru/LC_MESSAGES/base.po
@@ -609,8 +609,8 @@ msgstr "Введите каталог для сохранения конфигу
 msgid "Not a valid directory: {}"
 msgstr "Недействительный каталог: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "Пароль, который вы используете, кажется слабым,"
+msgid "The password you are using seems to be weak, "
+msgstr "Пароль, который вы используете, кажется слабым, "
 
 msgid "are you sure you want to use it?"
 msgstr "вы уверены, что хотите его использовать?"

--- a/archinstall/locales/sv/LC_MESSAGES/base.po
+++ b/archinstall/locales/sv/LC_MESSAGES/base.po
@@ -524,8 +524,8 @@ msgstr "Välj vilken mapp du vill spara konfigurerationerna till: "
 msgid "Not a valid directory: {}"
 msgstr "Inte en giltig mapp: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "Lösenordet du angav verkar svagt,"
+msgid "The password you are using seems to be weak, "
+msgstr "Lösenordet du angav verkar svagt, "
 
 msgid "are you sure you want to use it?"
 msgstr "Vill du verkligen använda det?"

--- a/archinstall/locales/tr/LC_MESSAGES/base.po
+++ b/archinstall/locales/tr/LC_MESSAGES/base.po
@@ -524,8 +524,8 @@ msgstr "Yapılandırma(lar)ın kaydedilmesi için bir dizin girin: "
 msgid "Not a valid directory: {}"
 msgstr "Geçerli bir dizin değil: {}"
 
-msgid "The password you are using seems to be weak,"
-msgstr "Kullandığınız şifre zayıf gözüküyor,"
+msgid "The password you are using seems to be weak, "
+msgstr "Kullandığınız şifre zayıf gözüküyor, "
 
 msgid "are you sure you want to use it?"
 msgstr "kullanmak istediğinize emin misiniz?"


### PR DESCRIPTION
Fix spacing in the message "The password you are using seems to be weak,are you sure you want to use it?" for every locale.

[Current state.](https://www.youtube.com/watch?v=leQbSsu-7F4&t=365s)