### PR TITLE
enhacements to FormattedOutput

### DIFF
--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -5,42 +5,80 @@ from pathlib import Path
 from typing import Dict, Union, List, Any
 
 from .storage import storage
+from dataclasses import asdict, is_dataclass
 
 
 class FormattedOutput:
 
 	@classmethod
-	def values(cls, o: Any) -> Dict[str, Any]:
-		if hasattr(o, 'as_json'):
+	def values(cls, o: Any, class_formatter: str = None, filter_list: List[str] = None) -> Dict[str, Any]:
+		""" the original values returned a dataclass as dict thru the call to some specific methods
+		this version allows thru the parameter class_formatter to call a dynamicly selected formatting method.
+		Can transmit a filter list to the class_formatter,
+		"""
+		if class_formatter:
+			# if invoked per reference it has to be a standard function or a classmethod.
+			# A method of an instance does not make sense
+			if callable(class_formatter):
+				return class_formatter(o, filter_list)
+			# if is invoked by name we restrict it to a method of the class. No need to mess more
+			elif hasattr(o, class_formatter) and callable(getattr(o, class_formatter)):
+				func = getattr(o, class_formatter)
+				return func(filter_list)
+		# kept as to make it backward compatible
+		elif hasattr(o, 'as_json'):
 			return o.as_json()
 		elif hasattr(o, 'json'):
 			return o.json()
+		elif is_dataclass(o):
+			return asdict(o)
 		else:
 			return o.__dict__
 
 	@classmethod
-	def as_table(cls, obj: List[Any]) -> str:
+	def as_table(cls, obj: List[Any], class_formatter: Union[str, Callable] = None, filter_list: List[str] = None) -> str:
+		""" variant of as_table (subtly different code) which has two additional parameters
+		filter which is a list of fields which will be shon
+		class_formatter a special method to format the outgoing data
+
+		A general comment, the format selected for the output (a string where every data record is separated by newline)
+		is for compatibility with a print statement
+		As_table_filter can be a drop in replacement for as_table
+		"""
+		raw_data = [cls.values(o, class_formatter, filter_list) for o in obj]
+		# determine the maximum column size
 		column_width: Dict[str, int] = {}
-		for o in obj:
-			for k, v in cls.values(o).items():
-				column_width.setdefault(k, 0)
-				column_width[k] = max([column_width[k], len(str(v)), len(k)])
+		for o in raw_data:
+			for k, v in o.items():
+				if not filter_list or k in filter_list:
+					column_width.setdefault(k, 0)
+					column_width[k] = max([column_width[k], len(str(v)), len(k)])
 
+		if not filter_list:
+			filter_list = (column_width.keys())
+		# create the header lines
 		output = ''
-		for key, width in column_width.items():
+		key_list = []
+		for key in filter_list:
+			width = column_width[key]
 			key = key.replace('!', '')
-			output += key.ljust(width) + ' | '
-
-		output = output[:-3] + '\n'
+			key_list.append(key.ljust(width))
+		output += ' | '.join(key_list) + '\n'
 		output += '-' * len(output) + '\n'
 
-		for o in obj:
-			for k, v in cls.values(o).items():
-				if '!' in k:
-					v = '*' * len(str(v))
-				output += str(v).ljust(column_width[k]) + ' | '
-			output = output[:-3]
-			output += '\n'
+		# create the data lines
+		for record in raw_data:
+			obj_data = []
+			for key in filter_list:
+				width = column_width.get(key, len(key))
+				value = record.get(key, '')
+				if '!' in key:
+					value = '*' * width
+				if isinstance(value,(int, float)) or (isinstance(value, str) and value.isnumeric()):
+					obj_data.append(str(value).rjust(width))
+				else:
+					obj_data.append(str(value).ljust(width))
+			output += ' | '.join(obj_data) + '\n'
 
 		return output
 

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Dict, Union, List, Any
+from typing import Dict, Union, List, Any, Callable
 
 from .storage import storage
 from dataclasses import asdict, is_dataclass


### PR DESCRIPTION
This PR contains some enhancements to the FormattedOutput class.

