### PR TITLE
Enhacements to scripts for developers (II)

### DIFF
--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -279,7 +279,7 @@ class Partition:
 			log(f"Could not reliably refresh PARTUUID of partition {self.device_path} due to partprobe error.", level=logging.DEBUG)
 
 		try:
-			return self.block_device.uuid
+			return SysCommand(f'blkid -s PARTUUID -o value {self.device_path}').decode('UTF-8').strip()
 		except SysCallError as error:
 			if self.block_device.partition_type == 'iso9660':
 				# Parent device is a Optical Disk (.iso dd'ed onto a device for instance)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -631,7 +631,7 @@ class Installer:
 			mkinit.write(f"BINARIES=({' '.join(self.BINARIES)})\n")
 			mkinit.write(f"FILES=({' '.join(self.FILES)})\n")
 
-			if not storage['arguments']['HSM']:
+			if not storage['arguments'].get('HSM',None):
 				# For now, if we don't use HSM we revert to the old
 				# way of setting up encryption hooks for mkinitcpio.
 				# This is purely for stability reasons, we're going away from this.
@@ -737,7 +737,7 @@ class Installer:
 		# TODO: Use python functions for this
 		SysCommand(f'/usr/bin/arch-chroot {self.target} chmod 700 /root')
 
-		if storage['arguments']['HSM']:
+		if storage['arguments'].get('HSM',None):
 			# TODO:
 			# A bit of a hack, but we need to get vconsole.conf in there
 			# before running `mkinitcpio` because it expects it in HSM mode.

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 class GlobalMenu(GeneralMenu):
 	def __init__(self,data_store):
+		self._disk_check = True
 		super().__init__(data_store=data_store, auto_cursor=True, preview_size=0.3)
 
 	def _setup_selection_menu_options(self):
@@ -303,11 +304,12 @@ class GlobalMenu(GeneralMenu):
 			missing += ['Hostname']
 		if not check('!root-password') and not has_superuser():
 			missing += [str(_('Either root-password or at least 1 user with sudo privileges must be specified'))]
-		if not check('harddrives'):
-			missing += [str(_('Drive(s)'))]
-		if check('harddrives'):
-			if not self._menu_options['harddrives'].is_empty() and not check('disk_layouts'):
-				missing += [str(_('Disk layout'))]
+		if self._disk_check:
+			if not check('harddrives'):
+				missing += [str(_('Drive(s)'))]
+			if check('harddrives'):
+				if not self._menu_options['harddrives'].is_empty() and not check('disk_layouts'):
+					missing += [str(_('Disk layout'))]
 
 		return missing
 
@@ -333,7 +335,7 @@ class GlobalMenu(GeneralMenu):
 	def _select_harddrives(self, old_harddrives : list) -> List:
 		harddrives = select_harddrives(old_harddrives)
 
