### PR TITLE
Check if line begins with 'warning' before adding it to package info

### DIFF
--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -106,7 +106,7 @@ def installed_package(package :str) -> LocalPackage:
 	package_info = {}
 	try:
 		for line in run_pacman(f"-Q --info {package}"):
-			if b':' in line:
+			if b':' in line and not line.startswith(b'warning'):
 				key, value = line.decode().split(':', 1)
 				package_info[key.strip().lower().replace(' ', '_')] = value.strip()
 	except SysCallError:

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import ssl
 from typing import Dict, Any, Tuple, List
@@ -106,10 +107,10 @@ def installed_package(package :str) -> LocalPackage:
 	package_info = {}
 	try:
 		for line in run_pacman(f"-Q --info {package}"):
-			if b':' in line and not line.startswith(b'warning'):
+			if b':' in line:
 				key, value = line.decode().split(':', 1)
 				package_info[key.strip().lower().replace(' ', '_')] = value.strip()
 	except SysCallError:
 		pass
 
-	return LocalPackage(**package_info)
+    return LocalPackage({field.name: package_info.get(field.name) for field in dataclasses.fields(LocalPackage)})

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -113,4 +113,4 @@ def installed_package(package :str) -> LocalPackage:
 	except SysCallError:
 		pass
 
-    return LocalPackage({field.name: package_info.get(field.name) for field in dataclasses.fields(LocalPackage)})
+	return LocalPackage({field.name: package_info.get(field.name) for field in dataclasses.fields(LocalPackage)})


### PR DESCRIPTION
- This fix issue: #1673<!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:
Skip lines from `pacman -Q --info` that begin with 'warning' before adding them to package info to avoid getting a TypeError.
The problem is explained with more detail on #1673 
<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  - Tested on live ISO
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
