### PR TITLE
Added parted sector unit

### DIFF
--- a/archinstall/lib/disk/validators.py
+++ b/archinstall/lib/disk/validators.py
@@ -7,10 +7,12 @@ def valid_parted_position(pos :str) -> bool:
 	if pos.isdigit():
 		return True
 
-	if pos.lower().endswith('b') and pos[:-1].isdigit():
+	pos_lower = pos.lower()
+
+	if (pos_lower.endswith('b') or pos_lower.endswith('s')) and pos[:-1].isdigit():
 		return True
 
-	if any(pos.lower().endswith(size) and pos[:-len(size)].replace(".", "", 1).isdigit()
+	if any(pos_lower.endswith(size) and pos[:-len(size)].replace(".", "", 1).isdigit()
 			for size in ['%', 'kb', 'mb', 'gb', 'tb', 'kib', 'mib', 'gib', 'tib']):
 		return True
 


### PR DESCRIPTION
## PR Description

Added the sector unit for parted. See: https://www.gnu.org/software/parted/manual/html_node/unit.html
The sector unit is IMO actually the most useful one. It makes creating partitions way easier. Instead of having to calculate the MB (i.e.) for the start and end location of the partition one can just work with the already given start and end sectors of the other partitions.

Maybe @Torxed left them out because he thought that sectors were the default unit.
But actually is kB the default (at least if not set differently) https://users.cs.fiu.edu/~downeyt/cgs3767/parted.html

Another alternative instead of adding the sector unit there would be setting the default unit to sectors in parted which is probably what you had in mind in the first place and what I would also recommend!

This PR partly also relates to https://github.com/archlinux/archinstall/issues/1669

## Todo
Also I think a better prompt text would be very helpful. I had to look up a lot of stuff before understanding what was going on. The "block number" was what confused me. I thought that meant the sector.

Currently ([code](https://github.com/archlinux/archinstall/blob/master/archinstall/lib/user_interaction/partitioning_conf.py#L211)):
> Enter the start sector (percentage or block number, default: {}):
> Enter the end sector of the partition (percentage or block number, ex: {}):

My idea:
> Enter the start sector (in parted units: 's', 'GB', '%', etc. ; default: {}):
> Enter the end sector of the partition (in parted units: 's', 'GB', '%', etc. ; ex: {}):

I am very new to the code base and have no idea how one would go about changing that in the locales and everything. If you like my idea or some variation of it please just commit it :)

## Tests and Checks
- [ ] I have tested the code!<br>

