### PR TITLE
Explicitly remove the hash character at the line-start in /etc/locale.gen

### DIFF
--- a/archinstall/lib/locale_helpers.py
+++ b/archinstall/lib/locale_helpers.py
@@ -20,7 +20,7 @@ def list_locales() -> List[str]:
 		entries.reverse()
 
 		for entry in entries:
-			text = entry[1:].strip()
+			text = entry.replace('#', '').strip()
 			if text == '':
 				break
 			locales.append(text)


### PR DESCRIPTION
Currently the helper remove the first character of each line, this can
lead to cases, where important characters are removed. For example if
the locale is already set up. (hash is already removed) in that case the
helper would remove the first character of the locale and lead to a
broken attempt to set the locale later on. This change should avoid that
and only remove the hash.

I have to say that I'm not a dev so this might be completely wrong. Nevertheless I have tested this change on the official archiso as well as my own one, where I found the bug.

Note: In my mind `.strip('# ')` should also work, but crashes archinstall for a reason I don't understand. Thats why I haven't done this here.

Fixes: https://github.com/archlinux/archinstall/issues/1344