-		if harddrives:
+		if harddrives is not None:
 			if len(harddrives) == 0:
 				prompt = _(
 					"You decided to skip harddrive selection\nand will use whatever drive-setup is mounted at {} (experimental)\n"
@@ -344,7 +346,10 @@ class GlobalMenu(GeneralMenu):
 				choice = Menu(prompt, Menu.yes_no(), default_option=Menu.yes(), skip=False).run()
 
 				if choice.value == Menu.no():
+					self._disk_check = True
 					return self._select_harddrives(old_harddrives)
+				else:
+					self._disk_check = False
 
 			# in case the harddrives got changed we have to reset the disk layout as well
 			if old_harddrives != harddrives:

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -442,15 +442,17 @@ class GeneralMenu:
 	def set_mandatory(self, field :str, status :bool):
 		self.option(field).set_mandatory(status)
 
-	def mandatory_overview(self) -> Tuple[int, int]:
+	def mandatory_overview(self) -> Tuple[int, int, List[str]]:
 		mandatory_fields = 0
 		mandatory_waiting = 0
+		mandatory_field_missing = []
 		for field, option in self._menu_options.items():
 			if option.is_mandatory():
 				mandatory_fields += 1
 				if not option.has_selection():
 					mandatory_waiting += 1
-		return mandatory_fields, mandatory_waiting
+					mandatory_field_missing.append(field)
+		return mandatory_fields, mandatory_waiting, mandatory_field_missing
 
 	def _select_archinstall_language(self, preset_value: str) -> str:
 		from ... import select_archinstall_language

--- a/archinstall/lib/user_interaction/backwards_compatible_conf.py
+++ b/archinstall/lib/user_interaction/backwards_compatible_conf.py
@@ -61,15 +61,16 @@ def generic_select(
 	soptions = list(map(str, options))
 	default_value = options[options.index(default)] if default else None
 
-	selected_option = Menu(input_text,
-							soptions,
-							skip=allow_empty_input,
-							multi=multi,
-							default_option=default_value,
-							sort=sort).run()
+	selected = Menu(input_text,
+					soptions,
+					skip=allow_empty_input,
+					multi=multi,
+					default_option=default_value,
+					sort=sort).run()
 	# we return the original objects, not the strings.
 	# options is the list with the original objects and soptions the list with the string values
 	# thru the map, we get from the value selected in soptions it index, and thu it the original object
+	selected_option = selected.value
 	if not selected_option:
 		return selected_option
 	elif isinstance(selected_option, list):  # for multi True

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -46,7 +46,6 @@ def ask_user_questions():
 	global_menu.enable('harddrives')
 
 	global_menu.enable('disk_layouts')
-
 	# Get disk encryption password (or skip if blank)
 	global_menu.enable('!encryption-password')
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -174,7 +174,7 @@ def setup_network(installation):
 def setup_audio(installation):
 	if archinstall.arguments.get('audio', None) is not None:
 		installation.log(f"This audio server will be used: {archinstall.arguments.get('audio', None)}",
-						 level=logging.INFO)
+						level=logging.INFO)
 		if archinstall.arguments.get('audio', None) == 'pipewire':
 			archinstall.Application(installation, 'pipewire').install()
 		elif archinstall.arguments.get('audio', None) == 'pulseaudio':
@@ -328,6 +328,8 @@ def perform_installation(mountpoint,mode='full'):
 #
 # initalization steps Executed once per session
 #
+
+
 if archinstall.arguments.get('help'):
 	print("See `man archinstall` for help.")
 	exit(0)
@@ -357,19 +359,19 @@ if not archinstall.arguments['offline']:
 	# and the installed package version is lower than the upstream version
 	if archinstall.arguments.get('skip-keyring-update', False) is False and \
 		archinstall.installed_package('archlinux-keyring').version < latest_version_archlinux_keyring:
-
-
 		# Then we update the keyring in the ISO environment
 		if not archinstall.update_keyring():
 			log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
 			archinstall.log(f"Failed to update the keyring. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 			exit(1)
 
+#
+# script specific code:
+#  this is the main loop code
+#  If you want to create the script copy this, add an import archinstall.example.guided or similar statements and start adapting it
+#
 nomen = getsourcefile(lambda: 0)
 script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
-#
-# script specific code
-#
 if __name__ in ('__main__',script_name):
 	if not archinstall.arguments.get('silent'):
 		ask_user_questions()

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -276,6 +276,7 @@ def perform_additional_software_setup(installation):
 
 def perform_installation_base(mountpoint,mode='full'):
 	"""
+	WARNING  is the first variant, kept for reasons, ... the actual perform_installation is coded below
 	This is the main installation routine
 	Performs the installation steps on a block device.
 	Only requirement is that the block devices are
@@ -326,6 +327,7 @@ def perform_installation_base(mountpoint,mode='full'):
 						installation.drop_to_shell()
 					except:
 						pass
+
 def perform_installation(mountpoint,mode='full'):
 	"""
 	This is the main installation routine
@@ -390,6 +392,12 @@ def perform_installation(mountpoint,mode='full'):
 				except:
 					pass
 
+def perform_show_save_arguments():
+	config_output = ConfigurationOutput(archinstall.arguments)
+	if not archinstall.arguments.get('silent'):
+		config_output.show()
+	config_output.save()
+
 #
 # initalization steps Executed once per session
 #
@@ -441,10 +449,7 @@ if __name__ in ('__main__',script_name):
 	if not archinstall.arguments.get('silent'):
 		ask_user_questions()
 
-	config_output = ConfigurationOutput(archinstall.arguments)
-	if not archinstall.arguments.get('silent'):
-		config_output.show()
-	config_output.save()
+	perform_show_save_arguments()
 
 	if archinstall.arguments.get('dry_run'):
 		exit(0)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -286,6 +286,9 @@ def perform_installation_base(mountpoint,mode='full'):
 	disk         only disk layout(
 	software     software
 	"""
+	# prepare the disks, if necessary
+	perform_filesystem_operations()
+
 	with archinstall.Installer(mountpoint, kernels=archinstall.arguments.get('kernels', ['linux'])) as installation:
 		# Mount all the drives to the desired mountpoint
 		if mode.lower() in ('full','disk'):
@@ -335,6 +338,10 @@ def perform_installation(mountpoint,mode='full'):
 	disk         only disk layout(
 	software     software
 	"""
+	# prepare the disks, if necessary
+	if mode in ('full','disk'):
+		perform_filesystem_operations()
+
 	with archinstall.Installer(mountpoint, kernels=archinstall.arguments.get('kernels', ['linux'])) as installation:
 		enable_testing = 'testing' in archinstall.arguments.get('additional-repositories', [])
 		enable_multilib = 'multilib' in archinstall.arguments.get('additional-repositories', [])
@@ -446,7 +453,6 @@ if __name__ in ('__main__',script_name):
 		input(str(_('Press Enter to continue.')))
 
 	archinstall.configuration_sanity_check()
-	perform_filesystem_operations()
 	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
 	# For support reasons, we'll log the disk layout post installation (crash or no crash)
 	archinstall.log(f"Disk states after installing: {archinstall.disk_layouts()}", level=logging.DEBUG)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -1,6 +1,18 @@
 import logging
 import os
 import time
+from inspect import getsourcefile
+
+if __name__ == '__main__':
+	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
+	# will work only with the copy at examples
+	# this solution was taken from https://stackoverflow.com/questions/714063/importing-modules-from-parent-folder/33532002#33532002
+	import os.path, sys
+	from inspect import getsourcefile
+	current_path = os.path.abspath(getsourcefile(lambda: 0))
+	current_dir = os.path.dirname(current_path)
+	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]
+	sys.path.append(parent_dir)
 
 import archinstall
 from archinstall import ConfigurationOutput, Menu
@@ -288,20 +300,24 @@ if not archinstall.arguments['offline']:
 			archinstall.log(f"Failed to update the keyring. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 			exit(1)
 
-if not archinstall.arguments.get('silent'):
-	ask_user_questions()
+nomen = getsourcefile(lambda: 0)
+script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
 
-config_output = ConfigurationOutput(archinstall.arguments)
-if not archinstall.arguments.get('silent'):
-	config_output.show()
-config_output.save()
+if __name__ in ('__main__',script_name):
+	if not archinstall.arguments.get('silent'):
+		ask_user_questions()
 
-if archinstall.arguments.get('dry_run'):
-	exit(0)
+	config_output = ConfigurationOutput(archinstall.arguments)
+	if not archinstall.arguments.get('silent'):
+		config_output.show()
+	config_output.save()
 
-if not archinstall.arguments.get('silent'):
-	input(str(_('Press Enter to continue.')))
+	if archinstall.arguments.get('dry_run'):
+		exit(0)
 
-archinstall.configuration_sanity_check()
-perform_filesystem_operations()
-perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
+	if not archinstall.arguments.get('silent'):
+		input(str(_('Press Enter to continue.')))
+
+	archinstall.configuration_sanity_check()
+	perform_filesystem_operations()
+	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -7,8 +7,7 @@ if __name__ == '__main__':
 	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
 	# will work only with the copy at examples
 	# this solution was taken from https://stackoverflow.com/questions/714063/importing-modules-from-parent-folder/33532002#33532002
-	import os.path, sys
-	from inspect import getsourcefile
+	import sys
 	current_path = os.path.abspath(getsourcefile(lambda: 0))
 	current_dir = os.path.dirname(current_path)
 	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -60,10 +60,7 @@ if __name__ in ('__main__',script_name):
 	if not archinstall.arguments.get('silent'):
 		ask_user_questions()
 
-	config_output = archinstall.ConfigurationOutput(archinstall.arguments)
-	if not archinstall.arguments.get('silent'):
-		config_output.show()
-	config_output.save()
+	guided.perform_show_save_arguments()
 
 	if archinstall.arguments.get('dry_run'):
 		exit(0)

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -17,6 +17,7 @@ from archinstall.lib.models import NetworkConfiguration
 import archinstall.examples.guided as guided
 
 if archinstall.arguments.get('help', None):
+	archinstall.log(" - Alternate disk layout    via -- disk_layouts = <json_file>")
 	archinstall.log(" - Optional disk encryption via --!encryption-password=<password>")
 	archinstall.log(" - Optional systemd network via --network")
 	archinstall.log(" - Optional keyboard layout via --keyboard-layout=<code>")
@@ -74,3 +75,8 @@ if __name__ in ('__main__',script_name):
 	guided.perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
 	# For support reasons, we'll log the disk layout post installation (crash or no crash)
 	archinstall.log(f"Disk states after installing: {archinstall.disk_layouts()}", level=logging.DEBUG)
+	# Once this is done, we output some useful information to the user
+	# And the installation is complete.
+	archinstall.log("There are two new accounts in your installation after reboot:")
+	archinstall.log(" * root (password: airoot)")
+	archinstall.log(" * devel (password: devel)")

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -29,7 +29,7 @@ script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
 #
 def ask_user_questions():
 	arguments = archinstall.arguments
-	storage   = archinstall.storage
+	# storage = archinstall.storage
 	# if we have a disk layouts files we use it (thus we create a minimal test environment fuor a given setup)
 	if not arguments['disk_layouts']:
 		arguments['harddrives'] = archinstall.select_harddrives(None)
@@ -48,12 +48,13 @@ def ask_user_questions():
 		arguments['bootloader'] = 'grub-install'
 	# TODO network setup
 	if arguments.get('network'):
-		arguments['nic'] = [NetworkConfiguration(dhcp = True,
-			dns = None,
-			gateway = None,
-			iface = None,
-			ip = None,
-			type = "iso")]
+		arguments['nic'] = [NetworkConfiguration(dhcp=True,
+			dns=None,
+			gateway=None,
+			iface=None,
+			ip=None,
+			type="iso")]
+
 
 if __name__ in ('__main__',script_name):
 	if not archinstall.arguments.get('silent'):

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -72,7 +72,6 @@ if __name__ in ('__main__',script_name):
 		input(str(_('Press Enter to continue.')))
 
 	archinstall.configuration_sanity_check()
-	guided.perform_filesystem_operations()
 	guided.perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
 	# For support reasons, we'll log the disk layout post installation (crash or no crash)
 	archinstall.log(f"Disk states after installing: {archinstall.disk_layouts()}", level=logging.DEBUG)

--- a/examples/minimal_orig.py
+++ b/examples/minimal_orig.py
@@ -1,0 +1,75 @@
+import archinstall
+
+# Select a harddrive and a disk password
+from archinstall import User
+
+archinstall.log("Minimal only supports:")
+archinstall.log(" * Being installed to a single disk")
+
+if archinstall.arguments.get('help', None):
+	archinstall.log(" - Optional disk encryption via --!encryption-password=<password>")
+	archinstall.log(" - Optional filesystem type via --filesystem=<fs type>")
+	archinstall.log(" - Optional systemd network via --network")
+
+archinstall.arguments['harddrive'] = archinstall.select_disk(archinstall.all_blockdevices())
+
+
+def install_on(mountpoint):
+	# We kick off the installer by telling it where the
+	with archinstall.Installer(mountpoint) as installation:
+		# Strap in the base system, add a boot loader and configure
+		# some other minor details as specified by this profile and user.
+		if installation.minimal_installation():
+			installation.set_hostname('minimal-arch')
+			installation.add_bootloader()
+
+			# Optionally enable networking:
+			if archinstall.arguments.get('network', None):
+				installation.copy_iso_network_config(enable_services=True)
+
+			installation.add_additional_packages(['nano', 'wget', 'git'])
+			installation.install_profile('minimal')
+
+			user = User('devel', 'devel', False)
+			installation.create_users(user)
+
+	# Once this is done, we output some useful information to the user
+	# And the installation is complete.
+	archinstall.log("There are two new accounts in your installation after reboot:")
+	archinstall.log(" * root (password: airoot)")
+	archinstall.log(" * devel (password: devel)")
+
+
+if archinstall.arguments['harddrive']:
+	archinstall.arguments['harddrive'].keep_partitions = False
+
+	print(f" ! Formatting {archinstall.arguments['harddrive']} in ", end='')
+	archinstall.do_countdown()
+
+	# First, we configure the basic filesystem layout
+	with archinstall.Filesystem(archinstall.arguments['harddrive'], archinstall.GPT) as fs:
+		# We use the entire disk instead of setting up partitions on your own
+		if archinstall.arguments['harddrive'].keep_partitions is False:
+			fs.use_entire_disk(root_filesystem_type=archinstall.arguments.get('filesystem', 'btrfs'))
+
+		boot = fs.find_partition('/boot')
+		root = fs.find_partition('/')
+
+		boot.format('fat32')
+
+		# We encrypt the root partition if we got a password to do so with,
+		# Otherwise we just skip straight to formatting and installation
+		if archinstall.arguments.get('!encryption-password', None):
+			root.encrypted = True
+			root.encrypt(password=archinstall.arguments.get('!encryption-password', None))
+
+			with archinstall.luks2(root, 'luksloop', archinstall.arguments.get('!encryption-password', None)) as unlocked_root:
+				unlocked_root.format(root.filesystem)
+				unlocked_root.mount('/mnt')
+		else:
+			root.format(root.filesystem)
+			root.mount('/mnt')
+
+		boot.mount('/mnt/boot')
+
+install_on('/mnt')

--- a/examples/only_hd.py
+++ b/examples/only_hd.py
@@ -1,11 +1,7 @@
-
 import logging
 import os
-import pathlib
 
 from inspect import getsourcefile
-
-
 
 if __name__ == '__main__':
 	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
@@ -81,6 +77,7 @@ def ask_user_questions():
 # script specific code
 #
 
+
 nomen = getsourcefile(lambda: 0)
 script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
 #
@@ -104,4 +101,3 @@ if __name__ in ('__main__',script_name):
 	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'),'disk')
 	# For support reasons, we'll log the disk layout post installation (crash or no crash)
 	archinstall.log(f"Disk states after installing: {archinstall.disk_layouts()}", level=logging.DEBUG)
-

--- a/examples/only_hd.py
+++ b/examples/only_hd.py
@@ -5,6 +5,8 @@ import pathlib
 
 from inspect import getsourcefile
 
+from archinstall.examples.guided import perform_filesystem_operations, perform_installation
+
 if __name__ == '__main__':
 	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
 	# will work only with the copy at examples
@@ -17,6 +19,7 @@ if __name__ == '__main__':
 
 import archinstall
 from archinstall import ConfigurationOutput
+
 
 
 class OnlyHDMenu(archinstall.GlobalMenu):
@@ -74,84 +77,14 @@ def ask_user_questions():
 		menu.option('archinstall-language').set_enabled(False)
 		menu.run()
 
-def perform_disk_operations():
-	"""
-		Issue a final warning before we continue with something un-revertable.
-		We mention the drive one last time, and count from 5 to 0.
-	"""
-	if archinstall.arguments.get('harddrives', None):
-		print(f" ! Formatting {archinstall.arguments['harddrives']} in ", end='')
-		archinstall.do_countdown()
-		"""
-			Setup the blockdevice, filesystem (and optionally encryption).
-			Once that's done, we'll hand over to perform_installation()
-		"""
-		mode = archinstall.GPT
-		if archinstall.has_uefi() is False:
-			mode = archinstall.MBR
-
-		for drive in archinstall.arguments.get('harddrives', []):
-			if archinstall.arguments.get('disk_layouts', {}).get(drive.path):
-				with archinstall.Filesystem(drive, mode) as fs:
-					fs.load_layout(archinstall.arguments['disk_layouts'][drive.path])
-
-def perform_installation(mountpoint):
-	"""
-	Performs the installation steps on a block device.
-	Only requirement is that the block devices are
-	formatted and setup prior to entering this function.
-	"""
-	with archinstall.Installer(mountpoint, kernels=None) as installation:
-		# Mount all the drives to the desired mountpoint
-		# This *can* be done outside of the installation, but the installer can deal with it.
-		if archinstall.arguments.get('disk_layouts'):
-			installation.mount_ordered_layout(archinstall.arguments['disk_layouts'])
-
-		# Placing /boot check during installation because this will catch both re-use and wipe scenarios.
-		for partition in installation.partitions:
-			if partition.mountpoint == installation.target + '/boot':
-				if partition.size <= 0.25: # in GB
-					raise archinstall.DiskError(f"The selected /boot partition in use is not large enough to properly install a boot loader. Please resize it to at least 256MB and re-run the installation.")
-		# to generate a fstab directory holder. Avoids an error on exit and at the same time checks the procedure
-		target = pathlib.Path(f"{mountpoint}/etc/fstab")
-		if not target.parent.exists():
-			target.parent.mkdir(parents=True)
-
-	# For support reasons, we'll log the disk layout post installation (crash or no crash)
-	archinstall.log(f"Disk states after installing: {archinstall.disk_layouts()}", level=logging.DEBUG)
-
-def log_execution_environment():
-	# Log various information about hardware before starting the installation. This might assist in troubleshooting
-	archinstall.log(f"Hardware model detected: {archinstall.sys_vendor()} {archinstall.product_name()}; UEFI mode: {archinstall.has_uefi()}", level=logging.DEBUG)
-	archinstall.log(f"Processor model detected: {archinstall.cpu_model()}", level=logging.DEBUG)
-	archinstall.log(f"Memory statistics: {archinstall.mem_available()} available out of {archinstall.mem_total()} total installed", level=logging.DEBUG)
-	archinstall.log(f"Virtualization detected: {archinstall.virtualization()}; is VM: {archinstall.is_vm()}", level=logging.DEBUG)
-	archinstall.log(f"Graphics devices detected: {archinstall.graphics_devices().keys()}", level=logging.DEBUG)
-
-	# For support reasons, we'll log the disk layout pre installation to match against post-installation layout
-	archinstall.log(f"Disk states before installing: {archinstall.disk_layouts()}", level=logging.DEBUG)
-
-
-if archinstall.arguments.get('help'):
-	print("See `man archinstall` for help.")
-	exit(0)
-if os.getuid() != 0:
-	print("Archinstall requires root privileges to run. See --help for more.")
-	exit(1)
-
-log_execution_environment()
-
-if not archinstall.check_mirror_reachable():
-	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
-	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
-	exit(1)
-
+#
+# script specific code
+#
 
 nomen = getsourcefile(lambda: 0)
 script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
-
+#
 if __name__ in ('__main__',script_name):
-
 	if not archinstall.arguments.get('silent'):
 		ask_user_questions()
 
@@ -162,8 +95,13 @@ if __name__ in ('__main__',script_name):
 
 	if archinstall.arguments.get('dry_run'):
 		exit(0)
-	if not archinstall.arguments.get('silent'):
-		input('Press Enter to continue.')
 
-	perform_disk_operations()
-	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
+	if not archinstall.arguments.get('silent'):
+		input(str(_('Press Enter to continue.')))
+
+	archinstall.configuration_sanity_check()
+	perform_filesystem_operations()
+	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'),'disk')
+	# For support reasons, we'll log the disk layout post installation (crash or no crash)
+	archinstall.log(f"Disk states after installing: {archinstall.disk_layouts()}", level=logging.DEBUG)
+

--- a/examples/only_hd.py
+++ b/examples/only_hd.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
 
 import archinstall
 from archinstall import ConfigurationOutput
-from archinstall.examples.guided import perform_filesystem_operations, perform_installation
+from archinstall.examples.guided import perform_installation, perform_show_save_arguments
 
 
 class OnlyHDMenu(archinstall.GlobalMenu):
@@ -85,10 +85,7 @@ if __name__ in ('__main__',script_name):
 	if not archinstall.arguments.get('silent'):
 		ask_user_questions()
 
-	config_output = ConfigurationOutput(archinstall.arguments)
-	if not archinstall.arguments.get('silent'):
-		config_output.show()
-	config_output.save()
+	perform_show_save_arguments()
 
 	if archinstall.arguments.get('dry_run'):
 		exit(0)
@@ -97,7 +94,7 @@ if __name__ in ('__main__',script_name):
 		input(str(_('Press Enter to continue.')))
 
 	archinstall.configuration_sanity_check()
-	
+
 	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'),'disk')
 	# For support reasons, we'll log the disk layout post installation (crash or no crash)
 	archinstall.log(f"Disk states after installing: {archinstall.disk_layouts()}", level=logging.DEBUG)

--- a/examples/only_hd.py
+++ b/examples/only_hd.py
@@ -97,7 +97,7 @@ if __name__ in ('__main__',script_name):
 		input(str(_('Press Enter to continue.')))
 
 	archinstall.configuration_sanity_check()
-	perform_filesystem_operations()
+	
 	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'),'disk')
 	# For support reasons, we'll log the disk layout post installation (crash or no crash)
 	archinstall.log(f"Disk states after installing: {archinstall.disk_layouts()}", level=logging.DEBUG)

--- a/examples/only_hd.py
+++ b/examples/only_hd.py
@@ -3,6 +3,18 @@ import logging
 import os
 import pathlib
 
+from inspect import getsourcefile
+
+if __name__ == '__main__':
+	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
+	# will work only with the copy at examples
+	# this solution was taken from https://stackoverflow.com/questions/714063/importing-modules-from-parent-folder/33532002#33532002
+	import sys
+	current_path = os.path.abspath(getsourcefile(lambda: 0))
+	current_dir = os.path.dirname(current_path)
+	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]
+	sys.path.append(parent_dir)
+
 import archinstall
 from archinstall import ConfigurationOutput
 
@@ -134,18 +146,24 @@ if not archinstall.check_mirror_reachable():
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
-if not archinstall.arguments.get('silent'):
-	ask_user_questions()
 
-config_output = ConfigurationOutput(archinstall.arguments)
-if not archinstall.arguments.get('silent'):
-	config_output.show()
-config_output.save()
+nomen = getsourcefile(lambda: 0)
+script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
 
-if archinstall.arguments.get('dry_run'):
-	exit(0)
-if not archinstall.arguments.get('silent'):
-	input('Press Enter to continue.')
+if __name__ in ('__main__',script_name):
 
-perform_disk_operations()
-perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))
+	if not archinstall.arguments.get('silent'):
+		ask_user_questions()
+
+	config_output = ConfigurationOutput(archinstall.arguments)
+	if not archinstall.arguments.get('silent'):
+		config_output.show()
+	config_output.save()
+
+	if archinstall.arguments.get('dry_run'):
+		exit(0)
+	if not archinstall.arguments.get('silent'):
+		input('Press Enter to continue.')
+
+	perform_disk_operations()
+	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'))

