### PR TITLE
Add compression to /etc/fstab for btrfs subvolumes

### DIFF
--- a/archinstall/lib/disk/btrfs/__init__.py
+++ b/archinstall/lib/disk/btrfs/__init__.py
@@ -54,7 +54,3 @@ def create_subvolume(installation: Installer, subvolume_location :Union[pathlib.
 	log(f"Creating a subvolume on {target}", level=logging.INFO)
 	if (cmd := SysCommand(f"btrfs subvolume create {target}")).exit_code != 0:
 		raise DiskError(f"Could not create a subvolume at {target}: {cmd}")
-
-
-def manage_btrfs_subvolumes(installation :Installer, partition :Dict[str, str]) -> list:
-	raise Deprecated("Use setup_subvolumes() instead.")

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from pathlib import Path
 from typing import Optional, Dict, Any, TYPE_CHECKING
 
@@ -21,9 +22,15 @@ class fstab_btrfs_compression_plugin():
 
 	def on_genfstab(self, installation):
 		with open(f"{installation.target}/etc/fstab", 'r') as fh:
-			print(fh.read())
+			fstab = fh.read()
 
-		print(self.partition_dict)
+		for line in fstab.split():
+			if subvoldef := re.findall(',.*?subvol=.*?[ ]', line):
+				line = line.replace(subvoldef[0], f",compress=zstd{subvoldef[0]}")
+
+			print(line)
+
+		for subvolume self.partition_dict)
 		exit(1)
 
 

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -24,8 +24,11 @@ class fstab_btrfs_compression_plugin():
 		with open(f"{installation.target}/etc/fstab", 'r') as fh:
 			fstab = fh.read()
 
+		print([fstab])
 		for line in fstab.split():
+			print([line])
 			if subvoldef := re.findall(',.*?subvol=.*?[ ]', line):
+				print(subvoldef)
 				line = line.replace(subvoldef[0], f",compress=zstd{subvoldef[0]}")
 
 			print(line)

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -71,7 +71,7 @@ def setup_subvolumes(installation: 'Installer', partition_dict: Dict[str, Any]):
 					raise DiskError(f"Could not set compress attribute at {installation.target}/{name}: {cmd}")
 
 			if 'fstab_btrfs_compression_plugin' not in plugins:
-				plugins['fstab_btrfs_compression_plugin'] = fstab_btrfs_compression_plugin(installation)
+				plugins['fstab_btrfs_compression_plugin'] = fstab_btrfs_compression_plugin()
 
 
 def subvolume_info_from_path(path: Path) -> Optional[BtrfsSubvolumeInfo]:

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -25,7 +25,7 @@ class fstab_btrfs_compression_plugin():
 			fstab = fh.read()
 
 		print([fstab])
-		for line in fstab.split():
+		for line in fstab.split('\n'):
 			print([line])
 			if subvoldef := re.findall(',.*?subvol=.*?[ ]', line):
 				print(subvoldef)

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -24,16 +24,19 @@ class fstab_btrfs_compression_plugin():
 		with open(f"{installation.target}/etc/fstab", 'r') as fh:
 			fstab = fh.read()
 
-		print([fstab])
-		for line in fstab.split('\n'):
-			print([line])
-			if subvoldef := re.findall(',.*?subvol=.*?[ ]', line):
-				print(subvoldef)
-				line = line.replace(subvoldef[0], f",compress=zstd{subvoldef[0]}")
+		print(self.partition_dict)
 
-			print(line)
+		# Replace the {installation}/etc/fstab with entries
+		# using the compress=zstd where the mountpoint has compression set.
+		with open(f"{installation.target}/etc/fstab", 'w') as fh:
+			for line in fstab.split('\n'):
+				if subvoldef := re.findall(',.*?subvol=.*?[ ]', line):
+					line = line.replace(subvoldef[0], f",compress=zstd{subvoldef[0]}")
+
+				fh.write(f"{line}\n")
 
 		exit(1)
+		return True
 
 
 def mount_subvolume(installation: 'Installer', device: 'BTRFSPartition', subvolume: Subvolume):

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -30,7 +30,6 @@ class fstab_btrfs_compression_plugin():
 
 			print(line)
 
-		for subvolume self.partition_dict)
 		exit(1)
 
 

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -33,7 +33,7 @@ class fstab_btrfs_compression_plugin():
 				if (subvoldef := re.findall(',.*?subvol=.*?[ ]', line)) and (mountpoint := re.findall('[\t ]/.*?[\t ]', line)):
 					for subvolume in self.partition_dict.get('btrfs', {}).get('subvolumes', []):
 						# We then locate the correct subvolume and check if it's compressed
