### PR TITLE
Error handling cmd history

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -391,7 +391,7 @@ class SysCommandWorker:
 				except Exception as e:
 					exception_type = type(e).__name__
 					log(f"Unexpected {exception_type} occurred in {self.cmd}: {e}", level=logging.ERROR)
-					raise(e)
+					raise e
 
 				os.execve(self.cmd[0], list(self.cmd), {**os.environ, **self.environment_vars})
 				if storage['arguments'].get('debug'):

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -385,6 +385,10 @@ class SysCommandWorker:
 						os.chmod(str(history_logfile), stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
 				except PermissionError:
 					pass
+				except Exception as e:
+					exception_type = type(e).__name__
+					log(f"Unexpected {exception_type} occurred in {self.cmd}: {e}", level=logging.ERROR)
+					raise(e)
 
 				os.execve(self.cmd[0], list(self.cmd), {**os.environ, **self.environment_vars})
 				if storage['arguments'].get('debug'):

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -385,6 +385,9 @@ class SysCommandWorker:
 						os.chmod(str(history_logfile), stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
 				except PermissionError:
 					pass
+				# If history_logfile does not exist, ignore the error
+				except FileNotFoundError:
+					pass
 				except Exception as e:
 					exception_type = type(e).__name__
 					log(f"Unexpected {exception_type} occurred in {self.cmd}: {e}", level=logging.ERROR)


### PR DESCRIPTION
- This fix issue: n/a

## PR Description:

Given the situation that you use archinstall on a system where /var/log/archinstall/cmd_history.txt does not exist (yet) and you use the following script:
``` python
import archinstall
bd = archinstall.all_blockdevices()
```
The first time the script is executed it fails, indicating something went wrong with lsblk, which has nothing to do with what actually went wrong. Also the logfile is created during this instance of archinstall and therefor the script succeeds when running a second time.

Error on first execution:
```
[root@archinstall project]# python install.py 
Raising ex because: 256
Traceback (most recent call last):
  File "/project/install.py", line 4, in <module>
    bd = archinstall.all_blockdevices()
  File "/project/archinstall/lib/disk/helpers.py", line 266, in all_blockdevices
    raise ex
  File "/project/archinstall/lib/disk/helpers.py", line 244, in all_blockdevices
    lsblk_info = get_lsblk_info(device_path)
  File "/project/archinstall/lib/disk/diskinfo.py", line 30, in get_lsblk_info
    output = SysCommand(f'lsblk --json -b -o+{lsblk_fields} {dev_path}').decode('UTF-8')
  File "/project/archinstall/lib/general.py", line 447, in __init__
    self.create_session()
  File "/project/archinstall/lib/general.py", line 498, in create_session
    with SysCommandWorker(
  File "/project/archinstall/lib/general.py", line 279, in __exit__
    raise SysCallError(f"{self.cmd} exited with abnormal exit code [{self.exit_code}]: {self._trace_log[-500:]}", self.exit_code, worker=self)
archinstall.lib.exceptions.SysCallError: ['/usr/bin/lsblk', '--json', '-b', '-o+SIZE,LOG-SEC,PTTYPE,ROTA,TRAN,PTUUID,PARTUUID,UUID,FSTYPE,TYPE,MOUNTPOINTS', '/dev/sda2'] exited with abnormal exit code [256]: b'l/lib/general.py", line 498, in create_session\r\n    with SysCommandWorker(\r\n  File "/project/archinstall/lib/general.py", line 279, in __exit__\r\n    raise SysCallError(f"{self.cmd} exited with abnormal exit code [{self.exit_code}]: {self._trace_log[-500:]}", self.exit_code, worker=self)\r\narchinstall.lib.exceptions.SysCallError: [\'/usr/bin/lsblk\', \'--json\', \'-b\', \'-o+SIZE,LOG-SEC,PTTYPE,ROTA,TRAN,PTUUID,PARTUUID,UUID,FSTYPE,TYPE,MOUNTPOINTS\', \'/dev/sda2\'] exited with abnormal exit code [1]: b\'\'\r\n'
```
This fixes this case by ignoring the FileNotFoundError, since that piece of code should not rely on existence of a log file. Same case as when permissions can't be fixed.

I also added an except to log any other errors that might be thrown, to make it easier to troubleshoot via the install.log

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