--- a/examples/only_hd.py
+++ b/examples/only_hd.py
@@ -14,7 +14,6 @@ if __name__ == '__main__':
 	sys.path.append(parent_dir)
 
 import archinstall
-from archinstall import ConfigurationOutput
 from archinstall.examples.guided import perform_installation, perform_show_save_arguments
 
 

--- a/examples/only_hd.py
+++ b/examples/only_hd.py
@@ -5,7 +5,7 @@ import pathlib
 
 from inspect import getsourcefile
 
-from archinstall.examples.guided import perform_filesystem_operations, perform_installation
+
 
 if __name__ == '__main__':
 	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
@@ -19,7 +19,7 @@ if __name__ == '__main__':
 
 import archinstall
 from archinstall import ConfigurationOutput
-
+from archinstall.examples.guided import perform_filesystem_operations, perform_installation
 
 
 class OnlyHDMenu(archinstall.GlobalMenu):

--- a/examples/swiss.py
+++ b/examples/swiss.py
@@ -357,6 +357,4 @@ if __name__ in ('__main__',script_name):
 	if not archinstall.arguments.get('silent'):
 		input('Press Enter to continue.')
 
-	if mode in ('full','disk'):
-		perform_filesystem_operations()
 	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'), archinstall.arguments.get('mode', 'full').lower())

