### PR TITLE
Detect more modules requiring `alsa-firmware`

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -191,4 +191,33 @@ class SysInfo:
 
 	@staticmethod
 	def requires_alsa_fw() -> bool:
-		return 'snd_emu10k1' in _sys_info.loaded_modules
+		modules = (
+			'snd_asihpi',
+			'snd_cs46xx',
+			'snd_darla20',
+			'snd_darla24',
+			'snd_echo3g',
+			'snd_emu10k1',
+			'snd_gina20',
+			'snd_gina24',
+			'snd_hda_codec_ca0132',
+			'snd_hdsp',
+			'snd_indigo',
+			'snd_indigodj',
+			'snd_indigodjx',
+			'snd_indigoio',
+			'snd_indigoiox',
+			'snd_layla20',
+			'snd_layla24',
+			'snd_mia',
+			'snd_mixart',
+			'snd_mona',
+			'snd_pcxhr',
+			'snd_vx_lib'
+		)
+
+		for loaded_module in _sys_info.loaded_modules:
+			if loaded_module in modules:
+				return True
+
+		return False


### PR DESCRIPTION
In #1812 detection for the module `snd-emu10k1` was added, this adds detection for more modules.

I was unable to find a list of loadable kernel modules that on Arch Linux require firmware provided by the `alsa-firmware` package so I created the following Python script.

- [script](https://github.com/codefiles/examples/blob/main/src/alsa-firmware.py)
- [output](https://github.com/codefiles/examples/actions/runs/4998487791/jobs/8953940446#step:9:1)

Only a few firmware files provided by the package were not matched to any of the sound loadable kernel modules provided by the `linux` kernel package.
