### PR TITLE
Revise packages in Budgie profile

### DIFF
--- a/profiles/budgie.py
+++ b/profiles/budgie.py
@@ -4,12 +4,16 @@ import archinstall
 
 is_top_level_profile = False
 
-# "It is recommended also to install the gnome group, which contains applications required for the standard GNOME experience." - Arch Wiki
 __packages__ = [
+	"arc-gtk-theme",
 	"budgie-desktop",
-	"gnome",
+	"budgie-desktop-view",
 	"lightdm",
 	"lightdm-gtk-greeter",
+	"mate-terminal",
+	"network-manager-applet",
+	"nemo",
+	"papirus-icon-theme",
 ]
 
 

--- a/profiles/budgie.py
+++ b/profiles/budgie.py
@@ -6,12 +6,10 @@ is_top_level_profile = False
 
 __packages__ = [
 	"arc-gtk-theme",
-	"budgie-desktop",
-	"budgie-desktop-view",
+	"budgie",
 	"lightdm",
 	"lightdm-gtk-greeter",
 	"mate-terminal",
-	"network-manager-applet",
 	"nemo",
 	"papirus-icon-theme",
 ]


### PR DESCRIPTION
## PR Description:

This PR revises the list of packages included in the Budgie profile.

- The Arc GTK theme and Papirus icon theme are the schema defaults for the `budgie-desktop` package (Adwaita does not support Budgie), and thus including their packages sets them in the desktop automatically
- The `gnome` group has been replaced with Nemo and MATE Terminal, as most of that group was unnecessary to include in a minimal Budgie installation
- `budgie-desktop-view` provides desktop icon support for users who want the feature

These changes result in a Budgie installation more reflective of current upstream recommendations.

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
