### PR TITLE
Added more services that we need to wait for.

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -113,7 +113,7 @@ class Filesystem:
 				format_options = partition.get('options',[]) + partition.get('filesystem',{}).get('format_options',[])
 				disk_encryption: DiskEncryption = storage['arguments'].get('disk_encryption')
 
-				if partition in disk_encryption.partitions:
+				if disk_encryption and partition in disk_encryption.partitions:
 					if not partition['device_instance']:
 						raise DiskError(f"Internal error caused us to loose the partition. Please report this issue upstream!")
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -146,14 +146,6 @@ def perform_installation(mountpoint):
 				if partition.size < 0.19: # ~200 MiB in GiB
 					raise archinstall.DiskError(f"The selected /boot partition in use is not large enough to properly install a boot loader. Please resize it to at least 200MiB and re-run the installation.")
 
-		# if len(mirrors):
-		# Certain services might be running that affects the system during installation.
-		# Currently, only one such service is "reflector.service" which updates /etc/pacman.d/mirrorlist
-		# We need to wait for it before we continue since we opted in to use a custom mirror/region.
-		installation.log('Waiting for automatic mirror selection (reflector) to complete.', level=logging.INFO)
-		while archinstall.service_state('reflector') not in ('dead', 'failed'):
-			time.sleep(1)
-
 		# If we've activated NTP, make sure it's active in the ISO too and
 		# make sure at least one time-sync finishes before we continue with the installation
 		if archinstall.arguments.get('ntp', False):
@@ -175,6 +167,22 @@ def perform_installation(mountpoint):
 					installation.log(f"Waiting for timedatectl timesync-status to report a timesync against a server", level=logging.INFO)
 					logged = True
 				time.sleep(1)
+		
+		# if len(mirrors):
+		# Certain services might be running that affects the system during installation.
+		# Currently, only one such service is "reflector.service" which updates /etc/pacman.d/mirrorlist
+		# We need to wait for it before we continue since we opted in to use a custom mirror/region.
+		installation.log('Waiting for automatic mirror selection (reflector) to complete.', level=logging.INFO)
+		while archinstall.service_state('reflector') not in ('dead', 'failed'):
+			time.sleep(1)
+
+		installation.log('Waiting pacman-init.service to complete.', level=logging.INFO)
+		while archinstall.service_state('pacman-init') not in ('dead', 'failed'):
+			time.sleep(1)
+
+		installation.log('Waiting Arch Linux keyring sync (archlinux-keyring-wkd-sync) to complete.', level=logging.INFO)
+		while archinstall.service_state('archlinux-keyring-wkd-sync') not in ('dead', 'failed'):
+			time.sleep(1)
 
 		# Set mirrors used by pacstrap (outside of installation)
 		if archinstall.arguments.get('mirror-region', None):


### PR DESCRIPTION
- This fix issue: #1389 

## PR Description:

As more services have been added to combat the keyring issue of booting a live ISO, we also need to wait for more services. Currently we need to wait for:

 * ntp (if chosen in a pre-loaded `--conf`)
 * `reflector.service` *(otherwise mirrors will be slow to even get the initial `-Syy`)*
 * `pacman-init.service` *(which is a one-time-setup for the ISO specifically in our case)*
 * `archlinux-keyring-wkd-sync` *(which syncs new keys from archlinux-keyring into the ISO PGP keyring, this is the mother dough of solving our issues I think)*`

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
