### PR TITLE
Fix default value idx in `_determine_cursor_pos()`

### DIFF
--- a/archinstall/lib/menu/menu.py
+++ b/archinstall/lib/menu/menu.py
@@ -337,7 +337,10 @@ class Menu(TerminalMenu):
 					if '|' in p:
 						p = p.replace('|', '\\|')
 
-					idx = self._menu_options.index(p)
+					if p in self._menu_options:
+						idx = self._menu_options.index(p)
+					else:
+						idx = self._menu_options.index(self._default_menu_value)
 					indexes.append(idx)
 				except (IndexError, ValueError):
 					log(f'Error finding index of {p}: {self._menu_options}', level=logging.DEBUG)


### PR DESCRIPTION
The following are examples of messages that can be observed in the log when interacting with a `Menu` that is initialized with a `default_option` such as the guided installer menus for swap, NTP, and audio.
- `Error finding index of yes: ['yes (default)', 'no']`
- `Error finding index of No audio server: ['No audio server (default)', 'pipewire', 'pulseaudio']`

~~This is fixed by increasing the priority of a default value over that of preset values in `_determine_cursor_pos()`.~~
