### PR TITLE
Option for Parallel Downloads

### DIFF
--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -149,8 +149,8 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Parallel Downloads'),
 				add_number_of_parrallel_downloads,
-				display_func = lambda x: x if x else '0',
-				default= None
+				display_func=lambda x: x if x else '0',
+				default=None
 			)
 
 		self._menu_options['kernels'] = \

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -143,6 +143,15 @@ class GlobalMenu(GeneralMenu):
 				display_func=lambda x: x if x else 'None',
 				default=None
 			)
+
+		self._menu_options['parallel downloads'] = \
+			Selector(
+				_('Parallel Downloads')
+			)
+
+
+
+
 		self._menu_options['kernels'] = \
 			Selector(
 				_('Kernels'),

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -149,6 +149,7 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Parallel Downloads'),
 				add_number_of_parrallel_downloads,
+				display_func = lambda x: x if x else 'None',
 				default= 0
 			)
 

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -32,6 +32,7 @@ from ..user_interaction import select_encrypted_partitions
 from ..user_interaction import select_harddrives
 from ..user_interaction import select_profile
 from ..user_interaction import select_additional_repositories
+from ..user_interaction import add_number_of_parrallel_downloads
 from ..models.users import User
 from ..user_interaction.partitioning_conf import current_partition_layout
 from ..output import FormattedOutput
@@ -146,7 +147,9 @@ class GlobalMenu(GeneralMenu):
 
 		self._menu_options['parallel downloads'] = \
 			Selector(
-				_('Parallel Downloads')
+				_('Parallel Downloads'),
+				add_number_of_parrallel_downloads,
+				default= 0
 			)
 
 

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -150,7 +150,7 @@ class GlobalMenu(GeneralMenu):
 				_('Parallel Downloads'),
 				add_number_of_parrallel_downloads,
 				display_func = lambda x: x if x else '0',
-				default= 0
+				default= None
 			)
 
 		self._menu_options['kernels'] = \

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -149,12 +149,9 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Parallel Downloads'),
 				add_number_of_parrallel_downloads,
-				display_func = lambda x: x if x else 'None',
+				display_func = lambda x: x if x else '0',
 				default= 0
 			)
-
-
-
 
 		self._menu_options['kernels'] = \
 			Selector(

--- a/archinstall/lib/user_interaction/__init__.py
+++ b/archinstall/lib/user_interaction/__init__.py
@@ -7,6 +7,6 @@ from .network_conf import ask_to_configure_network
 from .partitioning_conf import select_partition, select_encrypted_partitions
 from .general_conf import (ask_ntp, ask_for_a_timezone, ask_for_audio_selection, select_language, select_mirror_regions,
 							select_profile, select_archinstall_language, ask_additional_packages_to_install,
-							select_additional_repositories, ask_hostname)
+							select_additional_repositories, ask_hostname, add_number_of_parrallel_downloads)
 from .disk_conf import ask_for_main_filesystem_format, select_individual_blockdevice_usage, select_disk_layout, select_disk
 from .utils import get_password, do_countdown

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -196,29 +196,27 @@ def ask_additional_packages_to_install(pre_set_packages: List[str] = []) -> List
 
 	return packages
 
-def add_number_of_parrallel_downloads(input_number = None):
+def add_number_of_parrallel_downloads(input_number = None) -> Optional[int]:
 	print(_("Enter the number of parallel downloads to be enabled.\n [Default value is 0]"))
-	while True:
+
+	while input_number is None:
 		try:
-			input_number = str(int(TextInput(_("> ")).run().strip() or 0))
+			input_number = int(TextInput("> ").run().strip() or 0)
 			break
 		except:
 			print(_("Invalid input! Try again with a valid input"))
-	print(_(input_number))
-	file_address = "/etc/pacman.conf"
-	f = open(file_address,"r")
-	fileread = f.read().split("\n")
-	f.close()
-	new_val = "ParallelDownloads = "+input_number
-	open(file_address,"w").close()
-	fwrite = open(file_address,"a")
-	for x in fileread:
-		if "ParallelDownloads" in x:
-			fwrite.write(new_val)
-		else:
-			fwrite.write(x)
-		fwrite.write("\n")
-	fwrite.close()
+
+	pacman_conf_path = pathlib.Path("/etc/pacman.conf")
+	with pacman_conf_path.open() as f:
+		pacman_conf = f.read().split("\n")
+
+	with pacman_conf_path.open("w"):
+		for line in pacman_conf:
+			if "ParallelDownloads" in line:
+				fwrite.write(f"ParallelDownloads = {input_number}\n")
+			else:
+				fwrite.write(f"{line}\n")
+
 	return input_number
 
 

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -197,10 +197,10 @@ def ask_additional_packages_to_install(pre_set_packages: List[str] = []) -> List
 	return packages
 
 def add_number_of_parrallel_downloads(input_number = None):
-	print(_("Enter the number of parallel downloads to be enabled."))
+	print(_("Enter the number of parallel downloads to be enabled.\n [Default value is 0]"))
 	while True:
 		try:
-			input_number = str(int(TextInput(_("> ")).run().strip()))
+			input_number = str(int(TextInput(_("> ")).run().strip() or 0))
 			break
 		except:
 			print(_("Invalid input! Try again with a valid input"))

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -196,7 +196,7 @@ def ask_additional_packages_to_install(pre_set_packages: List[str] = []) -> List
 
 	return packages
 
-def add_number_of_parrallel_downloads():
+def add_number_of_parrallel_downloads(input_number = None):
 	print(_("Enter the number of parallel downloads to be enabled."))
 	input_number = TextInput(_("> ")).run().strip()
 	print(_(input_number))

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -200,6 +200,7 @@ def add_number_of_parrallel_downloads(input_number = None):
 	print(_("Enter the number of parallel downloads to be enabled."))
 	input_number = TextInput(_("> ")).run().strip()
 	print(_(input_number))
