### PR TITLE
Converted a path to pathlib.Path

### DIFF
--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -403,6 +403,10 @@ def get_partitions_in_use(mountpoint :str) -> Dict[str, Any]:
 	log(f'Filtering available mounts {block_devices_mountpoints} to those under {mountpoint}', level=logging.DEBUG)
 
 	for mountpoint in list(get_all_targets(output['filesystems']).keys()):
+		# Since all_blockdevices() returns PosixPath objects, we need to convert
+		# findmnt paths to pathlib.Path() first:
+		mountpoint = pathlib.Path(mountpoint)
+		
 		if mountpoint in block_devices_mountpoints:
 			if mountpoint not in mounts:
 				mounts[mountpoint] = block_devices_mountpoints[mountpoint]

--- a/archinstall/lib/disk/mapperdev.py
+++ b/archinstall/lib/disk/mapperdev.py
@@ -67,7 +67,7 @@ class MapperDev:
 	@property
 	def mount_information(self) -> List[Dict[str, Any]]:
 		from .helpers import find_mountpoint
-		return list(find_mountpoint(self.path))
+		return [{**obj, 'target' : pathlib.Path(obj.get('target', '/dev/null'))} for obj in find_mountpoint(self.path)]
 
 	@property
 	def filesystem(self) -> Optional[str]:

--- a/archinstall/lib/disk/mapperdev.py
+++ b/archinstall/lib/disk/mapperdev.py
@@ -65,6 +65,10 @@ class MapperDev:
 		return None
 
 	@property
+	def mountpoints(self) -> List[Dict[str, Any]]:
+		return [obj['target'] for obj in self.mount_information()]
+
+	@property
 	def mount_information(self) -> List[Dict[str, Any]]:
 		from .helpers import find_mountpoint
 		return [{**obj, 'target' : pathlib.Path(obj.get('target', '/dev/null'))} for obj in find_mountpoint(self.path)]

--- a/archinstall/lib/disk/mapperdev.py
+++ b/archinstall/lib/disk/mapperdev.py
@@ -66,7 +66,7 @@ class MapperDev:
 
 	@property
 	def mountpoints(self) -> List[Dict[str, Any]]:
-		return [obj['target'] for obj in self.mount_information()]
+		return [obj['target'] for obj in self.mount_information]
 
 	@property
 	def mount_information(self) -> List[Dict[str, Any]]:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1000,9 +1000,9 @@ class Installer:
 		root_partition = None
 		for partition in self.partitions:
 			print(partition, [partition.mountpoint], [self.target])
-			if partition.mountpoint == self.target / 'boot':
+			if self.target / 'boot' in partition.mountpoints:
 				boot_partition = partition
-			elif partition.mountpoint == self.target:
+			elif self.target in partition.mountpoints:
 				root_partition = partition
 
 		if boot_partition is None or root_partition is None:


### PR DESCRIPTION
- This fix issue: #1411 

## PR Description:

In #1333 we cleaned up the partition handling a bit and introduced more strict types, among those were `pathlib.Path()` on partition mountpoints.

We forgot to add a conversion for `findmnt` paths when comparing against a list of partitions paths.
The error was here (kinda): https://github.com/archlinux/archinstall/blob/3842f1eb5644851ad3af84d84e704c0b33b2b204/archinstall/lib/disk/partition.py#L170

This caused an issue in comparison here: https://github.com/archlinux/archinstall/blob/3842f1eb5644851ad3af84d84e704c0b33b2b204/archinstall/lib/disk/helpers.py#L410-L411

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