The main enhacements is to add (and handle) two new optional parameters to the `FormattedOutput.as_table` classmethod:
* `Filter` which is a list of a subset atrributes from the class to be exclusively shown. This list also determines the presentation order
* `class_formatter` which is the name or reference of a callable, to do the recovery and formatting of the data (being used at the `FormattedOutput.values` classmethod. If it is a name, it must be a method of the dataclass and accept a filter list as parameter. If it is a Callable can be anything (class methods are not recomended unless they are `classmethod`) and has to accept the object reference and a filter_list as arguments. They will return a dictionary of data keyed by the field name.

Filter settings are processed at the `as_table` level, but can also be used at the `class_method` one.
A class_method can create, drop, or merge output fields without restriction


While there are API compatible with the current implementation, they show, by design, some deviant runtime behaviour you should be aware:
* "Secret" fields -those whose name is prefixed with an exclamantion mark (!)- are shown with an uniform width, as not to give away the actual field (password) lenght
* Numeric fields are right justified by default. Numeric fields in this context are those which return True to isnumeric() or are int or float. If you need some fancy formatting or process numbers with thousand separators, please use the `class_formatter`
* The default content of a dataclass will be extracted with the dataclasses.asdict() function. This might produce some differences at output with the default __dict__

As a sample we create a very simple dataclass 
```python
@dataclass
class Person:
	first_name: str
	family_name: str
	add_name: str
	nationality: str
	anualincome: int

	def simple_formatter(self,field_list=None):
        # we add, modify and delete the attribute
		data = asdict(self)
		data['full name'] = f"{self.family_name} {self.first_name}" if self.nationality in ('hun','roc','prc','jpn','kor') else f"{self.first_name} {self.family_name}"
		data['income'] = f"{self.anualincome:>12,}"
		del data['anualincome']
		return data

	def more_complex(self,field_list=None):
        # the same as above, but we only return a subset of fields
		data = self.simple_formatter(field_list)
		if field_list is None:
			field_list = list(data.keys())
		short_data = {}
		for k in field_list:
			short_data[k] = data.get(k,'')
		return short_data

	@classmethod
	def my_formatter(cls,o,field_list=None):
        # the same as above, but using classmethod syntax, for using it by reference
		return o.simple_formatter(field_list)

```

```python
# And this are some examples

*** with the actual implementation ***

first_name       | family_name | add_name | nationality | anualincome
----------------------------------------------------------------------
jose             | garcia      | perez    | esp         | 36000      
Gregor Friedrich | Hegel       | None     | ger         | 127000     
Istvan           | Szabo       | None     | hun         | 7251       
Liu              | Chang       | Hua      | roc         | 625      

>>print(FormattedOutput.as_table(lista))

first_name       | family_name | add_name | nationality | anualincome
----------------------------------------------------------------------
jose             | garcia      | perez    | esp         |       36000
Gregor Friedrich | Hegel       | None     | ger         |      127000
Istvan           | Szabo       | None     | hun         |        7251
Liu              | Chang       | Hua      | roc         |         625

>> print(FormattedOutput.as_table(lista, filter_list=['family_name', 'first_name', 'anualincome']))

family_name | first_name       | anualincome
---------------------------------------------
garcia      | jose             |       36000
Hegel       | Gregor Friedrich |      127000
Szabo       | Istvan           |        7251
Chang       | Liu              |         625

print(FormattedOutput.as_table(lista, class_formatter='simple_formatter'))

first_name       | family_name | add_name | nationality | full name              | income      
------------------------------------------------------------------------------------------------
jose             | garcia      | perez    | esp         | jose garcia            |       36,000
Gregor Friedrich | Hegel       | None     | ger         | Gregor Friedrich Hegel |      127,000
Istvan           | Szabo       | None     | hun         | Szabo Istvan           |        7,251
Liu              | Chang       | Hua      | roc         | Chang Liu              |          625

# this three give the same result
print(FormattedOutput.as_table(lista, class_formatter='simple_formatter',
							   filter_list=['full name', 'nationality', 'income']))
print(FormattedOutput.as_table(lista, class_formatter='more_complex', filter_list=['full name', 'nationality', 'income']))
print(FormattedOutput.as_table(lista, class_formatter=Person.my_formatter,
							   filter_list=['full name', 'nationality', 'income']))


full name              | nationality | income      
----------------------------------------------------
jose garcia            | esp         |       36,000
Gregor Friedrich Hegel | ger         |      127,000
Szabo Istvan           | hun         |        7,251
Chang Liu              | roc         |          625



Process finished with exit code 0
```