### PR TITLE
Adding a DependencyCheck runner. 

### DIFF
--- a/.github/workflows/dependencycheck.yaml
+++ b/.github/workflows/dependencycheck.yaml
@@ -1,0 +1,26 @@
+on: [ push, pull_request ]
+jobs:
+  depchecktest:
+    runs-on: ubuntu-latest
+    name: depecheck_test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build project with Maven
+        run: mvn clean install
+      - name: Depcheck
+        uses: dependency-check/Dependency-Check_Action@main
+        id: Depcheck
+        with:
+          project: 'archinstall'
+          path: '.'
+          format: 'HTML'
+          out: 'reports' # this is the default, no need to specify unless you wish to override it
+          args: >
+            --failOnCVSS 7
+            --enableRetired
+      - name: Upload Test results
+        uses: actions/upload-artifact@master
+        with:
+           name: Depcheck report
+           path: ${{github.workspace}}/reports


### PR DESCRIPTION
Mainly for future prep, when we start using external dependencies.
This should at least give us a basic safety check against some known issues.

I might have misunderstood DependencyCheck support for Python?: https://github.com/jeremylong/DependencyCheck/pull/5025