--- a/examples/swiss.py
+++ b/examples/swiss.py
@@ -16,6 +16,7 @@ This script respects the --dry_run argument
 import logging
 import os
 from typing import TYPE_CHECKING, Any
+
 if TYPE_CHECKING:
 	_: Any
 
@@ -33,7 +34,7 @@ if __name__ == '__main__':
 
 import archinstall
 from archinstall import ConfigurationOutput, Menu
-from archinstall.examples.guided import perform_filesystem_operations, perform_installation
+from archinstall.examples.guided import perform_installation, perform_show_save_arguments
 
 """
 particular routines to SetupMenu
@@ -333,7 +334,7 @@ def ask_user_questions(mode):
 			global_menu.set_option('install',
 							archinstall.Selector(
 								global_menu._install_text(),
-								exec_func=lambda n,v: True if global_menu._missing_configs() == 0 else False,
+								exec_func=lambda n,v: True if len(global_menu._missing_configs()) == 0 else False,
 								preview_func=global_menu._prev_install_missing_config,
 								no_store=True, enabled=True))
 			global_menu.run()
@@ -343,18 +344,17 @@ nomen = getsourcefile(lambda: 0)
 script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
 
 if __name__ in ('__main__',script_name):
+
 	mode = archinstall.arguments.get('mode', 'full').lower()
 	if not archinstall.arguments.get('silent'):
 		ask_user_questions(mode)
 
-	config_output = ConfigurationOutput(archinstall.arguments)
-	if not archinstall.arguments.get('silent'):
-		config_output.show()
-	config_output.save()
+	perform_show_save_arguments()
 
 	if archinstall.arguments.get('dry_run'):
 		exit(0)
 	if not archinstall.arguments.get('silent'):
 		input('Press Enter to continue.')
+
 
 	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'), archinstall.arguments.get('mode', 'full').lower())

--- a/examples/swiss.py
+++ b/examples/swiss.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
 	sys.path.append(parent_dir)
 
 import archinstall
-from archinstall import ConfigurationOutput, Menu
+from archinstall import Menu
 from archinstall.examples.guided import perform_installation, perform_show_save_arguments
 
 """
