### PR TITLE
Fix NTP option

### DIFF
--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -18,6 +18,7 @@ from .user_interaction import ask_for_audio_selection
 from .user_interaction import ask_for_bootloader
 from .user_interaction import ask_for_swap
 from .user_interaction import ask_hostname
+from .user_interaction import ask_ntp
 from .user_interaction import ask_to_configure_network
 from .user_interaction import get_password, ask_for_a_timezone
 from .user_interaction import select_additional_repositories
@@ -163,6 +164,7 @@ class GlobalMenu(AbstractMenu):
 		self._menu_options['ntp'] = \
 			Selector(
 				_('Automatic time sync (NTP)'),
+				lambda preset: ask_ntp(preset),
 				default=True)
 		self._menu_options['__separator__'] = \
 			Selector('')


### PR DESCRIPTION
I missed that a mistake was made when upstream master was merged in #1729. The intention of that pull request was to remove enabling NTP in the ISO/live environment since it is already activated on boot of that environment. That was successful but the merge of upstream master broke the option in the guided installer to disable/enable use of systemd-timesyncd (NTP) in the installation (installation is an entirely separate environment from ISO/live environment with its own systemd-timesyncd). The option is stuck on enable and can not be disabled. This restores that function.
