### PR TITLE
add polkit to packages since it won't launch without it

### DIFF
--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -15,6 +15,7 @@ __packages__ = [
 	"slurp",
 	"pavucontrol",
 	"foot",
+	"polkit", ## Sway wont launch and throw errors if polkit is not installed. 
 ]
 
 


### PR DESCRIPTION
I believe polkit is required for sway to launch properly if using the sway profile. 