### PR TITLE
Install the package `sof-firmware` if required

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -1,7 +1,7 @@
 import os
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 
 from .general import SysCommand
 from .networking import list_interfaces, enrich_iface_types
@@ -169,3 +169,22 @@ class SysInfo:
 			debug(f"System is not running in a VM: {err}")
 
 		return False
+
+	@staticmethod
+	def _loaded_modules() -> List[str]:
+		"""
+		Returns loaded kernel modules
+		"""
+		modules_path = Path('/proc/modules')
+		modules: List[str] = []
+
+		with modules_path.open() as file:
+			for line in file:
+				module = line.split(maxsplit=1)[0]
+				modules.append(module)
+
+		return modules
+
+	@staticmethod
+	def requires_sof() -> bool:
+		return 'snd_sof' in SysInfo._loaded_modules()

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -182,6 +182,9 @@ def perform_installation(mountpoint: Path):
 				PipewireProfile().install(installation)
 			elif audio == 'pulseaudio':
 				installation.add_additional_packages("pulseaudio")
+
+			if SysInfo.requires_sof():
+				installation.add_additional_packages('sof-firmware')
 		else:
 			info("No audio server will be installed")
 

--- a/examples/interactive_installation.py
+++ b/examples/interactive_installation.py
@@ -161,6 +161,9 @@ def perform_installation(mountpoint: Path):
 				PipewireProfile().install(installation)
 			elif audio == 'pulseaudio':
 				installation.add_additional_packages("pulseaudio")
+
+			if SysInfo.requires_sof():
+				installation.add_additional_packages('sof-firmware')
 		else:
 			info("No audio server will be installed.")
 


### PR DESCRIPTION
Resolves #1807

"[sof-firmware](https://archlinux.org/packages/?name=sof-firmware) is required for some newer laptop models (mainly since 2019) ..." [1]

The 'Sound Open Firmware (SOF) Core' kernel module (`sof_snd`) should be automatically loaded when hardware that requires it is detected. [2] Determine if the package is required by checking if this kernel module is loaded. Install the package if it is required and an audio selection is present.

[1] https://wiki.archlinux.org/title/Advanced_Linux_Sound_Architecture#ALSA_firmware
[2] https://wiki.archlinux.org/title/Kernel_module#Automatic_module_loading