-						if subvolume.compress and subvolume.mountpoint == mountpoint.strip():
+						if subvolume.compress and subvolume.mountpoint == mountpoint[0].strip():
 							# We then sneak in the compress=zstd option and add back the rest of the options
 							line = line.replace(subvoldef[0], f",compress=zstd{subvoldef[0]}")
 							break

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -30,7 +30,7 @@ class fstab_btrfs_compression_plugin():
 			for line in fstab.split('\n'):
 				# So first we grab the mount options by using subvol=.*? as a locator.
 				# And we also grab the mountpoint for the entry, for instance /var/log
-				if (subvoldef := re.findall(',.*?subvol=.*?[ ]', line)) and (mountpoint := re.findall('[\t ]/.*?[\t ]', line)):
+				if (subvoldef := re.findall(',.*?subvol=.*?[\t ]', line)) and (mountpoint := re.findall('[\t ]/.*?[\t ]', line)):
 					for subvolume in self.partition_dict.get('btrfs', {}).get('subvolumes', []):
 						# We then locate the correct subvolume and check if it's compressed
 						if subvolume.compress and subvolume.mountpoint == mountpoint[0].strip():

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -16,10 +16,14 @@ if TYPE_CHECKING:
 
 
 class fstab_btrfs_compression_plugin():
+	def __init__(self, partition_dict):
+		self.partition_dict = partition_dict
+
 	def on_genfstab(self, installation):
 		with open(f"{installation.target}/etc/fstab", 'r') as fh:
 			print(fh.read())
 
+		print(self.partition_dict)
 		exit(1)
 
 
@@ -71,7 +75,7 @@ def setup_subvolumes(installation: 'Installer', partition_dict: Dict[str, Any]):
 					raise DiskError(f"Could not set compress attribute at {installation.target}/{name}: {cmd}")
 
 			if 'fstab_btrfs_compression_plugin' not in plugins:
-				plugins['fstab_btrfs_compression_plugin'] = fstab_btrfs_compression_plugin()
+				plugins['fstab_btrfs_compression_plugin'] = fstab_btrfs_compression_plugin(partition_dict)
 
 
 def subvolume_info_from_path(path: Path) -> Optional[BtrfsSubvolumeInfo]:

--- a/archinstall/lib/disk/btrfs/btrfs_helpers.py
+++ b/archinstall/lib/disk/btrfs/btrfs_helpers.py
@@ -34,9 +34,11 @@ class fstab_btrfs_compression_plugin():
 					for subvolume in self.partition_dict.get('btrfs', {}).get('subvolumes', []):
 						# We then locate the correct subvolume and check if it's compressed
 						if subvolume.compress and subvolume.mountpoint == mountpoint[0].strip():
-							# We then sneak in the compress=zstd option and add back the rest of the options
-							line = line.replace(subvoldef[0], f",compress=zstd{subvoldef[0]}")
-							break
+							# We then sneak in the compress=zstd option if it doesn't already exist:
+							# We skip entries where compression is already defined
+							if ',compress=zstd,' not in line:
+								line = line.replace(subvoldef[0], f",compress=zstd{subvoldef[0]}")
+								break
 
 				fh.write(f"{line}\n")
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -432,7 +432,8 @@ class Installer:
 
 		for plugin in plugins.values():
 			if hasattr(plugin, 'on_genfstab'):
-				plugin.on_genfstab(self)
+				if plugin.on_genfstab(self) is True:
+					break
 
 		return True
 


### PR DESCRIPTION
- This fix issue: #1303 

## PR Description:

We were missing `compress=zstd` in the `/etc/fstab` entries where applicable.
This will use a fstab plugin to put the compression in during generating.

I'm not super stoked about all the string logic, but `/etc/fstab` is a string collection so what will you do : )

## Tests and Checks
- [x] I have tested the code!<br>
