### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Current translations are listed below and vary in the amount of translations per
 English
 Deutsch
 Español
-Française
+Français
 Indonesia
 Italiano
 Nederlands

--- a/archinstall/locales/languages.json
+++ b/archinstall/locales/languages.json
@@ -43,7 +43,7 @@
  {"abbr": "fa", "lang": "Persian"},
  {"abbr": "fj", "lang": "Fijian"},
  {"abbr": "fi", "lang": "Finnish"},
- {"abbr": "fr", "lang": "French", "translated_lang": "Française"},
+ {"abbr": "fr", "lang": "French", "translated_lang": "Français"},
  {"abbr": "fy", "lang": "Western Frisian"},
  {"abbr": "ff", "lang": "Fulah"},
  {"abbr": "gd", "lang": "Scottish Gaelic"},


### PR DESCRIPTION
Add back "Français" instead of "Française", which is indeed feminine singular where masculine singular is expected, hence "Français".

Follows #1494.
