### PR TITLE
Resolving Failed to read disk "/dev/sdaX" with lsblk.

### DIFF
--- a/archinstall/lib/disk/blockdevice.py
+++ b/archinstall/lib/disk/blockdevice.py
@@ -137,6 +137,8 @@ class BlockDevice:
 		# Doesn't harm us, but worth noting in case something weird happens.
 		try:
 			output = SysCommand(f"parted -s --machine {self._path} print free").decode('utf-8')
+			if not output:
+				output = SysCommand(f'lsblk -a -e 8 --json -b -o+SIZE,PTTYPE,ROTA,TRAN,PTUUID {self._path}').decode('UTF-8')
 			if output:
 				free_lines = [line for line in output.split('\n') if 'free' in line]
 				sizes = []

--- a/archinstall/lib/disk/diskinfo.py
+++ b/archinstall/lib/disk/diskinfo.py
@@ -26,6 +26,8 @@ def get_lsblk_info(dev_path: str) -> LsblkInfo:
 	lsblk_fields = ','.join([f.upper().replace('_', '-') for f in fields])
 
 	output = SysCommand(f'lsblk --json -b -o+{lsblk_fields} {dev_path}').decode('UTF-8')
+	if not output:
+		output = SysCommand(f'lsblk -a -e 8 --json -b -o+{lsblk_fields} {dev_path}').decode('UTF-8')
 
 	if output:
 		block_devices = json.loads(output)

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -55,6 +55,8 @@ class Filesystem:
 
 			# We'll use unreliable lbslk to grab children under the /dev/<device>
 			output = json.loads(SysCommand(f"lsblk --json {self.blockdevice.device}").decode('UTF-8'))
+			if not output or not output.get('blockdevices'):
+				output = json.loads(SysCommand(f"lsblk -a -e 8 --json {self.blockdevice.device}").decode('UTF-8'))
 
 			for device in output['blockdevices']:
 				for index, partition in enumerate(device.get('children', [])):

--- a/archinstall/lib/disk/helpers.py
+++ b/archinstall/lib/disk/helpers.py
@@ -493,6 +493,8 @@ def convert_device_to_uuid(path :str) -> str:
 		# TODO: Convert lsblk to blkid
 		# (lsblk supports BlockDev and Partition UUID grabbing, blkid requires you to pick PTUUID and PARTUUID)
 		output = json.loads(SysCommand(f"lsblk --json -o+UUID {device_name}").decode('UTF-8'))
+		if not output or not output.get('blockdevices'):
+			output = json.loads(SysCommand(f"lsblk -a -e 8 --json -o+UUID {device_name}").decode('UTF-8'))
 
 		for device in output['blockdevices']:
 			if (dev_uuid := device.get('uuid', None)):

--- a/archinstall/lib/disk/partition.py
+++ b/archinstall/lib/disk/partition.py
@@ -36,7 +36,10 @@ class PartitionInfo:
 	def __post_init__(self):
 		if not all([self.partuuid, self.uuid]):
 			for i in range(storage['DISK_RETRY_ATTEMPTS']):
-				lsblk_info = SysCommand(f"lsblk --json -b -o+LOG-SEC,SIZE,PTTYPE,PARTUUID,UUID,FSTYPE {self.device_path}").decode('UTF-8')
+				try:
+					lsblk_info = SysCommand(f"lsblk --json -b -o+LOG-SEC,SIZE,PTTYPE,PARTUUID,UUID,FSTYPE {self.device_path}").decode('UTF-8')
+				except:
+					lsblk_info = SysCommand(f"lsblk -a -e 8 --json -b -o+LOG-SEC,SIZE,PTTYPE,PARTUUID,UUID,FSTYPE {self.device_path}").decode('UTF-8')
 				try:
 					lsblk_info = json.loads(lsblk_info)
 				except json.decoder.JSONDecodeError:


### PR DESCRIPTION
- This fix issue:  #1557 for instance.

## PR Description:
When we are running the installation an error appears, preventing the installation.
```
Could not decode JSON: lsblk: /dev/sda1: not a block device
{
   "blockdevices": [

   ]
}
```
If we run the command `lsblk` we get can get a similar result:
```
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
loop0         7:0    0 705.6M  1 loop /run/archiso/airootfs
sda           8:0    1  29.9G  0 disk
└─sda2        8:2    1    15M  0 part
nvme0n1     259:0    0 476.9G  0 disk
├─nvme0n1p1 259:1    0   100M  0 part
├─nvme0n1p2 259:2    0   128M  0 part
├─nvme0n1p3 259:3    0   475G  0 part
└─nvme0n1p4 259:4    0   1.7G  0 part
```
**sda** is our installation disk, the **MAJ** value is **8** and, it's the problem, in my code I have add a option to run the `lsblk`excluding this device.

## Tests and Checks
- [x] I have tested the code!<br>
Maybe it's not the best way to resolve it, but for this moment is working.
