### PR TITLE
Fix KeyError exceptions

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -631,7 +631,7 @@ class Installer:
 			mkinit.write(f"BINARIES=({' '.join(self.BINARIES)})\n")
 			mkinit.write(f"FILES=({' '.join(self.FILES)})\n")
 
-			if not storage['arguments']['HSM']:
+			if not storage['arguments'].get('HSM'):
 				# For now, if we don't use HSM we revert to the old
 				# way of setting up encryption hooks for mkinitcpio.
 				# This is purely for stability reasons, we're going away from this.
@@ -673,7 +673,7 @@ class Installer:
 					self.HOOKS.remove('fsck')
 
 			if self.detect_encryption(partition):
-				if storage['arguments']['HSM']:
+				if storage['arguments'].get('HSM'):
 					# Required bby mkinitcpio to add support for fido2-device options
 					self.pacstrap('libfido2')
 
@@ -737,7 +737,7 @@ class Installer:
 		# TODO: Use python functions for this
 		SysCommand(f'/usr/bin/arch-chroot {self.target} chmod 700 /root')
 
-		if storage['arguments']['HSM']:
+		if storage['arguments'].get('HSM'):
 			# TODO:
 			# A bit of a hack, but we need to get vconsole.conf in there
 			# before running `mkinitcpio` because it expects it in HSM mode.
@@ -865,7 +865,7 @@ class Installer:
 
 					kernel_options = f"options"
 
-					if storage['arguments']['HSM']:
+					if storage['arguments'].get('HSM'):
 						# Note: lsblk UUID must be used, not PARTUUID for sd-encrypt to work
 						kernel_options += f" rd.luks.name={real_device.uuid}=luksdev"
 						# Note: tpm2-device and fido2-device don't play along very well:

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -187,11 +187,12 @@ def perform_installation(mountpoint):
 		if installation.minimal_installation(testing=enable_testing, multilib=enable_multilib):
 			installation.set_locale(archinstall.arguments['sys-language'], archinstall.arguments['sys-encoding'].upper())
 			installation.set_hostname(archinstall.arguments['hostname'])
-			if archinstall.arguments['mirror-region'].get("mirrors", None) is not None:
-				installation.set_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors in the installation medium
-			if archinstall.arguments['swap']:
+			if archinstall.arguments.get('mirror-region') is not None:
+				if archinstall.arguments.get("mirrors", None) is not None:
+					installation.set_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors in the installation medium
+			if archinstall.arguments.get('swap'):
 				installation.setup_swap('zram')
-			if archinstall.arguments["bootloader"] == "grub-install" and archinstall.has_uefi():
+			if archinstall.arguments.get("bootloader") == "grub-install" and archinstall.has_uefi():
 				installation.add_additional_packages("grub")
 			installation.add_bootloader(archinstall.arguments["bootloader"])
 
@@ -274,7 +275,7 @@ if not (archinstall.check_mirror_reachable() or archinstall.arguments.get('skip-
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
-if not archinstall.arguments['offline']:
+if not archinstall.arguments.get('offline'):
 	latest_version_archlinux_keyring = max([k.pkg_version for k in archinstall.find_package('archlinux-keyring')])
 
 	# If we want to check for keyring updates


### PR DESCRIPTION
# Describe your PR

I have been attempting to create a set of config files to automate installation of my preferred Arch setup referencing the example files and the documentation available at https://archinstall.readthedocs.io/installing/guided.html.

While testing my config files on a VM I have run into multiple issues with archinstall crashing, all related to dictionary KeyError exceptions:
```
Enabling service fstrim.timer
'HSM'
[!] A log file has been created here: /var/log/archinstall/install.log
    Please submit this issue (and file) to https://github.com/archlinux/archinstall/issues
Traceback (most recent call last):
  File "/usr/bin/archinstall", line 8, in <module>
    sys.exit(run_as_a_module())
  File "/usr/lib/python3.10/site-packages/archinstall/__init__.py", line 281, in run_as_a_module
    script.execute()
  File "/usr/lib/python3.10/site-packages/archinstall/lib/profiles.py", line 195, in execute
    self.spec.loader.exec_module(sys.modules[self.namespace])
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3.10/site-packages/archinstall/examples/guided.py", line 307, in <module>
    perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
  File "/usr/lib/python3.10/site-packages/archinstall/examples/guided.py", line 137, in perform_installation
    with archinstall.Installer(mountpoint, kernels=archinstall.arguments.get('kernels', ['linux'])) as installation:
  File "/usr/lib/python3.10/site-packages/archinstall/lib/installer.py", line 159, in __exit__
    raise args[1]
  File "/usr/lib/python3.10/site-packages/archinstall/examples/guided.py", line 187, in perform_installation
    if installation.minimal_installation(testing=enable_testing, multilib=enable_multilib):
  File "/usr/lib/python3.10/site-packages/archinstall/lib/installer.py", line 761, in minimal_installation
    if storage['arguments']['HSM']:
KeyError: 'HSM'
```

```
Traceback (most recent call last):
  File "/usr/bin/archinstall", line 8, in <module>
    sys.exit(run_as_a_module())
  File "/usr/lib/python3.10/site-packages/archinstall/__init__.py", line 281, in run_as_a_module
    script.execute()
  File "/usr/lib/python3.10/site-packages/archinstall/lib/profiles.py", line 195, in execute
    self.spec.loader.exec_module(sys.modules[self.namespace])
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3.10/site-packages/archinstall/examples/guided.py", line 307, in <module>
    perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
  File "/usr/lib/python3.10/site-packages/archinstall/examples/guided.py", line 137, in perform_installation
    with archinstall.Installer(mountpoint, kernels=archinstall.arguments.get('kernels', ['linux'])) as installation:
  File "/usr/lib/python3.10/site-packages/archinstall/lib/installer.py", line 159, in __exit__
    raise args[1]
  File "/usr/lib/python3.10/site-packages/archinstall/examples/guided.py", line 190, in perform_installation
    if archinstall.arguments['mirror-region'].get("mirrors", None) is not None:
KeyError: 'mirror-region'

```

```
Traceback (most recent call last):
  File "/usr/bin/archinstall", line 8, in <module>
    sys.exit(run_as_a_module())
  File "/usr/lib/python3.10/site-packages/archinstall/__init__.py", line 281, in run_as_a_module
    script.execute()
  File "/usr/lib/python3.10/site-packages/archinstall/lib/profiles.py", line 195, in execute
    self.spec.loader.exec_module(sys.modules[self.namespace])
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3.10/site-packages/archinstall/examples/guided.py", line 278, in <module>
    if not archinstall.arguments['offline']:
KeyError: 'offline'
```

Looking at the code all of these issues stem from attempting to access objects in a dictionary via keys that do not exist.
The proper way to access items in a dictionary when it is unknown if the key exists is via the `dict.get('key')` method, which will return None if the given key does not exist and it's corresponding value cannot be retrieved.
Accessing a dictionary via `dict['key']` will raise a KeyError if the key does not exist, which is what is causing these crashes.
```
root@archiso ~ # python
Python 3.10.4 (main, May 14 2022, 05:21:19) [GCC 12.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> test = {"key1": 1, "key2": 2}
>>> if test["key1"]:
...     print(1)

1
>>> if test["key3"]:
...     print(3)
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'key3'
```

I have fixed several of these issues in this pull request in order to get my configs to work. 
It would be a good idea to review the rest of the code base for other uses of `dict['key']` in order to prevent any other unexpected issues.


# Testing

Tested on Live ISO, does not crash where it was crashing before.
