### PR TITLE
Fixing double insertion of encoding in locale.gen/locale.conf

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -444,7 +444,7 @@ class SysCommand:
 
 	def __repr__(self, *args :List[Any], **kwargs :Dict[str, Any]) -> str:
 		if self.session:
-			return self.session._trace_log.decode('UTF-8')
+			return self.session._trace_log.decode('UTF-8', errors='backslashreplace')
 		return ''
 
 	def __json__(self) -> Dict[str, Union[str, bool, List[str], Dict[str, Any], Optional[bool], Optional[Dict[str, Any]]]]:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -447,7 +447,7 @@ class Installer:
 
 		# This is a temporary patch to fix #1200
 		if '.' in locale:
-			locale, potential_encoding = locale.split('.', 1)[0]
+			locale, potential_encoding = locale.split('.', 1)
 
 			# Override encoding if encoding is set to the default parameter
 			# and the "found" encoding differs.

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -443,6 +443,9 @@ class Installer:
 		if not len(locale):
 			return True
 
+		if '.' in locale:
+			locale = locale.split('.', 1)[0]
+
 		with open(f'{self.target}/etc/locale.gen', 'a') as fh:
 			fh.write(f'{locale}.{encoding} {encoding}\n')
 		with open(f'{self.target}/etc/locale.conf', 'w') as fh:


### PR DESCRIPTION
- This fix issue: #1200 

## PR Description:

Since we migrated to the new menu system, we started give more and accurate options throughout the installation (since we have a better search and way of presenting).
This meant that locales were offered "as is", meaning we offered both:
```
sv_SE.UTF-8 UTF-8
sv_SE ISO-8859-1
```

Previously we would only have offered `sv_SE`, and separately offered `UTF-8` or `ISO-8859-1` in another step.
Since we still offered both steps, but also both options - you see where this is going.

The "fix" is a small one, it simply checks if there's a `.` in the locale part, splits that and overrides `UTF-8` if the split one differes from `UTF-8` (which is our default value).

Any modifiers like `sr_RS@latin UTF-8` should be kept intact as well, and placed in the order mentioned here: [Locale#Generating_locales](https://wiki.archlinux.org/title/Locale#Generating_locales): `language[_territory][.codeset][@modifier]`.

## Tests and Checks
- [x] I have tested the code!<br>
