### PR TITLE
Add gwenview spectacle and kcalc to "KDE"

### DIFF
--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -13,6 +13,9 @@ __packages__ = [
 	"sddm",
 	"plasma-wayland-session",
 	"egl-wayland"
+	"spectacle"
+	"gwenview"
+	"kcalc"
 ]
 
 


### PR DESCRIPTION
## PR Description:
We are adding those in this PR for the "KDE" option
Gwenview - is the default KDE software to open image files
Spectacle - is the default KDE software to make screenshots (without it "printscreen" key does nothing at all)
Kcalc - is the default KDE "calculator"

Always good to have basic apps pre-installed

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
