### PR TITLE
Adding better error output for when loading remote configurations goes wrong.

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -12,6 +12,7 @@ import time
 import re
 import urllib.parse
 import urllib.request
+import urllib.error
 import pathlib
 from datetime import datetime, date
 from typing import Callable, Optional, Dict, Any, List, Union, Iterator, TYPE_CHECKING
@@ -548,8 +549,12 @@ def json_stream_to_structure(configuration_identifier : str, stream :str, target
 	parsed_url = urllib.parse.urlparse(stream)
 
 	if parsed_url.scheme: # The stream is in fact a URL that should be grabbed
-		with urllib.request.urlopen(urllib.request.Request(stream, headers={'User-Agent': 'ArchInstall'})) as response:
-			target.update(json.loads(response.read()))
+		try:
+			with urllib.request.urlopen(urllib.request.Request(stream, headers={'User-Agent': 'ArchInstall'})) as response:
+				target.update(json.loads(response.read()))
+		except urllib.error.HTTPError as error:
+			log(f"Could not load {configuration_identifier} via {parsed_url} due to: {error}", level=logging.ERROR, fg="red")
+			return False
 	else:
 		if pathlib.Path(stream).exists():
 			try:


### PR DESCRIPTION
## PR Description:

Small tweak to give a better error messages when our JSON-remote-loader fails on HTTP status codes.
This shows which config goes wrong, for instance `--conf` as well as what HTTP status code was generated and how we perceived the URL.

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
