### PR TITLE
Improved speed in --skip-mirror-check

### DIFF
--- a/examples/guided.py
+++ b/examples/guided.py
@@ -278,7 +278,7 @@ def perform_installation(mountpoint):
 	archinstall.log(f"Disk states after installing: {archinstall.disk_layouts()}", level=logging.DEBUG)
 
 
-if not (archinstall.check_mirror_reachable() or archinstall.arguments.get('skip-mirror-check', False)):
+if archinstall.arguments.get('skip-mirror-check', False) is False and archinstall.check_mirror_reachable() is False:
 	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
 	archinstall.log(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.", level=logging.INFO, fg="red")
 	exit(1)


### PR DESCRIPTION
- This fix issue: #1504 

## PR Description:

This should improve speed by leveraging lazy evaluation.
As otherwise the mirror check would be performed anyway - and then the override would kick in to avoid hard exit at this point.

## Tests and Checks
- [ ] I have tested the code!<br>
