### PR TITLE
Handle no internet connection gracefully

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -254,7 +254,7 @@ def verify_internet_connection():
 		req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
 		urllib.request.urlopen(req, timeout=5)
 	except Exception as e:
-		err = str(_('To run archinstall your system must have internet access.'))
+		err = str(_('Your system must have internet access to be able to run archinstall'))
 		log(err, fg="red", level=logging.WARNING)
 		sys.exit(1)
 

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -1,4 +1,5 @@
 """Arch Linux installer - guided, templates etc."""
+import sys
 from argparse import ArgumentParser
 
 from .lib.disk import *
@@ -245,6 +246,20 @@ def post_process_arguments(arguments):
 	load_config()
 
 
+def verify_internet_connection():
+	from urllib.request import urlopen
+	try:
+		import urllib.request
+		url = 'https://1.1.1.1'
+		req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+		urllib.request.urlopen(req, timeout=5)
+	except Exception as e:
+		err = str(_('To run archinstall your system must have internet access.'))
+		log(err, fg="red", level=logging.WARNING)
+		sys.exit(1)
+
+
+verify_internet_connection()
 define_arguments()
 arguments = get_arguments()
 post_process_arguments(arguments)

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -1,5 +1,4 @@
 """Arch Linux installer - guided, templates etc."""
-import sys
 from argparse import ArgumentParser
 
 from .lib.disk import *

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -246,20 +246,6 @@ def post_process_arguments(arguments):
 	load_config()
 
 
-def verify_internet_connection():
-	from urllib.request import urlopen
-	try:
-		import urllib.request
-		url = 'https://1.1.1.1'
-		req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-		urllib.request.urlopen(req, timeout=5)
-	except Exception:
-		err = str(_('Your system must have internet access to be able to run archinstall'))
-		log(err, fg="red", level=logging.WARNING)
-		sys.exit(1)
-
-
-verify_internet_connection()
 define_arguments()
 arguments = get_arguments()
 post_process_arguments(arguments)

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -253,7 +253,7 @@ def verify_internet_connection():
 		url = 'https://1.1.1.1'
 		req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
 		urllib.request.urlopen(req, timeout=5)
-	except Exception as e:
+	except Exception:
 		err = str(_('Your system must have internet access to be able to run archinstall'))
 		log(err, fg="red", level=logging.WARNING)
 		sys.exit(1)

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -4,7 +4,7 @@ import socket
 import struct
 from typing import Union, Dict, Any, List
 
-from .exceptions import HardwareIncompatibilityError
+from .exceptions import HardwareIncompatibilityError, SysCallError
 from .general import SysCommand
 from .output import log
 from .pacman import run_pacman
@@ -33,13 +33,16 @@ def list_interfaces(skip_loopback :bool = True) -> Dict[str, str]:
 
 def check_mirror_reachable() -> bool:
 	log("Testing connectivity to the Arch Linux mirrors ...", level=logging.INFO)
-	if run_pacman("-Sy").exit_code == 0:
-		return True
-
-	elif os.geteuid() != 0:
-		log("check_mirror_reachable() uses 'pacman -Sy' which requires root.", level=logging.ERROR, fg="red")
+	try:
+		if run_pacman("-Sy").exit_code == 0:
+			return True
+		elif os.geteuid() != 0:
+			log("check_mirror_reachable() uses 'pacman -Sy' which requires root.", level=logging.ERROR, fg="red")
+	except SysCallError as err:
+		log(err, level=logging.DEBUG)
 
 	return False
+
 
 def update_keyring() -> bool:
 	log("Updating archlinux-keyring ...", level=logging.INFO)


### PR DESCRIPTION
When starting archinstall and there's not internet access it will fail with a cryptic error message such as reported in https://github.com/archlinux/archinstall/issues/1357 and https://github.com/archlinux/archinstall/issues/1347. 

# Changes
This PR validates if there's an internet connection available on the system and if not will terminate gracefully with a respective message 

```
Your system must have internet access to be able to run archinstall
```