+	input()
 
 
 def select_additional_repositories(preset: List[str]) -> List[str]:

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -200,7 +200,7 @@ def add_number_of_parrallel_downloads(input_number = None):
 	print(_("Enter the number of parallel downloads to be enabled."))
 	while True:
 		try:
-			input_number = int(TextInput(_("> ")).run().strip())
+			input_number = str(int(TextInput(_("> ")).run().strip()))
 			break
 		except:
 			print(_("Invalid input! Try again with a valid input"))

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -218,6 +218,7 @@ def add_number_of_parrallel_downloads(input_number = None):
 		else:
 			fwrite.write(x)
 		fwrite.write("\n")
+	fwrite.close()
 	return input_number
 
 

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import pathlib
 from typing import List, Any, Optional, Dict, TYPE_CHECKING
 
 from ..menu.menu import MenuSelectionType

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -196,6 +196,11 @@ def ask_additional_packages_to_install(pre_set_packages: List[str] = []) -> List
 
 	return packages
 
+def add_number_of_parrallel_downloads():
+	print(_("Enter the number of parallel downloads to be enabled."))
+	input_number = TextInput(_("> ")).run().strip()
+	print(_(input_number))
+
 
 def select_additional_repositories(preset: List[str]) -> List[str]:
 	"""

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -199,10 +199,11 @@ def ask_additional_packages_to_install(pre_set_packages: List[str] = []) -> List
 def add_number_of_parrallel_downloads(input_number = None):
 	print(_("Enter the number of parallel downloads to be enabled."))
 	while True:
-		input_number = TextInput(_("> ")).run().strip()
-		if type(input_number) == int:
+		try:
+			input_number = int(TextInput(_("> ")).run().strip())
 			break
-		print(_("Invalid input! Try again with a valid input"))
+		except:
+			print(_("Invalid input! Try again with a valid input"))
 	print(_(input_number))
 	file_address = "/etc/pacman.conf"
 	f = open(file_address,"r")

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -200,7 +200,20 @@ def add_number_of_parrallel_downloads(input_number = None):
 	print(_("Enter the number of parallel downloads to be enabled."))
 	input_number = TextInput(_("> ")).run().strip()
 	print(_(input_number))
-	input()
+	file_address = "/etc/pacman.conf"
+	f = open(file_address,"r")
+	fileread = f.read().split("\n")
+	f.close()
+	new_val = "ParallelDownloads = "+input_number
+	open(file_address,"w").close()
+	fwrite = open(file_address,"a")
+	for x in fileread:
+		if "ParallelDownloads" in x:
+			fwrite.write(new_val)
+		else:
+			fwrite.write(x)
+		fwrite.write("\n")
+	return input_number
 
 
 def select_additional_repositories(preset: List[str]) -> List[str]:

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -197,7 +197,7 @@ def ask_additional_packages_to_install(pre_set_packages: List[str] = []) -> List
 
 	return packages
 
-def add_number_of_parrallel_downloads(input_number = None) -> Optional[int]:
+def add_number_of_parrallel_downloads(input_number :Optional[int] = None) -> Optional[int]:
 	print(_("Enter the number of parallel downloads to be enabled.\n [Default value is 0]"))
 
 	while input_number is None:
@@ -211,7 +211,7 @@ def add_number_of_parrallel_downloads(input_number = None) -> Optional[int]:
 	with pacman_conf_path.open() as f:
 		pacman_conf = f.read().split("\n")
 
-	with pacman_conf_path.open("w"):
+	with pacman_conf_path.open("w") as fwrite:
 		for line in pacman_conf:
 			if "ParallelDownloads" in line:
 				fwrite.write(f"ParallelDownloads = {input_number}\n")

--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -198,7 +198,11 @@ def ask_additional_packages_to_install(pre_set_packages: List[str] = []) -> List
 
 def add_number_of_parrallel_downloads(input_number = None):
 	print(_("Enter the number of parallel downloads to be enabled."))
-	input_number = TextInput(_("> ")).run().strip()
+	while True:
+		input_number = TextInput(_("> ")).run().strip()
+		if type(input_number) == int:
+			break
+		print(_("Invalid input! Try again with a valid input"))
 	print(_(input_number))
 	file_address = "/etc/pacman.conf"
 	f = open(file_address,"r")

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -85,6 +85,10 @@ def ask_user_questions():
 
 	global_menu.enable('packages')
 
+	# Enable parallel downloads
+
+	global_menu.enable('parallel downloads')
+
 	# Ask or Call the helper function that asks the user to optionally configure a network.
 	global_menu.enable('nic')
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -85,8 +85,9 @@ def ask_user_questions():
 
 	global_menu.enable('packages')
 
-	# Enable parallel downloads
-	global_menu.enable('parallel downloads')
+	if archinstall.arguments.get('advanced', False):
+		# Enable parallel downloads
+		global_menu.enable('parallel downloads')
 
 	# Ask or Call the helper function that asks the user to optionally configure a network.
 	global_menu.enable('nic')

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -86,7 +86,6 @@ def ask_user_questions():
 	global_menu.enable('packages')
 
 	# Enable parallel downloads
-
 	global_menu.enable('parallel downloads')
 
 	# Ask or Call the helper function that asks the user to optionally configure a network.


### PR DESCRIPTION
# Describe your PR

Adds the option to enable parallel downloads during installation.

[Note: This method directly edits the pacman.conf file to enable the parallel downloads]