### PR TITLE
restoring ability to use a predefined installation directory

### DIFF
--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 class GlobalMenu(GeneralMenu):
 	def __init__(self,data_store):
+		self._disk_check = True
 		super().__init__(data_store=data_store, auto_cursor=True, preview_size=0.3)
 
 	def _setup_selection_menu_options(self):
@@ -303,11 +304,12 @@ class GlobalMenu(GeneralMenu):
 			missing += ['Hostname']
 		if not check('!root-password') and not has_superuser():
 			missing += [str(_('Either root-password or at least 1 user with sudo privileges must be specified'))]
-		if not check('harddrives'):
-			missing += [str(_('Drive(s)'))]
-		if check('harddrives'):
-			if not self._menu_options['harddrives'].is_empty() and not check('disk_layouts'):
-				missing += [str(_('Disk layout'))]
+		if self._disk_check:
+			if not check('harddrives'):
+				missing += [str(_('Drive(s)'))]
+			if check('harddrives'):
+				if not self._menu_options['harddrives'].is_empty() and not check('disk_layouts'):
+					missing += [str(_('Disk layout'))]
 
 		return missing
 
@@ -333,7 +335,7 @@ class GlobalMenu(GeneralMenu):
 	def _select_harddrives(self, old_harddrives : list) -> List:
 		harddrives = select_harddrives(old_harddrives)
 
-		if harddrives:
+		if harddrives is not None:
 			if len(harddrives) == 0:
 				prompt = _(
 					"You decided to skip harddrive selection\nand will use whatever drive-setup is mounted at {} (experimental)\n"
@@ -344,7 +346,10 @@ class GlobalMenu(GeneralMenu):
 				choice = Menu(prompt, Menu.yes_no(), default_option=Menu.yes(), skip=False).run()
 
 				if choice.value == Menu.no():
+					self._disk_check = True
 					return self._select_harddrives(old_harddrives)
+				else:
+					self._disk_check = False
 
 			# in case the harddrives got changed we have to reset the disk layout as well
 			if old_harddrives != harddrives:


### PR DESCRIPTION
Seems that somewhere along the line we lost the ability to let archinstall use a predefined `mountpoint` (be it the default `/mnt/archinstall` or another one, at least using the `guided.py` script.
It happens at least from 2.5.0 and probably earlier.  Beside other minor troubles, the missing validator at GlobalMenu wasn't able to let an empty harddrives list be considered correct in this use case
This PR resolves this problem, and lets the way open to handle this use case thru an invocation argument (not implemented by now)