### PR TITLE
Remove partial upgrade from `build_iso.sh`

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -30,7 +30,6 @@ cat <<- _EOF_ | tee /tmp/archlive/airootfs/root/.zprofile
 	echo "Type archinstall to launch the installer."
 _EOF_
 
-pacman -Sy
 pacman --noconfirm -S git archiso
 
 cp -r /usr/share/archiso/configs/releng/* /tmp/archlive


### PR DESCRIPTION
One is done just before `build_iso.sh` is executed.

https://github.com/archlinux/archinstall/blob/6e6b850a8f687b193172aaa321d49bd2956c1d4f/.github/workflows/iso-build.yaml#L34-L35
