### PR TITLE
Update bootctl --path option to --esp-path

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -793,10 +793,10 @@ class Installer:
 
 		# Install the boot loader
 		try:
-			SysCommand(f'/usr/bin/arch-chroot {self.target} bootctl --path=/boot install')
+			SysCommand(f'/usr/bin/arch-chroot {self.target} bootctl --esp-path=/boot install')
 		except SysCallError:
 			# Fallback, try creating the boot loader without touching the EFI variables
-			SysCommand(f'/usr/bin/arch-chroot {self.target} bootctl --no-variables --path=/boot install')
+			SysCommand(f'/usr/bin/arch-chroot {self.target} bootctl --no-variables --esp-path=/boot install')
 
 		# Ensure that the /boot/loader directory exists before we try to create files in it
 		if not os.path.exists(f'{self.target}/boot/loader'):


### PR DESCRIPTION
Since systemd v242 the bootctl `--path` option has been a compatibility alias and is therefore no longer documented.

### References
- https://man.archlinux.org/man/bootctl.1#OPTIONS
- https://github.com/systemd/systemd/blob/0b2aa2064f93cc154e704b262713de4fc395ce56/src/boot/bootctl.c#L231-L232
- https://github.com/systemd/systemd/commit/d25d289ae2e72be97d794d2895ea016410f9c1e0
