### PR TITLE
Fix Turkish local typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Polskie
 Portugues do Brasil                                                                                                                                      
 Português                                                                                                                                                
 Svenska                                                                                                                                                  
-Türk                                                                                                                                                     
+Türkçe                                                                                                                                                     
 čeština                                                                                                                                                  
 Русский
 اردو

--- a/archinstall/locales/languages.json
+++ b/archinstall/locales/languages.json
@@ -166,7 +166,7 @@
  {"abbr": "tn", "lang": "Tswana"},
  {"abbr": "ts", "lang": "Tsonga"},
  {"abbr": "tk", "lang": "Turkmen"},
- {"abbr": "tr", "lang": "Turkish", "translated_lang" :  "Türk"},
+ {"abbr": "tr", "lang": "Turkish", "translated_lang" :  "Türkçe"},
  {"abbr": "tw", "lang": "Twi"},
  {"abbr": "ug", "lang": "Uighur"},
  {"abbr": "uk", "lang": "Ukrainian"},


### PR DESCRIPTION
- This fix issue: 

## PR Description:

"Türk" is the name of our nationality. "Türkçe" is the language we use. There was a small typo. I fixed it.

## Tests and Checks
- [X] I have tested the code!<br>
