### PR TITLE
Rework `build_iso.sh`

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-packages_file="/tmp/archlive/packages.x86_64"
+set -eu
 
-# Packages to add to the archiso profile packages
+readonly base_profile="/usr/share/archiso/configs/releng/"
+readonly custom_profile="/tmp/archlive"
+readonly packages_file="$custom_profile/packages.x86_64"
+readonly airootfs="$custom_profile/airootfs"
+readonly archinstall_dir="/root/archinstall"
+readonly build_script="/root/build-archinstall.sh"
+readonly build_service="/etc/systemd/system/build-archinstall.service"
+
+# Packages to add to the archiso custom profile
 packages=(
 	git
 	python
@@ -13,34 +21,79 @@ packages=(
 	python-pyparted
 )
 
-mkdir -p /tmp/archlive/airootfs/root/archinstall-git
-cp -r . /tmp/archlive/airootfs/root/archinstall-git
-
-cat <<- _EOF_ | tee /tmp/archlive/airootfs/root/.zprofile
-	cd archinstall-git
-	rm -rf dist
-
-	python -m build --wheel --no-isolation
-	pip install dist/archinstall*.whl
-
-	echo "This is an unofficial ISO for development and testing of archinstall. No support will be provided."
-	echo "This ISO was built from Git SHA $GITHUB_SHA"
-	echo "Type archinstall to launch the installer."
-_EOF_
-
 pacman -Sy
 pacman --noconfirm -S git archiso
 
-cp -r /usr/share/archiso/configs/releng/* /tmp/archlive
+# Copy an archiso base profile to create a custom profile from
+cp -r $base_profile $custom_profile
 
+# Copy the archinstall directory to the archiso custom profile
+cp -r "$(dirname "$0")" ${airootfs}${archinstall_dir}
+
+# Remove the archinstall package from the archiso custom profile
 sed -i /archinstall/d $packages_file
 
-# Add packages to the archiso profile packages
+# Add packages to the archiso custom profile
 for package in "${packages[@]}"; do
 	echo "$package" >> $packages_file
 done
 
-find /tmp/archlive
-cd /tmp/archlive
+# Use the `GITHUB_SHA` environment variable for the commit hash if it exists
+if [[ -v GITHUB_SHA ]]; then
+	commit_hash="$GITHUB_SHA"
+# Use git for the commit hash if the `GITHUB_SHA` environment varible is not set
+else
+	commit_hash="$(git rev-parse HEAD)"
+fi
 
-mkarchiso -v -w work/ -o out/ ./
+# Append an archinstall developement message to motd
+cat <<- _EOF_ >> $airootfs/etc/motd
+
+	[1;31marchinstall development ISO[0m
+	Git commit hash: $commit_hash
+	This is an unofficial ISO for development and testing of archinstall. No support will be provided.
+_EOF_
+
+# A script to build archinstall in the live environment
+cat <<- _EOF_ > ${airootfs}${build_script}
+	cd $archinstall_dir
+	rm -rf dist
+
+	python -m build --wheel --no-isolation
+	pip install dist/*.whl
+_EOF_
+
+# A service to run the archinstall build script in the live environment
+cat <<- _EOF_ > ${airootfs}${build_service}
+	[Unit]
+	Description=Build archinstall
+	After=network.target
+
+	[Service]
+	Type=oneshot
+	ExecStart=/bin/sh $build_script
+
+	[Install]
+	WantedBy=multi-user.target
+_EOF_
+
+# Enable the service that runs the archinstall build script
+ln -sf $build_service $airootfs/etc/systemd/system/multi-user.target.wants/
+
+# A startup file to wait for the completion of the service that runs the archinstall build script
+cat <<- _EOF_ > $airootfs/root/.zprofile
+	if [ "\$(systemctl show -p SubState --value ${build_service##*/})" != "dead" ]; then
+	    printf "Building archinstall (${build_service##*/})..."
+	    while [ "\$(systemctl show -p SubState --value ${build_service##*/})" != "dead" ]; do
+	        sleep 1
+	    done
+	    echo " done"
+	    echo "Type [35marchinstall[0m to launch the installer."
+	fi
+
+	cd $archinstall_dir
+_EOF_
+
+cd $custom_profile
+
+mkarchiso -v $custom_profile


### PR DESCRIPTION
Move the development message to motd. Move archinstall build from zprofile to a script. Create a service that is enabled on boot to run the script. Wait for completion of the service at root login shell (zprofile).

Currently the build of archinstall in the ISO environment is output to the console. This is problematic because there is not a scrollback buffer in the console to review the output. The changes in this pull request will allow the review of the build with `journalctl -u build-archinstall`.

Another issue with the current implementation is changing tty or executing tmux and opening panes and windows will read and execute the zprofile causing archinstall to be built and installed again. This pull request does not have this problem because the script to build and install archinstall is started by the service.
