### PR TITLE
Install the package `alsa-firmware` if required

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -86,6 +86,21 @@ class _SysInfo:
 	def mem_info_by_key(self, key: str) -> int:
 		return self.mem_info[key]
 
+	@cached_property
+	def loaded_modules(self) -> List[str]:
+		"""
+		Returns loaded kernel modules
+		"""
+		modules_path = Path('/proc/modules')
+		modules: List[str] = []
+
+		with modules_path.open() as file:
+			for line in file:
+				module = line.split(maxsplit=1)[0]
+				modules.append(module)
+
+		return modules
+
 
 _sys_info = _SysInfo()
 
@@ -171,20 +186,9 @@ class SysInfo:
 		return False
 
 	@staticmethod
-	def _loaded_modules() -> List[str]:
-		"""
-		Returns loaded kernel modules
-		"""
-		modules_path = Path('/proc/modules')
-		modules: List[str] = []
-
-		with modules_path.open() as file:
-			for line in file:
-				module = line.split(maxsplit=1)[0]
-				modules.append(module)
-
-		return modules
+	def requires_sof_fw() -> bool:
+		return 'snd_sof' in _sys_info.loaded_modules
 
 	@staticmethod
-	def requires_sof() -> bool:
-		return 'snd_sof' in SysInfo._loaded_modules()
+	def requires_alsa_fw() -> bool:
+		return 'snd_emu10k1' in _sys_info.loaded_modules

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -183,8 +183,11 @@ def perform_installation(mountpoint: Path):
 			elif audio == 'pulseaudio':
 				installation.add_additional_packages("pulseaudio")
 
-			if SysInfo.requires_sof():
+			if SysInfo.requires_sof_fw():
 				installation.add_additional_packages('sof-firmware')
+
+			if SysInfo.requires_alsa_fw():
+				installation.add_additional_packages('alsa-firmware')
 		else:
 			info("No audio server will be installed")
 

--- a/examples/interactive_installation.py
+++ b/examples/interactive_installation.py
@@ -162,8 +162,11 @@ def perform_installation(mountpoint: Path):
 			elif audio == 'pulseaudio':
 				installation.add_additional_packages("pulseaudio")
 
-			if SysInfo.requires_sof():
+			if SysInfo.requires_sof_fw():
 				installation.add_additional_packages('sof-firmware')
+
+			if SysInfo.requires_alsa_fw():
+				installation.add_additional_packages('alsa-firmware')
 		else:
 			info("No audio server will be installed.")
 


### PR DESCRIPTION
"The [alsa-firmware](https://archlinux.org/packages/?name=alsa-firmware) package contains firmware that may be required for certain sound cards (e.g. Creative SB0400 Audigy2)." [1]

Same concept as #1811 but for the package `alsa-firmware` and kernel module `snd-emu10k1`. [2]

[1] https://wiki.archlinux.org/title/Advanced_Linux_Sound_Architecture#ALSA_firmware
[2] https://www.alsa-project.org/main/index.php/Matrix%3aModule-emu10k1
