### PR TITLE
installer: add Limine bootloader

### DIFF
--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -347,8 +347,7 @@ class GlobalMenu(AbstractMenu):
 		if bootloader == Bootloader.Limine and boot_partition.fs_type == disk.FilesystemType.Btrfs:
 			return "Limine bootloader does not support booting from BTRFS filesystem"
 
-		return True
-
+		return None
 
 	def _is_config_valid(self) -> bool:
 		"""

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -331,7 +331,7 @@ class GlobalMenu(AbstractMenu):
 
 	def _validate_bootloader(self) -> Optional[str]:
 		"""
-		Checks the selected bootloader is valid for the selected filesystem 
+		Checks the selected bootloader is valid for the selected filesystem
 		type of the boot partition.
 
 		Returns [`None`] if the bootloader is valid, otherwise returns a

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -355,14 +355,6 @@ class GlobalMenu(AbstractMenu):
 
 		return None
 
-	def _is_config_valid(self) -> bool:
-		"""
-		Checks the validity of the current configuration.
-		"""
-		if len(self._missing_configs()) != 0:
-			return False
-		return self._validate_bootloader() is None
-
 	def _prev_install_invalid_config(self) -> Optional[str]:
 		if missing := self._missing_configs():
 			text = str(_('Missing configurations:\n'))

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -340,10 +340,16 @@ class GlobalMenu(AbstractMenu):
 		bootloader = self._menu_options['bootloader'].current_selection
 		boot_partition: Optional[disk.PartitionModification] = None
 
-		for layout in self._menu_options['disk_config'].current_selection.device_modifications:
-			if boot_partition := layout.get_boot_partition():
-				break
-		
+		if disk_config := self._menu_options['disk_config'].current_selection:
+			for layout in disk_config.device_modifications:
+				if boot_partition := layout.get_boot_partition():
+					break
+		else:
+			return "No disk layout selected"
+
+		if boot_partition is None:
+			return "Boot partition not found"
+
 		if bootloader == Bootloader.Limine and boot_partition.fs_type == disk.FilesystemType.Btrfs:
 			return "Limine bootloader does not support booting from BTRFS filesystem"
 

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -169,8 +169,8 @@ class GlobalMenu(AbstractMenu):
 		self._menu_options['install'] = \
 			Selector(
 				self._install_text(),
-				exec_func=lambda n, v: True if len(self._missing_configs()) == 0 else False,
-				preview_func=self._prev_install_missing_config,
+				exec_func=lambda n, v: self._is_config_valid(),
+				preview_func=self._prev_install_invalid_config,
 				no_store=True)
 
 		self._menu_options['abort'] = Selector(_('Abort'), exec_func=lambda n,v:exit(1))
@@ -199,6 +199,14 @@ class GlobalMenu(AbstractMenu):
 					missing.add(self._menu_options['disk_config'].description)
 
 		return list(missing)
+
+	def _is_config_valid(self) -> bool:
+		"""
+		Checks the validity of the current configuration.
+		"""
+		if len(self._missing_configs()) != 0:
+			return False
+		return self._validate_bootloader() is None
 
 	def _update_install_text(self, name: str, value: str):
 		text = self._install_text()
@@ -321,12 +329,45 @@ class GlobalMenu(AbstractMenu):
 			return disk.EncryptionType.type_to_text(current_value.encryption_type)
 		return ''
 
-	def _prev_install_missing_config(self) -> Optional[str]:
+	def _validate_bootloader(self) -> Optional[str]:
+		"""
+		Checks the selected bootloader is valid for the selected filesystem 
+		type of the boot partition.
+
+		Returns [`None`] if the bootloader is valid, otherwise returns a
+		string with the error message.
+		"""
+		bootloader = self._menu_options['bootloader'].current_selection
+		boot_partition: Optional[disk.PartitionModification] = None
+
+		for layout in self._menu_options['disk_config'].current_selection.device_modifications:
+			if boot_partition := layout.get_boot_partition():
+				break
+		
+		if bootloader == Bootloader.Limine and boot_partition.fs_type == disk.FilesystemType.Btrfs:
+			return "Limine bootloader does not support booting from BTRFS filesystem"
+
+		return True
+
+
+	def _is_config_valid(self) -> bool:
+		"""
+		Checks the validity of the current configuration.
+		"""
+		if len(self._missing_configs()) != 0:
+			return False
+		return self._validate_bootloader() is None
+
+	def _prev_install_invalid_config(self) -> Optional[str]:
 		if missing := self._missing_configs():
 			text = str(_('Missing configurations:\n'))
 			for m in missing:
 				text += f'- {m}\n'
 			return text[:-1]  # remove last new line
+
+		if error := self._validate_bootloader():
+			return f"Invalid configuration: {error}"
+
 		return None
 
 	def _prev_users(self) -> Optional[str]:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -886,7 +886,8 @@ class Installer:
 				# `limine-deploy` deploys the stage 1 and 2 to the disk.
 				cmd = f'/usr/bin/arch-chroot' \
 					f' {self.target}' \
