### PR TITLE
Guard against null in config processor

### DIFF
--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -71,7 +71,7 @@ class ConfigurationOutput:
 			else:
 				self._user_config[key] = self._config[key]
 
-				if key == 'disk_encryption':  # special handling for encryption password
+				if key == 'disk_encryption' and self._config[key]:  # special handling for encryption password
 					self._user_credentials['encryption_password'] = self._config[key].encryption_password
 
 	def user_config_to_json(self) -> str:


### PR DESCRIPTION
Fixes #1704


## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

`self._config['disk_encryption']` can exist and `= None` so guard against that case. 

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
