### PR TITLE
Allowing for fg='color' in info, warn, error and debug.

### DIFF
--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -238,20 +238,34 @@ def _stylize_output(
 	return f'\033[{ansi}m{text}\033[0m'
 
 
-def info(*msgs: str):
-	log(*msgs, level=logging.INFO)
+def info(*msgs: str, **kwargs: dict):
+	if 'level' not in kwargs:
+		kwargs['level'] = logging.INFO
+
+	log(*msgs, **kwargs)
+
+def debug(*msgs: str, **kwargs: dict):
+	if 'level' not in kwargs:
+		kwargs['level'] = logging.DEBUG
+
+	log(*msgs, **kwargs)
+
+def error(*msgs: str, **kwargs: dict):
+	if 'level' not in kwargs:
+		kwargs['level'] = logging.ERROR
+	if 'fg' not in kwargs:
+		kwargs['fg'] = 'red'
+
+	log(*msgs, **kwargs)
 
 
-def debug(*msgs: str):
-	log(*msgs, level=logging.DEBUG)
+def warn(*msgs: str, **kwargs: dict):
+	if 'level' not in kwargs:
+		kwargs['level'] = logging.ERROR
+	if 'fg' not in kwargs:
+		kwargs['fg'] = 'yellow'
 
-
-def error(*msgs: str):
-	log(*msgs, level=logging.ERROR, fg='red')
-
-
-def warn(*msgs: str):
-	log(*msgs, level=logging.WARNING, fg='yellow')
+	log(*msgs, **kwargs)
 
 
 def log(


### PR DESCRIPTION
This is a complementary patch to https://github.com/archlinux/archinstall/pull/1801
Otherwise things like this won't work: https://github.com/archlinux/archinstall/blob/6b367c7a1cc6011847daeb6b52d1593ac4b6b87a/archinstall/lib/configuration.py#L166

Technically yea, that maybe could be something other than `red` in the example. But could be purple or anything, issue is that keywords got lost :)