### PR TITLE
Change regex expression only to match #[multilib] string

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -325,7 +325,7 @@ class Installer:
 
 	def enable_multilib_repository(self):
 		# Set up a regular expression pattern of a commented line containing 'multilib' within []
-		pattern = re.compile("^#\\[.*multilib.*\\]$")
+		pattern = re.compile("^#\\[.*multilib*\\]$")
 
 		# This is used to track if the previous line is a match, so we end up uncommenting the line after the block.
 		matched = False

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -325,7 +325,7 @@ class Installer:
 
 	def enable_multilib_repository(self):
 		# Set up a regular expression pattern of a commented line containing 'multilib' within []
-		pattern = re.compile("^#\\[.*multilib*\\]$")
+		pattern = re.compile("^#\s*\[multilib\]$")
 
 		# This is used to track if the previous line is a match, so we end up uncommenting the line after the block.
 		matched = False

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -325,7 +325,7 @@ class Installer:
 
 	def enable_multilib_repository(self):
 		# Set up a regular expression pattern of a commented line containing 'multilib' within []
-		pattern = re.compile("^#\s*\[multilib\]$")
+		pattern = re.compile(r"^#\s*\[multilib\]$")
 
 		# This is used to track if the previous line is a match, so we end up uncommenting the line after the block.
 		matched = False


### PR DESCRIPTION
# Describe your PR

- By enabling **`multilib`** repository in **`Optional repositories`** menu also enables **`multilib-testing`** repository.

- This is due to period **`.`** at the end of **`multilib`** keyword in the regex expression which matches both **`#[multilib]`** and **`#[multilib-testing]`** keywords

     https://github.com/archlinux/archinstall/blob/a7ca037a26de53fd242f89bc6a90fd53337b4d13/archinstall/lib/installer.py#L328

- By removing it will match only **`#[multilib]`**

- This PR resolves [#1317](https://github.com/archlinux/archinstall/issues/1317)


# Testing

- Tested on live ISO
