### PR TITLE
Remove Flit from `build_iso.sh` added packages

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -8,7 +8,6 @@ packages=(
 	python
 	python-pip
 	python-build
-	python-flit
 	python-setuptools
 	python-wheel
 	python-pyparted


### PR DESCRIPTION
Remove `python-flit` from the packages added to the archiso profile packages in `build_iso.sh` since it was replaced in #1655.
