### PR TITLE
profiles/sway: update packages

### DIFF
--- a/profiles/sway.py
+++ b/profiles/sway.py
@@ -12,15 +12,17 @@ is_top_level_profile = False
 
 __packages__ = [
 	"sway",
+	"swaybg",
 	"swaylock",
 	"swayidle",
 	"waybar",
 	"dmenu",
-	"light",
+	"brightnessctl",
 	"grim",
 	"slurp",
 	"pavucontrol",
 	"foot",
+	"xorg-xwayland",
 ]
 
 


### PR DESCRIPTION
## PR Description:
This change updates the dependencies for Sway.
- `swaybg` is the default wallpaper tool used by Sway
- `light` isn't being developed anymore (see https://github.com/haikarainen/light), and `brightnessctl` is a good replacement
- `dmenu` requires Xwayland to run in Sway

This also duplicates PR #1514.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
