### PR TITLE
Enhacements to list_manager:

### DIFF
--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -44,6 +44,8 @@ class ListManager:
 		self._base_actions = base_actions
 		self._sub_menu_actions = sub_menu_actions
 
+		self.last_choice = None
+
 	def run(self):
 		while True:
 			# this will return a dictionary with the key as the menu entry to be displayed
@@ -73,6 +75,7 @@ class ListManager:
 				selected_entry = data_formatted[choice.value]
 				self._run_actions_on_entry(selected_entry)
 
+		self.last_choice = choice
 		if choice.value == self._cancel_action:
 			return self._original_data  # return the original list
 		else:
@@ -97,7 +100,7 @@ class ListManager:
 		return options, header
 
 	def _run_actions_on_entry(self, entry: Any):
-		options = self._sub_menu_actions + [self._cancel_action]
+		options = self.filter_options(entry,self._sub_menu_actions) + [self._cancel_action]
 		display_value = self.selected_action_display(entry)
 
 		prompt = _("Select an action for '{}'").format(display_value)
@@ -129,3 +132,7 @@ class ListManager:
 		# this function is called when a base action or
 		# a specific action for an entry is triggered
 		raise NotImplementedError('Please implement me in the child class')
+
+	def filter_options(self, selection :Any, options :List[str]) -> List[str]:
+		# filter which actions to show for an specific selection
+		return options

--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -44,7 +44,11 @@ class ListManager:
 		self._base_actions = base_actions
 		self._sub_menu_actions = sub_menu_actions
 
-		self.last_choice = None
+		self._last_choice = None
+
+	@property
+	def last_choice(self):
+		return self._last_choice
 
 	def run(self):
 		while True:
@@ -75,7 +79,7 @@ class ListManager:
 				selected_entry = data_formatted[choice.value]
 				self._run_actions_on_entry(selected_entry)
 
-		self.last_choice = choice
+		self._last_choice = choice
 		if choice.value == self._cancel_action:
 			return self._original_data  # return the original list
 		else:

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -188,6 +188,11 @@ class GeneralMenu:
 		self._menu_options: Dict[str, Selector] = {}
 		self._setup_selection_menu_options()
 		self.preview_size = preview_size
+		self._last_choice = None
+
+	@property
+	def last_choice(self):
+		return self._last_choice
 
 	def __enter__(self, *args :Any, **kwargs :Any) -> GeneralMenu:
 		self.is_context_mgr = True
@@ -324,6 +329,10 @@ class GeneralMenu:
 				# we allow for an callback for special processing on realeasing control
 				if not self._process_selection(value):
 					break
+
+		# we get the last action key
+		actions = {v.description:k for k,v in self._menu_options.items()}
+		self._last_choice = actions[selection.value.strip()]
 
 		if not self.is_context_mgr:
 			self.__exit__()

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -331,7 +331,7 @@ class GeneralMenu:
 					break
 
 		# we get the last action key
-		actions = {v.description:k for k,v in self._menu_options.items()}
+		actions = {str(v.description):k for k,v in self._menu_options.items()}
 		self._last_choice = actions[selection.value.strip()]
 
 		if not self.is_context_mgr:


### PR DESCRIPTION
Two small changes to _ListManager_:
1) One more user modifiable method *filter_options*
The idea is, given an object selected, filter (or if developer desires change the shown text) the available options, allowing to display only a subset.
I have three potential use-cases for it:
First (what i need) is, when having heterogeneous list, only the pertinent options for the type selected will be shown (imagine a list with disk/partitions or folder/files).
The second use (just theoretical) is that the options shown can be filtered on user-defined security levels. Haven't yet found a use for us, but ...
Third, to change the text of the option. f.i. in a user list, the promote/demote action could be shown just as _demote_ or _promote_ depends of which user is selected. Has its downsides -might need some code elsewhere- and might be not worth in this particular instance, but could be useful.

In this case I don't use a `NotImplementedError` exception but return the whole option list, as it is the default usage


2) One public attribute *last_choice*
It holds the last_choice selected by the user from the main list ONLY
The main use-case is when we need to know if the list was exited either with a _cancel_ or a _confirm_and_exit_ and perform some different action after each instance. Usually _cancel_ wouldn't do anything and _confirm_and_exit_ change the state of parts of the system.

If such behaviour is desired coding should be a bit different from the usual `ObjectList().run()`:
```
    my_list = MyList(...)
    result_list = my_list.run()
    if list.last_choice.value = my_list._confirm_action:
        process_list(result_list)
    else:
        pass
```
Other, more convoluted example is my actual need. I have a list of partitions to manage. I want to be able to delete partitions not only from the list but in the real hardware. This action has to be done after the list is fully processed, before anything else and NEVER if _cancel_ is invoked.
First I create an attribute `partitions_to_delete` which will hold the list of real partitions to be deleted
```
class MyList(ListManager):
   def __init__(self,...):
      super().__init__(...)
      self.partitions_to_delete = []
```
This attribute is filled during normal processing (a partition marked to be deleted is removed from the list, and is space is freed to define new partitons to be created). I could resort to some code like before, but in this case i don't need code branching, but to ensure that the deletion list is empty unless a confirm action is requested, so i decided to overcharge the run() method.
```
	def run(self):
		result_list = super().run()
		if self.last_choice.value != self._confirm_action:
		    self.partitions_to_delete =  []
		return result_list, self.partitions_to_delete

```
@svartkanin have a look at it please