### PR TITLE
Remove HSM from global menu

### DIFF
--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -260,8 +260,8 @@ class AbstractMenu:
 			if mandatory:
 				self._menu_options[selector_name].set_mandatory(True)
 			self.synch(selector_name,omit_if_set)
-
-		raise ValueError(f'No selector found: {selector_name}')
+		else:
+			raise ValueError(f'No selector found: {selector_name}')
 
 	def _preview_display(self, selection_name: str) -> Optional[str]:
 		config_name, selector = self._find_selection(selection_name)

--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 from typing import Callable, Any, List, Iterator, Tuple, Optional, Dict, TYPE_CHECKING
 
 from .menu import Menu, MenuSelectionType

--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -260,9 +260,8 @@ class AbstractMenu:
 			if mandatory:
 				self._menu_options[selector_name].set_mandatory(True)
 			self.synch(selector_name,omit_if_set)
-		else:
-			print(f'No selector found: {selector_name}')
-			sys.exit(1)
+
+		raise ValueError(f'No selector found: {selector_name}')
 
 	def _preview_display(self, selection_name: str) -> Optional[str]:
 		config_name, selector = self._find_selection(selection_name)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -57,10 +57,6 @@ def ask_user_questions():
 	# Specify disk encryption options
 	global_menu.enable('disk_encryption')
 
-	if archinstall.arguments.get('advanced', False) or archinstall.arguments.get('HSM', None):
-		# Enables the use of HSM
-		global_menu.enable('HSM')
-
 	# Ask which boot-loader to use (will only ask if we're in UEFI mode, otherwise will default to GRUB)
 	global_menu.enable('bootloader')
 


### PR DESCRIPTION
@Torxed small follow up PR for the merged https://github.com/archlinux/archinstall/pull/1520

Forgot to remove these lines, they were responsible for enabling the HSM entry in the main menu but that got moved into the submenu now so they are not needed and will cause an error if `advanced` is enabled. 