-					f' limine-deploy' \
+					f' limine' \
+					f' bios-install' \
 					f' {device.device_info.path}'
 				
 				SysCommand(cmd, peek_output=True)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1027,7 +1027,7 @@ TIMEOUT=5
 		Archinstall supports one of three types:
 		* systemd-bootctl
 		* grub
-		* limine
+		* limine (beta)
 		* efistub (beta)
 
 		:param bootloader: Type of bootloader to be added

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -857,7 +857,7 @@ class Installer:
 		boot_partition: disk.PartitionModification,
 		root_partition: disk.PartitionModification
 	):
-		self._pacstrap('limine')
+		self.pacman.strap('limine')
 		info(f"Limine boot partition: {boot_partition.dev_path}")
 
 		# XXX: We cannot use `root_partition.uuid` since corresponds to the UUID of the root
@@ -943,13 +943,13 @@ TIMEOUT=5
 :Arch Linux
 	PROTOCOL=linux
 	KERNEL_PATH=boot:///vmlinuz-linux
-	CMDLINE=root=UUID={root_uuid} rw rootfstype={root_partition.fs_type.value} loglevel=3
+	CMDLINE=root=UUID={root_uuid} rw rootfstype={root_partition.safe_fs_type.value} loglevel=3
 	MODULE_PATH=boot:///initramfs-linux.img
 
 :Arch Linux (fallback)
 	PROTOCOL=linux
 	KERNEL_PATH=boot:///vmlinuz-linux
-	CMDLINE=root=UUID={root_uuid} rw rootfstype={root_partition.fs_type.value} loglevel=3
+	CMDLINE=root=UUID={root_uuid} rw rootfstype={root_partition.safe_fs_type.value} loglevel=3
 	MODULE_PATH=boot:///initramfs-linux-fallback.img
 			"""
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -883,7 +883,7 @@ class Installer:
 				
 				SysCommand(cmd, peek_output=True)
 
-				# `limine-deploy` deploys the stage 1 and 2 to the disk. 
+				# `limine-deploy` deploys the stage 1 and 2 to the disk.
 				cmd = f'/usr/bin/arch-chroot' \
 					f' {self.target}' \
 					f' limine-deploy' \
@@ -900,16 +900,16 @@ class Installer:
 TIMEOUT=5
 
 :Arch Linux
-    PROTOCOL=linux
-    KERNEL_PATH=boot:///vmlinuz-linux
-    CMDLINE=root=UUID={root_partition.uuid} rw rootfstype={root_partition.fs_type.value} loglevel=3
-    MODULE_PATH=boot:///initramfs-linux.img
+	PROTOCOL=linux
+	KERNEL_PATH=boot:///vmlinuz-linux
+	CMDLINE=root=UUID={root_partition.uuid} rw rootfstype={root_partition.fs_type.value} loglevel=3
+	MODULE_PATH=boot:///initramfs-linux.img
 
 :Arch Linux (fallback)
-    PROTOCOL=linux
-    KERNEL_PATH=boot:///vmlinuz-linux
-    CMDLINE=root=UUID={root_partition.uuid} rw rootfstype={root_partition.fs_type.value} loglevel=3
-    MODULE_PATH=boot:///initramfs-linux-fallback.img
+	PROTOCOL=linux
+	KERNEL_PATH=boot:///vmlinuz-linux
+	CMDLINE=root=UUID={root_partition.uuid} rw rootfstype={root_partition.fs_type.value} loglevel=3
+	MODULE_PATH=boot:///initramfs-linux-fallback.img
 			"""
 
 			SysCommand(f"/usr/bin/arch-chroot {self.target} sh -c \"echo '{config}' > /boot/limine.cfg\"")

--- a/archinstall/lib/interactions/system_conf.py
+++ b/archinstall/lib/interactions/system_conf.py
@@ -40,9 +40,9 @@ def select_kernel(preset: List[str] = []) -> List[str]:
 
 
 def ask_for_bootloader(preset: Bootloader) -> Bootloader:
-	# when the system only supports grub
+	# Systemd is UEFI only
 	if not SysInfo.has_uefi():
-		options = [Bootloader.Grub.value]
+		options = [Bootloader.Grub.value, Bootloader.Limine.value]
 		default = Bootloader.Grub.value
 	else:
 		options = Bootloader.values()

--- a/archinstall/lib/models/bootloader.py
+++ b/archinstall/lib/models/bootloader.py
@@ -12,6 +12,7 @@ class Bootloader(Enum):
 	Systemd = 'Systemd-boot'
 	Grub = 'Grub'
 	Efistub = 'Efistub'
+	Limine = 'Limine'
 
 	def json(self):
 		return self.value


### PR DESCRIPTION
This pull request adds support for the limine bootloader to archinstall :) Limine is a modern, advanced, portable, multiprotocol bootloader.

## References

[Limine GitHub](https://github.com/limine-bootloader/limine) 
[Limine Arch Wiki](https://wiki.archlinux.org/title/Limine)

## Tests and Checks
- [x]  `x86_64` BIOS
- [x] `x86_64` UEFI