### PR TITLE
Homogenize language option during handling

### DIFF
--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -40,10 +40,6 @@ from ..output import FormattedOutput
 if TYPE_CHECKING:
 	_: Any
 
-def DEBUG(x):
-	print(x)
-	return x.display_name
-
 class GlobalMenu(GeneralMenu):
 	def __init__(self,data_store):
 		self._disk_check = True
@@ -55,7 +51,7 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Archinstall language'),
 				lambda x: self._select_archinstall_language(x),
-				display_func=DEBUG,
+				display_func=lambda x: x.display_name if type(x) is not str else x,
 				default=self.translation_handler.get_language('en'))
 		self._menu_options['keyboard-layout'] = \
 			Selector(

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -73,7 +73,7 @@ def display_language(global_menu, x):
 	if type(x) == Language:
 		return x.display_name
 	elif type(x) == str:
-		translation_handler = global_menu.self._translation_handler
+		translation_handler = global_menu._translation_handler
 		for language in translation_handler._get_translations():
 			print(language, language.lang)
 			if language.lang == x:

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -36,6 +36,7 @@ from ..user_interaction import add_number_of_parrallel_downloads
 from ..models.users import User
 from ..user_interaction.partitioning_conf import current_partition_layout
 from ..output import FormattedOutput
+from ..translationhandler import Language
 
 if TYPE_CHECKING:
 	_: Any

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -62,7 +62,7 @@ class GlobalMenu(GeneralMenu):
 		self._menu_options['archinstall-language'] = \
 			Selector(
 				_('Archinstall language'),
-				lambda x: self._select_archinstall_language(x),
+				lambda x: self._select_archinstall_language(display_language(self, x)),
 				display_func=lambda x: display_language(self, x),
 				default=self.translation_handler.get_language('en'))
 		self._menu_options['keyboard-layout'] = \

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -40,6 +40,9 @@ from ..output import FormattedOutput
 if TYPE_CHECKING:
 	_: Any
 
+def DEBUG(x):
+	print(x)
+	return x.display_name
 
 class GlobalMenu(GeneralMenu):
 	def __init__(self,data_store):
@@ -52,7 +55,7 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Archinstall language'),
 				lambda x: self._select_archinstall_language(x),
-				display_func=lambda x: x.display_name,
+				display_func=DEBUG,
 				default=self.translation_handler.get_language('en'))
 		self._menu_options['keyboard-layout'] = \
 			Selector(

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -43,12 +43,12 @@ if TYPE_CHECKING:
 
 def display_language(global_menu, x):
 	if type(x) == Language:
-		return x.display_name
+		return x
 	elif type(x) == str:
 		translation_handler = global_menu._translation_handler
 		for language in translation_handler._get_translations():
 			if language.lang == x:
-				return language.display_name
+				return language
 	else:
 		raise ValueError(f"Language entry needs to Language() object or string of full language like 'English'.")
 
@@ -63,7 +63,7 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Archinstall language'),
 				lambda x: self._select_archinstall_language(display_language(self, x)),
-				display_func=lambda x: display_language(self, x),
+				display_func=lambda x: display_language(self, x).display_name,
 				default=self.translation_handler.get_language('en'))
 		self._menu_options['keyboard-layout'] = \
 			Selector(

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -75,7 +75,6 @@ def display_language(global_menu, x):
 	elif type(x) == str:
 		translation_handler = global_menu._translation_handler
 		for language in translation_handler._get_translations():
-			print(language, language.lang)
 			if language.lang == x:
 				return language.display_name
 	else:

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -41,34 +41,6 @@ from ..translationhandler import Language
 if TYPE_CHECKING:
 	_: Any
 
-def _get_translations(self) -> List[Language]:
-	mappings = self._load_language_mappings()
-	defined_languages = self._defined_languages()
-
-	languages = []
-
-	for short_form in defined_languages:
-		mapping_entry: Dict[str, Any] = next(filter(lambda x: x['abbr'] == short_form, mappings))
-		abbr = mapping_entry['abbr']
-		lang = mapping_entry['lang']
-		translated_lang = mapping_entry.get('translated_lang', None)
-
-		try:
-			translation = gettext.translation('base', localedir=self._get_locales_dir(), languages=(abbr, lang))
-
-			if abbr == 'en':
-				percent = 100
-			else:
-				num_translations = self._get_catalog_size(translation)
-				percent = int((num_translations / self._total_messages) * 100)
-
-			language = Language(abbr, lang, translation, percent, translated_lang)
-			languages.append(language)
-		except FileNotFoundError as error:
-			raise TranslationError(f"Could not locate language file for '{lang}': {error}")
-
-	return languages
-
 def display_language(global_menu, x):
 	if type(x) == Language:
 		return x.display_name

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 def DEBUG(x):
 	print(x)
+	exit(1)
 	return x.display_name
 
 class GlobalMenu(GeneralMenu):

--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -40,6 +40,10 @@ from ..output import FormattedOutput
 if TYPE_CHECKING:
 	_: Any
 
+def DEBUG(x):
+	print(x)
+	return x.display_name
+
 class GlobalMenu(GeneralMenu):
 	def __init__(self,data_store):
 		self._disk_check = True
@@ -51,7 +55,7 @@ class GlobalMenu(GeneralMenu):
 			Selector(
 				_('Archinstall language'),
 				lambda x: self._select_archinstall_language(x),
-				display_func=lambda x: x.display_name if type(x) is not str else x,
+				display_func=DEBUG,
 				default=self.translation_handler.get_language('en'))
 		self._menu_options['keyboard-layout'] = \
 			Selector(

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -468,6 +468,8 @@ class GeneralMenu:
 		return mandatory_fields, mandatory_waiting
 
 	def _select_archinstall_language(self, preset_value: Language) -> Language:
+		print(preset_value)
+		raise ValueError()
 		language = select_archinstall_language(self.translation_handler.translated_languages, preset_value)
 		self._translation_handler.activate(language)
 		return language

--- a/archinstall/lib/menu/selection_menu.py
+++ b/archinstall/lib/menu/selection_menu.py
@@ -468,8 +468,6 @@ class GeneralMenu:
 		return mandatory_fields, mandatory_waiting
 
 	def _select_archinstall_language(self, preset_value: Language) -> Language:
-		print(preset_value)
-		raise ValueError()
 		language = select_archinstall_language(self.translation_handler.translated_languages, preset_value)
 		self._translation_handler.activate(language)
 		return language


### PR DESCRIPTION
- This fix issue: #1444 

## PR Description:

During normal operation and "vanilla" startup of `archinstall`, the language option of `archinstall` is prepared and structured via `translationhandler.py` which populates the menu entry with `Language()` options, that can be represented in different ways.

But loading a `--conf` externally, meaning launching `archinstall --conf ...` will cause the `Language` field to be populated with a `str` object. Which isn't handled and thus the crash mentioned in #1444.

There was two solutions to this, either to centralize cleaning of the specific variables early in the `__init__` process.
Or to deal with it at a local level. Seeing as the language structure might change by improving upon it.. I thought it was best to prepare a solution more close to that logic.

So the `lambda` handling of the `Language` variable now has a "cleaning function" called `display_language()` which displays the proper language regardless if the input is a `Language()` object or a `str` object.

## Tests and Checks
- [x] I have tested the code!<br>