### PR TITLE
Fixed French typo

### DIFF
--- a/archinstall/locales/fr/LC_MESSAGES/base.po
+++ b/archinstall/locales/fr/LC_MESSAGES/base.po
@@ -259,7 +259,7 @@ msgid "Disk layout"
 msgstr "Disposition du disque"
 
 msgid "Encryption password"
-msgstr "Mot de passe de cryptage"
+msgstr "Mot de passe de chiffrement"
 
 msgid "Swap"
 msgstr "Swap"
@@ -367,7 +367,7 @@ msgid "Enter a password: "
 msgstr "Entrer un mot de passe : "
 
 msgid "Enter a encryption password for {}"
-msgstr "Entrer un mot de passe de cryptage pour {}"
+msgstr "Entrer un mot de passe de chiffrement pour {}"
 
 msgid "Enter disk encryption password (leave blank for no encryption): "
 msgstr "Entrer le mot de passe de chiffrement du disque (laisser vide pour aucun chiffrement) : "


### PR DESCRIPTION
## PR Description:

"Cryptage" in French does not mean "Encryption". "Chiffrement" does. For more information for my French friends : https://chiffrer.info/

## Tests and Checks
- [x] I have tested the code!<br>
