### PR TITLE
Use setdefault for sys-language and sys-encoding

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -221,11 +221,8 @@ def load_config():
 			selected_region = arguments.get('mirror-region', None)
 			arguments['mirror-region'] = {selected_region: list_mirrors()[selected_region]}
 
-	if arguments.get('sys-language', None) is not None:
-		arguments['sys-language'] = arguments.get('sys-language', 'en_US')
-
-	if arguments.get('sys-encoding', None) is not None:
-		arguments['sys-encoding'] = arguments.get('sys-encoding', 'utf-8')
+    arguments.setdefault('sys-language', 'en_US')
+    arguments.setdefault('sys-encoding', 'utf-8')
 
 	if arguments.get('gfx_driver', None) is not None:
 		storage['gfx_driver_packages'] = AVAILABLE_GFX_DRIVERS.get(arguments.get('gfx_driver', None), None)


### PR DESCRIPTION
….

- This does not fix an issue <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:
For `sys-encoding` and `sys-language`, the setdefault function of the arguments dictionary is used instead of manually checking if key-value pair exists. Minimal changes.
<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
