### PR TITLE
Modify "Española" to "Español"

### DIFF
--- a/archinstall/locales/languages.json
+++ b/archinstall/locales/languages.json
@@ -146,7 +146,7 @@
  {"abbr": "sd", "lang": "Sindhi"},
  {"abbr": "so", "lang": "Somali"},
  {"abbr": "st", "lang": "Southern Sotho"},
- {"abbr": "es", "lang": "Spanish", "translated_lang": "Española"},
+ {"abbr": "es", "lang": "Spanish", "translated_lang": "Español"},
  {"abbr": "sq", "lang": "Albanian"},
  {"abbr": "sc", "lang": "Sardinian"},
  {"abbr": "sr", "lang": "Serbian"},


### PR DESCRIPTION
## PR Description:

So the translated name of Spanish is defined as "Española". It's pretty unnatural. At first, I thought it might be a shorthand for something like "la idioma española" : "the Spanish language", which, while still being really strange, would make a little bit of sense. Nevertheless, when looking at the other languages' names, they don't seem to follow this "convention" : French is "Français" and not "Française", Russian is "Ruskij" and not "Ruskaja"... 

## Tests and Checks
- [ ] I have tested the code!