@@ -355,6 +355,5 @@ if __name__ in ('__main__',script_name):
 		exit(0)
 	if not archinstall.arguments.get('silent'):
 		input('Press Enter to continue.')
-
 
 	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'), archinstall.arguments.get('mode', 'full').lower())

--- a/examples/swiss.py
+++ b/examples/swiss.py
@@ -19,6 +19,19 @@ import time
 import pathlib
 from typing import TYPE_CHECKING, Any
 
+from inspect import getsourcefile
+
+if __name__ == '__main__':
+	# to be able to execute simply as python examples/guided.py or (from inside examples python guided.py)
+	# will work only with the copy at examples
+	# this solution was taken from https://stackoverflow.com/questions/714063/importing-modules-from-parent-folder/33532002#33532002
+	import sys
+	current_path = os.path.abspath(getsourcefile(lambda: 0))
+	current_dir = os.path.dirname(current_path)
+	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]
+	sys.path.append(parent_dir)
+
+
 import archinstall
 from archinstall import ConfigurationOutput, NetworkConfigurationHandler, Menu
 
@@ -495,20 +508,25 @@ if not archinstall.check_mirror_reachable():
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)
 
-mode = archinstall.arguments.get('mode', 'full').lower()
-if not archinstall.arguments.get('silent'):
-	ask_user_questions(mode)
+nomen = getsourcefile(lambda: 0)
+script_name = nomen[nomen.rfind(os.path.sep) + 1:nomen.rfind('.')]
 
