### PR TITLE
Add `set -e` to `build_iso.sh`

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 packages_file="/tmp/archlive/packages.x86_64"
 
 # Packages to add to the archiso profile packages


### PR DESCRIPTION
From `help set` on the `-e` option, "Exit immediately if a command exits with a non-zero status."