### PR TITLE
Typo on the Spanish language name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Current translations are listed below and vary in the amount of translations per
 ```
 English                                                                                                                                       
 Deutsch
-Española                                                                                                                                                 
+Español                                                                                                                                                 
 Française
 Indonesia                                                                                                                                                
 Italiano                                                                                                                                                 


### PR DESCRIPTION
## PR Description:
Small typo fix of the word "Española" (incorrectly typed) to "Español" inside README.md


