### PR TITLE
Give lsblk x chances to respond

### DIFF
--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -173,23 +173,26 @@ class Partition:
 		# This sleep might be overkill, but lsblk is known to
 		# work against a chaotic cache that can change during call
 		# causing no information to be returned (blkid is better)
-		# time.sleep(1)
 
-		# TODO: Maybe incorporate a re-try system here based on time.sleep(max(0.1, storage.get('DISK_TIMEOUTS', 1)))
-
-		try:
-			output = SysCommand(f"lsblk --json -b -o+LOG-SEC,SIZE,PTTYPE,PARTUUID,UUID,FSTYPE {self.device_path}").decode('UTF-8')
-		except SysCallError as error:
-			# It appears as if lsblk can return exit codes like 8192 to indicate something.
-			# But it does return output so we'll try to catch it.
-			output = error.worker.decode('UTF-8')
-
-		if output:
+		i = 0
+		while i < range(storage['DISK_RETRY_ATTEMPTS']):
 			try:
-				lsblk_info = json.loads(output)
-				return lsblk_info
-			except json.decoder.JSONDecodeError:
-				log(f"Could not decode JSON: {output}", fg="red", level=logging.ERROR)
+				output = SysCommand(f"lsblk --json -b -o+LOG-SEC,SIZE,PTTYPE,PARTUUID,UUID,FSTYPE {self.device_path}").decode('UTF-8')
+			except SysCallError as error:
+				# It appears as if lsblk can return exit codes like 8192 to indicate something.
+				# But it does return output so we'll try to catch it.
+				output = error.worker.decode('UTF-8')
+
+			if output:
+				try:
+					lsblk_info = json.loads(output)
+					return lsblk_info
+				except json.decoder.JSONDecodeError:
+					log(f"Could not decode JSON: {output}", fg="red", level=logging.ERROR)
+					
+			else:
+				time.sleep(max(0.1, storage['DISK_TIMEOUTS'] * i))
+				i += 1
 
 		raise DiskError(f'Failed to read disk "{self.device_path}" with lsblk')
 


### PR DESCRIPTION
I see this sleep was removed '[for testing purposes](https://github.com/archlinux/archinstall/pull/1445)'

This is causing a DiskError on my poor slow USB stick.

```
...line 195, in _call_lasblk
...Failed to read disk "/dev/sdb1" with lsblk
```
I had a crack at implementing the retry system suggested on that fork. Any feedback would be appreciated ^_^

The changes look more drastic than they actually are because I added tabs for my while loop.