### PR TITLE
Fix boot entry containing subvolume definition when no subvolumes were selected

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -867,7 +867,7 @@ class Installer:
 
 				for subvolume in root_partition.subvolumes:
 					print(subvolume, subvolume.root)
-					if subvolume.root is True nad subvolume.name != '<FS_TREE>':
+					if subvolume.root is True and subvolume.name != '<FS_TREE>':
 						options_entry = f"rootflags=subvol={subvolume.name} " + options_entry
 
 				print(options_entry)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -866,12 +866,8 @@ class Installer:
 					options_entry = f'rw intel_pstate=no_hwp {" ".join(self.KERNEL_PARAMS)}\n'
 
 				for subvolume in root_partition.subvolumes:
-					print(subvolume, subvolume.root)
 					if subvolume.root is True and subvolume.name != '<FS_TREE>':
 						options_entry = f"rootflags=subvol={subvolume.name} " + options_entry
-
-				print(options_entry)
-				exit(1)
 
 				# Zswap should be disabled when using zram.
 				#

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -870,6 +870,8 @@ class Installer:
 					if subvolume.root is True:
 						options_entry = f"rootflags=subvol={subvolume.name} " + options_entry
 
+				exit(1)
+
 				# Zswap should be disabled when using zram.
 				#
 				# https://github.com/archlinux/archinstall/issues/881

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -866,6 +866,7 @@ class Installer:
 					options_entry = f'rw intel_pstate=no_hwp {" ".join(self.KERNEL_PARAMS)}\n'
 
 				for subvolume in root_partition.subvolumes:
+					print(subvolume, subvolume.root)
 					if subvolume.root is True:
 						options_entry = f"rootflags=subvol={subvolume.name} " + options_entry
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -867,9 +867,10 @@ class Installer:
 
 				for subvolume in root_partition.subvolumes:
 					print(subvolume, subvolume.root)
-					if subvolume.root is True:
+					if subvolume.root is True nad subvolume.name != '<FS_TREE>':
 						options_entry = f"rootflags=subvol={subvolume.name} " + options_entry
 
+				print(options_entry)
 				exit(1)
 
 				# Zswap should be disabled when using zram.


### PR DESCRIPTION
This fixes issue #1363 

## PR Description:

When selecting BTRFS but opting out of using subvolumes, the systemd bootloader entry contains `rootflags=subvol=<FS_TREE>` according to the above mentioned issue. This PR should address that and omit the subvol flag.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
