### PR TITLE
Fix translation fonts

### DIFF
--- a/archinstall/lib/translationhandler.py
+++ b/archinstall/lib/translationhandler.py
@@ -46,8 +46,8 @@ class TranslationHandler:
 	_languages = 'languages.json'
 
 	def __init__(self):
-		# to display cyrillic languages correctly
-		self._set_font('UniCyr_8x16')
+		# to display latin, greek, cyrillic characters
+		self._set_font('LatGrkCyr-8x16')
 
 		self._total_messages = self._get_total_active_messages()
 		self._translated_languages = self._get_translations()
@@ -61,7 +61,7 @@ class TranslationHandler:
 		Load all translated languages and return a list of such
 		"""
 		mappings = self._load_language_mappings()
-		defined_languages = self._defined_languages()
+		defined_languages = self._provided_translations()
 
 		languages = []
 
@@ -165,13 +165,20 @@ class TranslationHandler:
 		locales_dir = Path.joinpath(cur_path, 'locales')
 		return locales_dir
 
-	def _defined_languages(self) -> List[str]:
+	def _provided_translations(self) -> List[str]:
 		"""
 		Get a list of all known languages
 		"""
 		locales_dir = self._get_locales_dir()
 		filenames = os.listdir(locales_dir)
-		return list(filter(lambda x: len(x) == 2 or x == 'pt_BR', filenames))
+
+		translation_files = []
+		for filename in filenames:
+			if len(filename) == 2 or filename == 'pt_BR':
+				if filename not in ['ur', 'ta']:
+					translation_files.append(filename)
+
+		return translation_files
 
 
 class DeferredTranslation:


### PR DESCRIPTION
## Translation fixes

I have switched to set the `LatGrkCyr-8x16` font via the installer which covers Cyrillic and Greek at the same time. 

Unfortunately I wasn't able to fix the problem completely, I have checked the fonts in `/usr/share/kbd/consolefonts` but there doesn't seem to be any available that cover `Tamil` nor `Urdu`. So for now these have been excluded since they won't work anyways. 

For `Tamil` I could only find a font in the AUR https://aur.archlinux.org/packages/ttf-tamil (I have not actually tried it out) and for `Urdu` there's this one https://aur.archlinux.org/packages/ttf-urdufonts. I don't thing there will be an option of including those in the ISO.

Covering languages for which there's no font available on the ISO will also require manual work in the future though, so I'm a bit unsure at the moment if it might be considerable to exclude certain support?
