### PR TITLE
Install package if it is not installed and then return package_info o…

### DIFF
--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -112,4 +112,10 @@ def installed_package(package :str) -> LocalPackage:
 	except SysCallError:
 		pass
 
+	# If package is installed (package_info dictionary is not empty), then return the LocalPackage object
+	if(bool(package_info)):
+		return LocalPackage(**package_info)
+	
+	# Else if the package is not installed (package_info dictionary is empty), then install the package
+	run_pacman(f"-S {package} -y --noconfirm")
 	return LocalPackage(**package_info)


### PR DESCRIPTION
- This fix issue: #1686  

## PR Description:
This adds the code to install the package using run_pacman() function, if it is not installed. This is done inside the installed_package() function present in archinstall/archinstall/lib/packages/packages.py