### PR TITLE
Add runtime dependency for dmenu

### DIFF
--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -15,6 +15,7 @@ __packages__ = [
 	"slurp",
 	"pavucontrol",
 	"foot",
+	"xorg-xwayland",
 ]
 
 


### PR DESCRIPTION
## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

dmenu is a x11 application. Without xwayland it cannot be used with the default sway installation.

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
