### PR TITLE
Fixing starting of service via str argument

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -570,6 +570,8 @@ class Installer:
 	def enable_service(self, services: Union[str, List[str]]) -> None:
 		if type(services[0]) in (list, tuple):
 			services = services[0]
+		if type(services) == str:
+			services = [services, ]
 
 		for service in services:
 			self.log(f'Enabling service {service}', level=logging.INFO)


### PR DESCRIPTION
- This fix issue: #1778 

## PR Description:

If `Installer.enable_service("something.service")` was given, the for loop in `enable_service` will iterate over the string rather than treating the given string as `["something.service", ]`.
