### PR TITLE
Fixing a list access issue

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -219,7 +219,7 @@ class Installer:
 		"""
 		if partition.get("mountpoint") is None:
 			if (sub_list := partition.get("btrfs",{}).get('subvolumes',{})):
-				for mountpoint in [sub_list[subvolume] if isinstance(sub_list[subvolume],str) else sub_list[subvolume].get("mountpoint") for subvolume in sub_list if sub_list[subvolume]]:
+				for mountpoint in [sub_list[subvolume].get("mountpoint") if isinstance(subvolume, dict) else subvolume.mountpoint for subvolume in sub_list]:
 					if mountpoint == '/':
 						return True
 				return False


### PR DESCRIPTION
## PR Description:

After recent changes to partitions and surrounding objects caused a for loop to try and incorrectly access a set of subvolume definitions. The old way was a nested dictionary, I tried to preserve backwards comparability by partially leaving that lookup there. But access `subvolume.mountpoint` whenever possible as the result should be objects supporting that property.

## Tests and Checks
- [x] I have tested the code!<br>
