### PR TITLE
Update i3.py

### DIFF
--- a/archinstall/default_profiles/desktops/i3.py
+++ b/archinstall/default_profiles/desktops/i3.py
@@ -21,7 +21,7 @@ class I3wmProfile(XorgProfile):
 			'xterm',
 			'lightdm-gtk-greeter',
 			'lightdm',
-			'dmenu',
+			'dmenu'
 		]
 
 	@property


### PR DESCRIPTION
Bug with the installation of the i3 tiling manager because of an extra comma in the file

- This fix issue:

## PR Description:

Removed the comma after the "dmenu" package, since it is the final package

```
	@property
	def packages(self) -> List[str]:
		return [
			'i3-wm',
			'i3lock',
			'i3status',
			'i3blocks',
			'xterm',
			'lightdm-gtk-greeter',
			'lightdm',
			'dmenu' # Removed comma
		]
```

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
