### PR TITLE
Add Qt5 bindings for PackageKit for Discover to work properly

### DIFF
--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -12,7 +12,8 @@ __packages__ = [
 	"ark",
 	"sddm",
 	"plasma-wayland-session",
-	"egl-wayland"
+	"egl-wayland",
+	"packagekit-qt5"
 ]
 
 


### PR DESCRIPTION
Add packagekit-qt5 dependency to fix discover from not working, because plasma-meta package comes with discover which won't work on arch Linux without packagekit-qt5 dependency

this pull request is related to this issue #1379