### PR TITLE
Fix check for additional repositories

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -705,7 +705,7 @@ class Installer:
 			self.log("The multilib flag is set. This system will be installed with the multilib repository enabled.")
 			self.enable_multilib_repository()
 		else:
-			self.log("The testing flag is not set. This system will be installed without testing repositories enabled.")
+			self.log("The multilib flag is not set. This system will be installed without multilib repositories enabled.")
 
 		if testing:
 			self.log("The testing flag is set. This system will be installed with testing repositories enabled.")

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -181,8 +181,12 @@ def perform_installation(mountpoint):
 			archinstall.use_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors for the live medium
 
 		# Retrieve list of additional repositories and set boolean values appropriately
-		enable_testing = 'testing' in archinstall.arguments.get('additional-repositories', None)
-		enable_multilib = 'multilib' in archinstall.arguments.get('additional-repositories', None)
+		if archinstall.arguments.get('additional-repositories', None) is not None:
+			enable_testing = 'testing' in archinstall.arguments.get('additional-repositories', None)
+			enable_multilib = 'multilib' in archinstall.arguments.get('additional-repositories', None)
+		else:
+			enable_testing = False
+			enable_multilib = False
 
 		if installation.minimal_installation(testing=enable_testing, multilib=enable_multilib):
 			installation.set_locale(archinstall.arguments['sys-language'], archinstall.arguments['sys-encoding'].upper())


### PR DESCRIPTION
- This fixes issue: #1386

## PR Description:

Fix crash that occurs when `additional-repositories` is omitted from a [configuration file](https://github.com/archlinux/archinstall/blob/master/examples/config-sample.json).

Fix related typos in logging for when multilib flag is not set.

## Tests and Checks
- [ ] I have tested the code!