### PR TITLE
Fix i3 profile

### DIFF
--- a/profiles/i3.py
+++ b/profiles/i3.py
@@ -7,7 +7,7 @@ is_top_level_profile = False
 # New way of defining packages for a profile, which is iterable and can be used out side
 # of the profile to get a list of "what packages will be installed".
 __packages__ = [
-	'i3-wm'
+	'i3-wm',
 	'i3lock',
 	'i3status',
 	'i3blocks',


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->
Fix typo in the `__packages__ ` list of the i3 profile: add missing comma.

Before this fix installer has failed to execute this profile. It has tried to find `i3-wmi3lock` package, which is obviously doesn't exists.

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
