### PR TITLE
Cleaned up argument loading slighly. 

### DIFF
--- a/archinstall/lib/plugins.py
+++ b/archinstall/lib/plugins.py
@@ -97,6 +97,7 @@ def load_plugin(path :str) -> ModuleType:
 		if hasattr(sys.modules[namespace], 'Plugin'):
 			try:
 				plugins[namespace] = sys.modules[namespace].Plugin()
+				log(f"Plugin {plugins[namespace]} has been loaded.", fg="gray", level=logging.INFO)
 			except Exception as err:
 				log(err, level=logging.ERROR)
 				log(f"The above error was detected when initiating the plugin: {path}", fg="red", level=logging.ERROR)

--- a/archinstall/lib/plugins.py
+++ b/archinstall/lib/plugins.py
@@ -73,6 +73,7 @@ def find_nth(haystack :List[str], needle :str, n :int) -> int:
 
 def load_plugin(path :str) -> ModuleType:
 	parsed_url = urllib.parse.urlparse(path)
+	log(f"Loading plugin {parsed_url}.", fg="gray", level=logging.INFO)
 
 	# The Profile was not a direct match on a remote URL
 	if not parsed_url.scheme:

--- a/profiles/xorg.py
+++ b/profiles/xorg.py
@@ -49,7 +49,7 @@ if __name__ == 'xorg':
 				archinstall.storage['installation_session'].add_additional_packages("dkms")  # I've had kernel regen fail if it wasn't installed before nvidia-dkms
 				archinstall.storage['installation_session'].add_additional_packages("xorg-server", "xorg-xinit", "nvidia-dkms")
 			else:
-				archinstall.storage['installation_session'].add_additional_packages(f"xorg-server", "xorg-xinit", archinstall.storage.get('gfx_driver_packages', []))
+				archinstall.storage['installation_session'].add_additional_packages(f"xorg-server", "xorg-xinit", *archinstall.storage.get('gfx_driver_packages', []))
 		elif 'amdgpu' in archinstall.storage.get("gfx_driver_packages", []):
 			# The order of these two are important if amdgpu is installed #808
 			if 'amdgpu' in archinstall.storage['installation_session'].MODULES:
@@ -60,9 +60,9 @@ if __name__ == 'xorg':
 				archinstall.storage['installation_session'].MODULES.remove('radeon')
 			archinstall.storage['installation_session'].MODULES.append('radeon')
 
-			archinstall.storage['installation_session'].add_additional_packages(f"xorg-server", "xorg-xinit", archinstall.storage.get('gfx_driver_packages', []))
+			archinstall.storage['installation_session'].add_additional_packages(f"xorg-server", "xorg-xinit", *archinstall.storage.get('gfx_driver_packages', []))
 		else:
-			archinstall.storage['installation_session'].add_additional_packages(f"xorg-server", "xorg-xinit", archinstall.storage.get('gfx_driver_packages', []))
+			archinstall.storage['installation_session'].add_additional_packages(f"xorg-server", "xorg-xinit", *archinstall.storage.get('gfx_driver_packages', []))
 	except Exception as err:
 		archinstall.log(f"Could not handle nvidia and linuz-zen specific situations during xorg installation: {err}", level=logging.WARNING, fg="yellow")
 		archinstall.storage['installation_session'].add_additional_packages("xorg-server", "xorg-xinit")  # Prep didn't run, so there's no driver to install

--- a/profiles/xorg.py
+++ b/profiles/xorg.py
@@ -47,9 +47,9 @@ if __name__ == 'xorg':
 				for kernel in archinstall.storage['installation_session'].kernels:
 					archinstall.storage['installation_session'].add_additional_packages(f"{kernel}-headers") # Fixes https://github.com/archlinux/archinstall/issues/585
 				archinstall.storage['installation_session'].add_additional_packages("dkms")  # I've had kernel regen fail if it wasn't installed before nvidia-dkms
-				archinstall.storage['installation_session'].add_additional_packages("xorg-server xorg-xinit nvidia-dkms")
+				archinstall.storage['installation_session'].add_additional_packages("xorg-server", "xorg-xinit", "nvidia-dkms")
 			else:
-				archinstall.storage['installation_session'].add_additional_packages(f"xorg-server xorg-xinit {' '.join(archinstall.storage.get('gfx_driver_packages', []))}")
+				archinstall.storage['installation_session'].add_additional_packages(f"xorg-server", "xorg-xinit", archinstall.storage.get('gfx_driver_packages', []))
 		elif 'amdgpu' in archinstall.storage.get("gfx_driver_packages", []):
 			# The order of these two are important if amdgpu is installed #808
 			if 'amdgpu' in archinstall.storage['installation_session'].MODULES:
@@ -60,9 +60,9 @@ if __name__ == 'xorg':
 				archinstall.storage['installation_session'].MODULES.remove('radeon')
 			archinstall.storage['installation_session'].MODULES.append('radeon')
 
-			archinstall.storage['installation_session'].add_additional_packages(f"xorg-server xorg-xinit {' '.join(archinstall.storage.get('gfx_driver_packages', []))}")
+			archinstall.storage['installation_session'].add_additional_packages(f"xorg-server", "xorg-xinit", archinstall.storage.get('gfx_driver_packages', []))
 		else:
-			archinstall.storage['installation_session'].add_additional_packages(f"xorg-server xorg-xinit {' '.join(archinstall.storage.get('gfx_driver_packages', []))}")
+			archinstall.storage['installation_session'].add_additional_packages(f"xorg-server", "xorg-xinit", archinstall.storage.get('gfx_driver_packages', []))
 	except Exception as err:
 		archinstall.log(f"Could not handle nvidia and linuz-zen specific situations during xorg installation: {err}", level=logging.WARNING, fg="yellow")
-		archinstall.storage['installation_session'].add_additional_packages("xorg-server xorg-xinit")  # Prep didn't run, so there's no driver to install
+		archinstall.storage['installation_session'].add_additional_packages("xorg-server", "xorg-xinit")  # Prep didn't run, so there's no driver to install


### PR DESCRIPTION
- This fixe issue: #1418 

## PR Description:

This prevents parameters given in the JSON configuration file being overridden by any default values from argparser.
Also flipped some --silent logic to avoid double negatives. --plugin and --conf {'plugin': ...} should now both work.

## Tests and Checks
- [x] I have tested the code!<br>
