### PR TITLE
Sway profile - select seat

### DIFF
--- a/archinstall/lib/user_interaction/general_conf.py
+++ b/archinstall/lib/user_interaction/general_conf.py
@@ -174,7 +174,10 @@ def select_profile(preset) -> Optional[Profile]:
 			storage['profile_minimal'] = False
 			storage['_selected_servers'] = []
 			storage['_desktop_profile'] = None
+			storage['sway_sys_priv_ctrl'] = None
+			storage['arguments']['sway_sys_priv_ctrl'] = None
 			storage['arguments']['desktop-environment'] = None
+			storage['arguments']['gfx_driver'] = None
 			storage['arguments']['gfx_driver_packages'] = None
 			return None
 		case MenuSelectionType.Skip:

--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -71,7 +71,7 @@ def _prep_function(*args, **kwargs):
 
 """
 def _post_install(*args, **kwargs):
-	if "seatd" in _sway_system_privilege_control:
+	if "seatd" in sway_sys_priv_ctrl:
 		print(_('After booting, add user(s) to the `seat` user group and re-login to use Sway'))
 	return True
 """

--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -37,7 +37,7 @@ def _check_driver() -> bool:
 	return True
 
 def _get_system_privelege_control_preference():
-	## need to activate seat service and add to seat group
+	# need to activate seat service and add to seat group
 	title = str(_('Sway needs access to your seat (collection of hardware devices i.e. keyboard, mouse, etc)'))
 	title += str(_('\n\nChoose an option to give Sway access to your hardware'))
 	choice = Menu(title, ["polkit", "seatd"]).run()
@@ -68,6 +68,7 @@ def _prep_function(*args, **kwargs):
 		return True
 
 	return False
+
 
 """
 def _post_install(*args, **kwargs):

--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -1,6 +1,12 @@
 # A desktop environment using "Sway"
+from typing import Any, TYPE_CHECKING
+
 import archinstall
 from archinstall import Menu
+from archinstall.lib.menu.menu import MenuSelectionType
+
+if TYPE_CHECKING:
+	_: Any
 
 is_top_level_profile = False
 
@@ -22,7 +28,7 @@ def _check_driver() -> bool:
 	packages = archinstall.storage.get("gfx_driver_packages", [])
 
 	if packages and "nvidia" in packages:
-		prompt = 'The proprietary Nvidia driver is not supported by Sway. It is likely that you will run into issues, are you okay with that?'
+		prompt = _('The proprietary Nvidia driver is not supported by Sway. It is likely that you will run into issues, are you okay with that?')
 		choice = Menu(prompt, Menu.yes_no(), default_option=Menu.no(), skip=False).run()
 
 		if choice.value == Menu.no():
@@ -30,6 +36,18 @@ def _check_driver() -> bool:
 
 	return True
 
+def _get_system_privelege_control_preference():
+	## need to activate seat service and add to seat group
+	title = str(_('Sway needs access to your seat (collection of hardware devices i.e. keyboard, mouse, etc)'))
+	title += str(_('\n\nChoose an option to give Sway access to your hardware'))
+	choice = Menu(title, ["polkit", "seatd"]).run()
+
+	if choice.type_ != MenuSelectionType.Selection:
+		return False
+
+	archinstall.storage['sway_sys_priv_ctrl'] = [choice.value]
+	archinstall.arguments['sway_sys_priv_ctrl'] = [choice.value]
+	return True
 
 def _prep_function(*args, **kwargs):
 	"""
@@ -38,6 +56,9 @@ def _prep_function(*args, **kwargs):
 	other code in this stage. So it's a safe way to ask the user
 	for more input before any other installer steps start.
 	"""
+	if not _get_system_privelege_control_preference():
+		return False
+
 	driver = archinstall.select_driver()
 
 	if driver:
@@ -48,16 +69,29 @@ def _prep_function(*args, **kwargs):
 
 	return False
 
+"""
+def _post_install(*args, **kwargs):
+	if "seatd" in _sway_system_privilege_control:
+		print(_('After booting, add user(s) to the `seat` user group and re-login to use Sway'))
+	return True
+"""
 
 # Ensures that this code only gets executed if executed
 # through importlib.util.spec_from_file_location("sway", "/somewhere/sway.py")
 # or through conventional import sway
 if __name__ == "sway":
 	if not _check_driver():
-		raise archinstall.lib.exceptions.HardwareIncompatibilityError("Sway does not support the proprietary nvidia drivers.")
+		raise archinstall.lib.exceptions.HardwareIncompatibilityError(_('Sway does not support the proprietary nvidia drivers.'))
 
 	# Install the Sway packages
 	archinstall.storage['installation_session'].add_additional_packages(__packages__)
+	if "seatd" in archinstall.storage['sway_sys_priv_ctrl']:
+		archinstall.storage['installation_session'].add_additional_packages(['seatd'])
+		archinstall.storage['installation_session'].enable_service('seatd')
+	elif "polkit" in archinstall.storage['sway_sys_priv_ctrl']:
+		archinstall.storage['installation_session'].add_additional_packages(['polkit'])
+	else:
+		raise archinstall.lib.exceptions.ProfileError(_('Sway requires either seatd or polkit to run'))
 
 	# Install the graphics driver packages
 	archinstall.storage['installation_session'].add_additional_packages(f"xorg-server xorg-xinit {' '.join(archinstall.storage.get('gfx_driver_packages', None))}")


### PR DESCRIPTION
This is perhaps a more fleshed out option to resolve #1626 

## PR Description:

This PR adds a selection menu when selecting the sway profile that allows the user to either install polkit or seat. One of the two is required for sway to run, so we should prompt the user to choose one when installing sway.

## Tests and Checks
- [x] I have tested the code! I ran on the v2.5.3 ISO and testing the following installation flows:
    - Installing sway profile with polkit
    - Installing sway profile with seatd
    - Selecting sway profile with seatd/polkit, then clearing selection
    - Selecting sway profile with seatd/polkit, then clearing selection and selecting KDE
