### PR TITLE
Fixed broken imports

### DIFF
--- a/archinstall/lib/menu/menu.py
+++ b/archinstall/lib/menu/menu.py
@@ -3,7 +3,7 @@ from enum import Enum, auto
 from os import system
 from typing import Dict, List, Union, Any, TYPE_CHECKING, Optional, Callable
 
-from archinstall.lib.menu.simple_menu import TerminalMenu
+from .simple_menu import TerminalMenu
 
 from ..exceptions import RequirementError
 from ..output import log

--- a/archinstall/lib/translationhandler.py
+++ b/archinstall/lib/translationhandler.py
@@ -110,7 +110,7 @@ class TranslationHandler:
 		"""
 		Set the provided font as the new terminal font
 		"""
-		from archinstall import SysCommand, log
+		from .general import SysCommand, log
 		try:
 			log(f'Setting font: {font}', level=logging.DEBUG)
 			SysCommand(f'setfont {font}')


### PR DESCRIPTION
This fix issue: 

When using archinstall as a library (git cloning) the `from archinstall` will break most examples as it will attempt to import whatever is installed locally instead of relative from the source tree.

## PR Description:

This ensures that imports are relative, not frozen.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
