### PR TITLE
Convert preset drive objects to `str` before passing to `Menu`

### DIFF
--- a/archinstall/lib/menu/global_menu.py
+++ b/archinstall/lib/menu/global_menu.py
@@ -351,7 +351,7 @@ class GlobalMenu(AbstractMenu):
 
 		return ntp
 
-	def _select_harddrives(self, old_harddrives: List[str] = []) -> List:
+	def _select_harddrives(self, old_harddrives: Optional[List[Any]] = None) -> List:
 		harddrives = select_harddrives(old_harddrives)
 
 		if harddrives is not None:

--- a/archinstall/lib/user_interaction/system_conf.py
+++ b/archinstall/lib/user_interaction/system_conf.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Any, Dict, TYPE_CHECKING
+from typing import List, Any, Dict, TYPE_CHECKING, Optional
 
 from ..disk import all_blockdevices
 from ..exceptions import RequirementError
@@ -42,7 +42,7 @@ def select_kernel(preset: List[str] = None) -> List[str]:
 		case MenuSelectionType.Selection: return choice.value
 
 
-def select_harddrives(preset: List[str] = []) -> List[str]:
+def select_harddrives(preset: Optional[List[Any]] = None) -> List[Any]:
 	"""
 	Asks the user to select one or multiple hard drives
 
@@ -60,7 +60,7 @@ def select_harddrives(preset: List[str] = []) -> List[str]:
 	selected_harddrive = Menu(
 		title,
 		list(options.keys()),
-		preset_values=preset,
+		preset_values=[str(option) for option in preset] if preset else None,
 		multi=True,
 		allow_reset=True,
 		allow_reset_warning_msg=warning


### PR DESCRIPTION
- Fixes #1574 

## PR Description:

`all_blockdevices()` returns a list of `BlockDevice` or `Partition` objects, but `Menu` requires list of `str` for argument `preset_values`. Use the objects directly will cause error in the `TerminalMenu.convert_preselected_entries_to_indices()` method.

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
