### PR TITLE
Use partx instead of partprobe to avoid the kernel removing a blockdevice entry

### DIFF
--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -420,9 +420,9 @@ class Partition:
 	def partprobe(self) -> bool:
 		try:
 			if self.block_device:
-				return 0 == SysCommand(f'partprobe {self.block_device.device}').exit_code
+				return 0 == SysCommand(f'partx {self.block_device.device}').exit_code
 		except SysCallError as error:
-			log(f"Unreliable results might be given for {self._path} due to partprobe error: {error}", level=logging.DEBUG)
+			log(f"Unreliable results might be given for {self._path} due to partx error: {error}", level=logging.DEBUG)
 
 		return False
 


### PR DESCRIPTION
- This fix issue: #1557 

## PR Description:

Occasionally `partprobe` causes the kernel to remove a partition entry from its list of block devices.
This commit replaces the use of the `partprobe` command with `partx`. Refer to the following for more details:
 - https://access.redhat.com/solutions/510843
 - https://serverfault.com/questions/501493/partprobe-will-not-work-i-have-tried-everything

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
