### PR TITLE
Retry lsblk (partition._call_lsblk) when needed

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -259,9 +259,9 @@ class Filesystem:
 				self.blockdevice.flush_cache()
 
 				new_partition_uuids = [partition.part_uuid for partition in self.blockdevice.partitions.values()]
-				new_partuuid_set = (set(previous_partuuids) ^ set(new_partition_uuids))
+				new_partuuid_set = set(new_partition_uuids).difference(set(previous_partuuids))
 
-				if len(new_partuuid_set) and (new_partuuid := new_partuuid_set.pop()):
+				if len(new_partuuid_set) == 1 and (new_partuuid := new_partuuid_set.pop()):
 					try:
 						return self.blockdevice.get_partition(partuuid=new_partuuid)
 					except Exception as err:

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -171,7 +171,7 @@ class Partition:
 
 	def _call_lsblk(self) -> Dict[str, Any]:
 		self.partprobe()
-		for _ in range(storage['DISK_RETRY_ATTEMPTS']):
+		for _ in range(storage.get('DISK_RETRY_ATTEMPTS', 3)):
 			try:
 				output = SysCommand(f"lsblk --json -b -o+LOG-SEC,SIZE,PTTYPE,PARTUUID,UUID,FSTYPE {self.device_path}").decode('UTF-8')
 			except SysCallError as error:
@@ -179,7 +179,7 @@ class Partition:
 				# But it does return output so we'll try to catch it.
 				log(f"Error running lsblk: {error.worker.decode('UTF-8')}", level=logging.DEBUG)
 				# Catch the error but try again anyway
-				delay = max(0.1, storage.get('DISK_TIMEOUTS', 0.1))
+				delay = max(0.1, storage.get('DISK_TIMEOUTS', 1))
 				log(f"Waiting {delay}s to poll disk again", level=logging.DEBUG)
 				time.sleep(delay)
 				continue

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -171,26 +171,32 @@ class Partition:
 
 	def _call_lsblk(self) -> Dict[str, Any]:
 		self.partprobe()
-		# This sleep might be overkill, but lsblk is known to
-		# work against a chaotic cache that can change during call
-		# causing no information to be returned (blkid is better)
-		# time.sleep(1)
-
-		# TODO: Maybe incorporate a re-try system here based on time.sleep(max(0.1, storage.get('DISK_TIMEOUTS', 1)))
-
-		try:
-			output = SysCommand(f"lsblk --json -b -o+LOG-SEC,SIZE,PTTYPE,PARTUUID,UUID,FSTYPE {self.device_path}").decode('UTF-8')
-		except SysCallError as error:
-			# It appears as if lsblk can return exit codes like 8192 to indicate something.
-			# But it does return output so we'll try to catch it.
-			output = error.worker.decode('UTF-8')
-
-		if output:
+		for _ in range(storage['DISK_RETRY_ATTEMPTS']):
+			try:
+				output = SysCommand(f"lsblk --json -b -o+LOG-SEC,SIZE,PTTYPE,PARTUUID,UUID,FSTYPE {self.device_path}").decode('UTF-8')
+			except SysCallError as error:
+				# It appears as if lsblk can return exit codes like 8192 to indicate something.
+				# But it does return output so we'll try to catch it.
+				log(f"Error running lsblk: {error.worker.decode('UTF-8')}", level=logging.DEBUG)
+				# Catch the error but try again anyway
+				delay = max(0.1, storage.get('DISK_TIMEOUTS', 0.1))
+				log(f"Waiting {delay}s to poll disk again", level=logging.DEBUG)
+				time.sleep(delay)
+				continue
+			
 			try:
 				lsblk_info = json.loads(output)
-				return lsblk_info
 			except json.decoder.JSONDecodeError:
 				log(f"Could not decode JSON: {output}", fg="red", level=logging.ERROR)
+				# This is unexpected, better to raise an error
+				break
+			if not lsblk_info['blockdevices'][0]['partuuid']:
+				# If partition info doesn't have content, try again
+				delay = max(0.1, storage.get('DISK_TIMEOUTS', 1))
+				log(f"Waiting {delay}s to poll disk again", level=logging.DEBUG)
+				time.sleep(delay)
+				continue
+			return lsblk_info
 
 		raise DiskError(f'Failed to read disk "{self.device_path}" with lsblk')
 

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -190,7 +190,7 @@ class Partition:
 				log(f"Could not decode JSON: {output}", fg="red", level=logging.ERROR)
 				# This is unexpected, better to raise an error
 				break
-			if not lsblk_info['blockdevices'][0]['partuuid']:
+			if not lsblk_info.get('blockdevices', [{'partuuid': None}])[0].get('partuuid'):
 				# If partition info doesn't have content, try again
 				delay = max(0.1, storage.get('DISK_TIMEOUTS', 1))
 				log(f"Waiting {delay}s to poll disk again", level=logging.DEBUG)


### PR DESCRIPTION
## PR Description:

Modify lib.disk.partition._call_lsblk() function to make it more reliable. I was getting many errors trying automated install. Tracked the problem to lsblk giving incomplete information (like missing partition UUID) that made partition creation and mounting very unreliable. Test environment was Virtualbox in several different physical computers (Linux and Windows).

## Tests and Checks
- [X ] I have tested the code manually in a Virtualbox virtual machine
