### PR TITLE
The Live ISO image does not have 'python-setuptools' installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ you can replace the version of archinstall with a new version and run that with 
 5. Enter the repository with `cd archinstall`
    *At this stage, you can choose to check out a feature branch for instance with `git checkout v2.3.1-rc1`*
 6. Build the project and install it using `python setup.py install`
+   *If you get a 'No Module named setuptools' error, run `pacman -S python-setuptools`*
 
 After this, running archinstall with `python -m archinstall` will run against whatever branch you chose in step 5.
 


### PR DESCRIPTION
- This fix issue: #1532 

## PR Description:

Corrects README instructions to help beginners install `python-setuptools`

## Tests and Checks

- [x] I have tested the added instruction