-config_output = ConfigurationOutput(archinstall.arguments)
-if not archinstall.arguments.get('silent'):
-	config_output.show()
-config_output.save()
+if __name__ in ('__main__',script_name):
 
-if archinstall.arguments.get('dry_run'):
-	exit(0)
-if not archinstall.arguments.get('silent'):
-	input('Press Enter to continue.')
+	mode = archinstall.arguments.get('mode', 'full').lower()
+	if not archinstall.arguments.get('silent'):
+		ask_user_questions(mode)
 
-if mode in ('full','only_hd'):
-	perform_filesystem_operations()
-perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'), mode)
+	config_output = ConfigurationOutput(archinstall.arguments)
+	if not archinstall.arguments.get('silent'):
+		config_output.show()
+	config_output.save()
+
+	if archinstall.arguments.get('dry_run'):
+		exit(0)
+	if not archinstall.arguments.get('silent'):
+		input('Press Enter to continue.')
+
+	if mode in ('full','only_hd'):
+		perform_filesystem_operations()
+	perform_installation(archinstall.storage.get('MOUNT_POINT', '/mnt'), mode)

--- a/examples/swiss.py
+++ b/examples/swiss.py
@@ -15,9 +15,9 @@ This script respects the --dry_run argument
 """
 import logging
 import os
-import time
-import pathlib
 from typing import TYPE_CHECKING, Any
+if TYPE_CHECKING:
+	_: Any
 
 from inspect import getsourcefile
 
@@ -31,21 +31,9 @@ if __name__ == '__main__':
 	parent_dir = current_dir[:current_dir.rfind(os.path.sep)]
 	sys.path.append(parent_dir)
 
-
 import archinstall
-from archinstall import ConfigurationOutput, NetworkConfigurationHandler, Menu
+from archinstall import ConfigurationOutput, Menu
 from archinstall.examples.guided import perform_filesystem_operations, perform_installation
-
-
-if TYPE_CHECKING:
-	_: Any
-
-if archinstall.arguments.get('help'):
-	print("See `man archinstall` for help.")
-	exit(0)
-if os.getuid() != 0:
-	print("Archinstall requires root privileges to run. See --help for more.")
-	exit(1)
 
 """
 particular routines to SetupMenu
