### PR TITLE
Fix issue where direct attached PCIe block devices causes issues under /dev/*

### DIFF
--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -220,7 +220,12 @@ def all_blockdevices(mappers=False, partitions=False, error=False) -> Dict[str, 
 	# we'll iterate the /sys/class definitions and find the information
 	# from there.
 	for block_device in glob.glob("/sys/class/block/*"):
-		device_path = f"/dev/{pathlib.Path(block_device).readlink().name}"
+		device_path = pathlib.Path(f"/dev/{pathlib.Path(block_device).readlink().name}")
+
+		if device_path.exists() is False:
+			log(f"Unknown device found by '/sys/class/block/*', ignoring: {device_path}", level=logging.WARNING, fg="yellow")
+			continue
+
 		try:
 			information = blkid(f'blkid -p -o export {device_path}')
 		except SysCallError as ex:


### PR DESCRIPTION
## PR Description:

On certain hardware where blockdevices will show up under /sys/class/block/ but not always under /dev/* and thus breaking the all_blockdevices() logic. This should fix that by verifying that the /dev/* path exists..

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
