### PR TITLE
Enhacements to scripts for developers

### DIFF
--- a/examples/guided.py
+++ b/examples/guided.py
@@ -1,6 +1,18 @@
 import logging
 import os
 import time
+from inspect import getsourcefile
+
+if __name__ == '__main__':
+	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
+	# will work only with the copy at examples
+	# this solution was taken from https://stackoverflow.com/questions/714063/importing-modules-from-parent-folder/33532002#33532002
+	import os.path, sys
+	from inspect import getsourcefile
+	current_path = os.path.abspath(getsourcefile(lambda: 0))
+	current_dir = os.path.dirname(current_path)
+	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]
+	sys.path.append(parent_dir)
 
 import archinstall
 from archinstall import ConfigurationOutput, Menu
@@ -288,20 +300,24 @@ if not archinstall.arguments['offline']:
 			archinstall.log(f"Failed to update the keyring. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 			exit(1)
 
-if not archinstall.arguments.get('silent'):
-	ask_user_questions()
+nomen = getsourcefile(lambda: 0)
+script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
 
-config_output = ConfigurationOutput(archinstall.arguments)
-if not archinstall.arguments.get('silent'):
-	config_output.show()
-config_output.save()
+if __name__ in ('__main__',script_name):
+	if not archinstall.arguments.get('silent'):
+		ask_user_questions()
 
-if archinstall.arguments.get('dry_run'):
-	exit(0)
+	config_output = ConfigurationOutput(archinstall.arguments)
+	if not archinstall.arguments.get('silent'):
+		config_output.show()
+	config_output.save()
 
-if not archinstall.arguments.get('silent'):
-	input(str(_('Press Enter to continue.')))
+	if archinstall.arguments.get('dry_run'):
+		exit(0)
 
-archinstall.configuration_sanity_check()
-perform_filesystem_operations()
-perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
+	if not archinstall.arguments.get('silent'):
+		input(str(_('Press Enter to continue.')))
+
+	archinstall.configuration_sanity_check()
+	perform_filesystem_operations()
+	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -7,8 +7,7 @@ if __name__ == '__main__':
 	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
 	# will work only with the copy at examples
 	# this solution was taken from https://stackoverflow.com/questions/714063/importing-modules-from-parent-folder/33532002#33532002
-	import os.path, sys
-	from inspect import getsourcefile
+	import sys
 	current_path = os.path.abspath(getsourcefile(lambda: 0))
 	current_dir = os.path.dirname(current_path)
 	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]

--- a/examples/only_hd.py
+++ b/examples/only_hd.py
@@ -3,6 +3,18 @@ import logging
 import os
 import pathlib
 
+from inspect import getsourcefile
+
+if __name__ == '__main__':
+	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
+	# will work only with the copy at examples
+	# this solution was taken from https://stackoverflow.com/questions/714063/importing-modules-from-parent-folder/33532002#33532002
+	import sys
+	current_path = os.path.abspath(getsourcefile(lambda: 0))
+	current_dir = os.path.dirname(current_path)
+	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]
+	sys.path.append(parent_dir)
+
 import archinstall
 from archinstall import ConfigurationOutput
 
@@ -134,18 +146,24 @@ if not archinstall.check_mirror_reachable():
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
-if not archinstall.arguments.get('silent'):
-	ask_user_questions()
 
-config_output = ConfigurationOutput(archinstall.arguments)
-if not archinstall.arguments.get('silent'):
-	config_output.show()
-config_output.save()
+nomen = getsourcefile(lambda: 0)
+script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
 
-if archinstall.arguments.get('dry_run'):
-	exit(0)
-if not archinstall.arguments.get('silent'):
-	input('Press Enter to continue.')
+if __name__ in ('__main__',script_name):
 
-perform_disk_operations()
-perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
+	if not archinstall.arguments.get('silent'):
+		ask_user_questions()
+
+	config_output = ConfigurationOutput(archinstall.arguments)
+	if not archinstall.arguments.get('silent'):
+		config_output.show()
+	config_output.save()
+
+	if archinstall.arguments.get('dry_run'):
+		exit(0)
+	if not archinstall.arguments.get('silent'):
+		input('Press Enter to continue.')
+
+	perform_disk_operations()
+	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))

--- a/examples/swiss.py
+++ b/examples/swiss.py
@@ -19,6 +19,19 @@ import time
 import pathlib
 from typing import TYPE_CHECKING, Any
 
+from inspect import getsourcefile
+
+if __name__ == '__main__':
+	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
+	# will work only with the copy at examples
+	# this solution was taken from https://stackoverflow.com/questions/714063/importing-modules-from-parent-folder/33532002#33532002
+	import sys
+	current_path = os.path.abspath(getsourcefile(lambda: 0))
+	current_dir = os.path.dirname(current_path)
+	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]
+	sys.path.append(parent_dir)
+
+
 import archinstall
 from archinstall import ConfigurationOutput, NetworkConfigurationHandler, Menu
 
@@ -495,20 +508,25 @@ if not archinstall.check_mirror_reachable():
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
-mode = archinstall.arguments.get('mode', 'full').lower()
-if not archinstall.arguments.get('silent'):
-	ask_user_questions(mode)
+nomen = getsourcefile(lambda: 0)
+script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
 
-config_output = ConfigurationOutput(archinstall.arguments)
-if not archinstall.arguments.get('silent'):
-	config_output.show()
-config_output.save()
+if __name__ in ('__main__',script_name):
 
-if archinstall.arguments.get('dry_run'):
-	exit(0)
-if not archinstall.arguments.get('silent'):
-	input('Press Enter to continue.')
+	mode = archinstall.arguments.get('mode', 'full').lower()
+	if not archinstall.arguments.get('silent'):
+		ask_user_questions(mode)
 
-if mode in ('full','only_hd'):
-	perform_filesystem_operations()
-perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'), mode)
+	config_output = ConfigurationOutput(archinstall.arguments)
+	if not archinstall.arguments.get('silent'):
+		config_output.show()
+	config_output.save()
+
+	if archinstall.arguments.get('dry_run'):
+		exit(0)
+	if not archinstall.arguments.get('silent'):
+		input('Press Enter to continue.')
+
+	if mode in ('full','only_hd'):
+		perform_filesystem_operations()
+	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'), mode)


### PR DESCRIPTION
two small enhacements to script execution.
1) Ability to be invoked directly without the need of using the `-m archinstall` . Also, in PyCharm and Kdevelop at least i managed to execute the scripts inside the IDE (a bit more tinkering is requiered 'cause the sudo)
This is achieved playing with the python path:
```python
if __name__ == '__main__':
	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
	# will work only with the copy at examples
	# this solution was taken from https://stackoverflow.com/questions/714063/importing-modules-from-parent-folder/33532002#33532002
	import sys
	current_path = os.path.abspath(getsourcefile(lambda: 0))
	current_dir = os.path.dirname(current_path)
	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]
	sys.path.append(parent_dir)
```
2) Ability to get functions called extenally from other scripts:

Just separating code with has not to be executed if it is imported as a library inside this block[¹]
```python
nomen = getsourcefile(lambda: 0)
script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
if __name__ in ('__main__',script_name):
    ....
```
In the other script the functions can be imported via [²]
```python
from archinstall.examples.guided import perform_filesystem_operations, perform_installation
```

[¹]the two previous lines are to get the name of the script from the system (could have done from archinstall.arguments[script], but is more generic).  That `getsourcefile` is from `inspect` -thus the weird syntax-
[²]As long as we keep the shadow copy between  archinstall/examples and examples