@@ -298,7 +286,6 @@ class MyMenu(archinstall.GlobalMenu):
 	def _update_install_text(self, mode='full'):
 		text = self._install_text(mode)
 		self.option('install').update_description(text)
-
 
 
 def ask_user_questions(mode):


### PR DESCRIPTION
This is a followup of PR #1377 (which it of course, includes)  I decided for two different PR as i think this one could be a bit more controversial and merits separate (and probably more intense) review.
The most important change is a more or less thoroughly reorder of `guided.py` code. I've made almost any single action (or a closely related group) as an independent routine ( called `set_*` for changes at the host level and `setup_*` for those at the target level, and a series of groups of this activities ( usually `perform_*`) to manage them as blocks. A lot in the way of classic Pascal code (at least as we were taught in the early 80's)
Why ?
* Improve readability. YMMV, but the abstraction it provides simplifies the understanding of what the code is doing, and the flow of it
* Improve internal maintanability.  it's easier to locate where is the action we need to modify, or change the order of certain actions
* Easier patching. guided.py is the area where (at least me) gets the maximum number of collisions during merges, and the most difficult to sort out. I believe this new structure will limit them, or at least make them easier to resolve
* Improve flexibility (see below)
* Improve reusability (see below)

Against this advantages, it could have also have disadvantages i've tried to minimize
* slighter longer code 
* argument handling. Thanks $DEITY we have a "global memory area" (`archinstall.arguments` and `archinstall.storage`) and a ll-rounder central object instance ( `installation`), which makes that in, almost all, cases (the `setup_*` routines) only need the last as function argument.
* the intermediate routines (those which direct the workflow of actions) can be controversial in it scope, but now it becomes easier to test new arrangements
* future maintenance ... as long as we can stay with this structure, it's easy to expand functionally. But, well ... we are only humans
* the first time merge:. With over 30 PR waiting on the queue, it's very probable that some will impact guided.py code. This have to be ported manually, i'm afraid

