### PR TITLE
Fixed flake8 warnings

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -319,7 +319,7 @@ class Installer:
 
 		partition.mount(f'{self.target}{mountpoint}', options=options)
 
-	def add_swapfile(self, size = '4G', enable_resume = True, file='/swapfile'):
+	def add_swapfile(self, size='4G', enable_resume=True, file='/swapfile'):
 		if file[:1] != '/':
 			file = f"/{file}"
 		if len(file.strip()) <= 0 or file == '/':
@@ -337,7 +337,7 @@ class Installer:
 
 			self.HOOKS.append('resume')
 			self.KERNEL_PARAMS.append(f'resume=UUID={resume_uuid}')
-			self.KERNEL_PARAMS.append(f'resume_offset={resume_offset}')			
+			self.KERNEL_PARAMS.append(f'resume_offset={resume_offset}')
 
 	def post_install_check(self, *args :str, **kwargs :str) -> List[str]:
 		return [step for step, flag in self.helper_flags.items() if flag is False]
@@ -456,7 +456,6 @@ class Installer:
 		with open(f"{self.target}/etc/fstab", 'a') as fstab_fh:
 			for entry in self.FSTAB_ENTRIES:
 				fstab_fh.write(f'{entry}\n')
-
 
 		return True
 


### PR DESCRIPTION
- This fix issue: #1675 

## PR Description:

This PR only fixes these warnings below to follow PEP8:
```bash
./archinstall/lib/installer.py:322:29: E251 unexpected spaces around keyword / parameter equals
        def add_swapfile(self, size = '4G', enable_resume = True, file='/swapfile'):
                                   ^
./archinstall/lib/installer.py:322:31: E251 unexpected spaces around keyword / parameter equals
        def add_swapfile(self, size = '4G', enable_resume = True, file='/swapfile'):
                                     ^
./archinstall/lib/installer.py:322:51: E251 unexpected spaces around keyword / parameter equals
        def add_swapfile(self, size = '4G', enable_resume = True, file='/swapfile'):
                                                         ^
./archinstall/lib/installer.py:322:53: E251 unexpected spaces around keyword / parameter equals
        def add_swapfile(self, size = '4G', enable_resume = True, file='/swapfile'):
                                                           ^
./archinstall/lib/installer.py:340:63: W291 trailing whitespace
                        self.KERNEL_PARAMS.append(f'resume_offset={resume_offset}')
                                                                                   ^
./archinstall/lib/installer.py:461:3: E303 too many blank lines (2)
                return True
                ^
4     E251 unexpected spaces around keyword / parameter equals
1     E303 too many blank lines (2)
1     W291 trailing whitespace
```

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
