### PR TITLE
Add command line option to print the program version

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -66,6 +66,7 @@ def define_arguments():
 	Remember that the property/entry name python assigns to the parameters is the first string defined as argument and
 	dashes inside it '-' are changed to '_'
 	"""
+	parser.add_argument("-v", "--version", action="version", version="%(prog)s " + __version__)
 	parser.add_argument("--config", nargs="?", help="JSON configuration file or URL")
 	parser.add_argument("--creds", nargs="?", help="JSON credentials configuration file")
 	parser.add_argument("--disk_layouts","--disk_layout","--disk-layouts","--disk-layout",nargs="?",


### PR DESCRIPTION
With that, it prints:

```
archinstall --version
# archinstall 2.5.0
```

GNU Coding Standards recommends:

> The standard `--version` option should direct the program to print information about its name, version, origin and legal status, all on standard output, and then exit successfully. Other options and arguments should be ignored once this is seen, and the program should not perform its normal function. 

https://www.gnu.org/prep/standards/standards.html#g_t_002d_002dversion

:star2: 