## Why it is more flexible.

 A greater level of modularization allows for easier coding of alternate routes. I had at `swiss.py` defined a new application argument (`--mode`) which allows only to execute a subset of functionality. I've ported this over `guided.py` and this is all the code I needed:
```python
def perform_installation(mountpoint,mode='full'):
	"""
	This is the main installation routine
	Performs the installation steps on a block device.
	Only requirement is that the block devices are
	formatted and setup prior to entering this function.
	Planned modes:
	Full install (default)
	Recover      (pacstrap and minimal setup. No user definition. WIP
	disk         only disk layout(
	software     software installation, not storage management
	"""
	with archinstall.Installer(mountpoint, kernels=archinstall.arguments.get('kernels', ['linux'])) as installation:
		# Mount all the drives to the desired mountpoint
		if mode.lower() in ('full','disk'):
			perform_partition_management(installation)
		# setup host environment
		if mode.lower() != 'disk':
			set_ntp_environment(installation)
			set_pacstrap_mirrors()
			# Retrieve list of additional repositories and set boolean values appropriately
			enable_testing = 'testing' in archinstall.arguments.get('additional-repositories',[])
			enable_multilib = 'multilib' in archinstall.arguments.get('additional-repositories',[])
			if mode.lower() != 'software':
				if not installation.minimal_installation(testing=enable_testing, multilib=enable_multilib):
					return
				if mode.lower() != 'recover':
					perform_basic_setup(installation)
					setup_users(installation)
			if mode.lower() != 'recover':
				perform_additional_software_setup(installation)
			# This step must be after profile installs to allow profiles to install language pre-requisits.
			# After which, this step will set the language both for console and x11 if x11 was installed for instance.
			installation.set_keyboard_language(archinstall.arguments.get('keyboard-layout','us'))
			# If the user provided custom commands to be run post-installation, execute them now.
			if archinstall.arguments.get('custom-commands', None):
				archinstall.run_custom_user_commands(archinstall.arguments['custom-commands'], installation)

			installation.genfstab()

			installation.log("For post-installation tips, see https://wiki.archlinux.org/index.php/Installation_guide#Post-installation", fg="yellow")
			if not archinstall.arguments.get('silent') and mode == 'full':
				prompt = str(_('Would you like to chroot into the newly created installation and perform post-installation configuration?'))
				choice = Menu(prompt, Menu.yes_no(), default_option=Menu.yes()).run()
				if choice == Menu.yes():
					try:
						installation.drop_to_shell()
					except:
						pass

```
As of now, this is still not a thing you should call directly at `guided.py` but thru `swiss.py` (UI is still not ready for this, and when it is done, most of swiss won't be necessary) or other scripts.

## How to improve reusability ##

Developing scripts based on `guided.py` is a necessity and a nightmare. 
A necessity to provide special interfaces (as now `minimal`, `only_hd` and `swiss`, do, or should do) or to create semi automatic test suits for functionality we're developing (as long it's not UI related). Also third party users, could built their own solutions based on it.
But a nightmare, first because knowing exactly and reusing what you need or not is not that easy with the current codebase. And it becomes obsolete or worse at any change at guided as it is not automatically carried over. `Only_hd` and `swiss` are constantly playing catch-up and half-broken, and usually involves manual upgrades. `Minimal` is not working since time immemorial ...
the new structure should allow to minimize this effects, as we can call instead of copying `guided.py` reference implementation.
To start a script we only need to create a module with the structure
```python
import archinstall
from archinstall.examples.guided import *   # this is the fastest way. only during development. be more explicit 
if __name__ in ('__main__', this_script):
     mode = archinstall.arguments.get('mode',the_mode_I_need_in_this_case)
     # copy the contents of the same section of guided. This is inavoidable
     ...
```
Then you simply have to adapt (copy and modify) exactly the parts you need to change (well the call hierarchy) (usually  `ask_questions` at least) 
All the rest will be maintained thru one single copy. that of `guided.py`

I've included updated code for the general scripts. `minimal` isn't exactly what it was in origin, but the new implementation is a very good testing environment and an ideal piece of code to start making your own scripts
