### PR TITLE
Add hostname and locales as parameters to `minimal_installation()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ with archinstall.luks2(root, 'luksloop', disk_password) as unlocked_root:
     boot.mount('/mnt/boot')
 
 with archinstall.Installer('/mnt') as installation:
-    if installation.minimal_installation():
-        installation.set_hostname('minimal-arch')
+    if installation.minimal_installation(hostname='minimal-arch'):
         installation.add_bootloader()
 
         installation.add_additional_packages(['nano', 'wget', 'git'])

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -661,7 +661,9 @@ class Installer:
 
 		return SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}').exit_code == 0
 
-	def minimal_installation(self, testing=False, multilib=False) -> bool:
+	def minimal_installation(
+			self, testing: bool = False, multilib: bool = False,
+			hostname: str = 'archinstall', locales: List[str] = ['en_US.UTF-8 UTF-8']) -> bool:
 		# Add necessary packages if encrypting the drive
 		# (encrypted partitions default to btrfs for now, so we need btrfs-progs)
 		# TODO: Perhaps this should be living in the function which dictates
@@ -749,8 +751,8 @@ class Installer:
 		# os.remove(f'{self.target}/etc/localtime')
 		# sys_command(f'/usr/bin/arch-chroot {self.target} ln -s /usr/share/zoneinfo/{localtime} /etc/localtime')
 		# sys_command('/usr/bin/arch-chroot /mnt hwclock --hctosys --localtime')
-		self.set_hostname('archinstall')
-		self.set_locale('en_US')
+		self.set_hostname(hostname)
+		self.set_locale(*locales[0].split())
 
 		# TODO: Use python functions for this
 		SysCommand(f'/usr/bin/arch-chroot {self.target} chmod 700 /root')

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -192,9 +192,9 @@ def perform_installation(mountpoint):
 			enable_testing = False
 			enable_multilib = False
 
-		if installation.minimal_installation(testing=enable_testing, multilib=enable_multilib):
-			installation.set_locale(archinstall.arguments['sys-language'], archinstall.arguments['sys-encoding'].upper())
-			installation.set_hostname(archinstall.arguments['hostname'])
+		if installation.minimal_installation(
+				testing=enable_testing, multilib=enable_multilib, hostname=archinstall.arguments['hostname'],
+				locales=[f"{archinstall.arguments['sys-language']} {archinstall.arguments['sys-encoding'].upper()}"]):
 			if archinstall.arguments.get('mirror-region') is not None:
 				if archinstall.arguments.get("mirrors", None) is not None:
 					installation.set_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors in the installation medium

--- a/examples/swiss.py
+++ b/examples/swiss.py
@@ -402,9 +402,9 @@ def os_setup(installation):
 	# Set mirrors used by pacstrap (outside of installation)
 	if archinstall.arguments.get('mirror-region', None):
 		archinstall.use_mirrors(archinstall.arguments['mirror-region'])  # Set the mirrors for the live medium
-	if installation.minimal_installation():
-		installation.set_locale(archinstall.arguments['sys-language'], archinstall.arguments['sys-encoding'].upper())
-		installation.set_hostname(archinstall.arguments['hostname'])
+	if installation.minimal_installation(
+			hostname=archinstall.arguments['hostname'],
+			locales=[f"{archinstall.arguments['sys-language']} {archinstall.arguments['sys-encoding'].upper()}"]):
 		if archinstall.arguments['mirror-region'].get("mirrors", None) is not None:
 			installation.set_mirrors(
 				archinstall.arguments['mirror-region'])  # Set the mirrors in the installation medium


### PR DESCRIPTION
- This resolves: https://github.com/archlinux/archinstall/issues/1200#issuecomment-1130564952

## PR Description:

Fix occurrence of duplicate calls to `set_hostname()` and `set_locale()` by adding hostname and locales as parameters to `minimal_installation()`.

## Tests and Checks
- [ ] I have tested the code!
