### PR TITLE
Simplify object serialization before JSON encoding

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -33,7 +33,7 @@ from .lib.configuration import ConfigurationOutput
 
 from .lib.general import (
 	generate_password, locate_binary, clear_vt100_escape_codes,
-	JsonEncoder, JSON, UNSAFE_JSON, SysCommandWorker, SysCommand,
+	JSON, UNSAFE_JSON, SysCommandWorker, SysCommand,
 	run_custom_user_commands, json_stream_to_structure, secret
 )
 

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -60,14 +60,11 @@ def clear_vt100_escape_codes(data :Union[bytes, str]) -> Union[bytes, str]:
 
 def serialize_to_dict(obj: Any, safe: bool = True) -> Any:
 	"""
-	Converts any archinstall data structures, instances or variables into
-	json.dumps() compatible nested dictionaries.
-
+	Converts objects into json.dumps() compatible nested dictionaries.
 	Setting safe to True skips dictionary keys starting with a bang (!)
 	"""
 
 	compatible_types = str, int, float, bool
-
 	if isinstance(obj, dict):
 		return {
 			key: serialize_to_dict(value, safe)

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -59,29 +59,21 @@ def clear_vt100_escape_codes(data :Union[bytes, str]) -> Union[bytes, str]:
 
 def serialize_to_dict(obj: Any, safe: bool = True) -> Any:
 	"""
-	This function will try it's best to convert any archinstall data structures,
-	instances or variables into json.dumps() compatible nested dictionaries.
+	Converts any archinstall data structures, instances or variables into
+	json.dumps() compatible nested dictionaries.
 
-	Setting safe to True will skip any dictionary key starting with
-	an exclamation mark (!)
+	Setting safe to True skips dictionary keys starting with a bang (!)
 	"""
+
+	compatible_types = str, int, float, bool
+
 	if isinstance(obj, dict):
-		# We'll need to iterate not just the value that default() usually gets passed
-		# But also iterate manually over each key: value pair in order to trap the keys.
-
-		copy = {}
-		for key, val in obj.items():
-			# These are the only types supported by json.dumps function.
-			# Anything else, especially unhashable types must be avoided.
-			if not isinstance(key, (str, int, float, bool)):
-				continue
-
-			if safe and isinstance(key, str) and key.startswith('!'):
-				continue
-			# These above key datatypes are primitives,
-			# we do not need to serialize them.
-			copy[key] = serialize_to_dict(val, safe)
-		return copy
+		return {
+			key: serialize_to_dict(value, safe)
+			for key, value in obj.items()
+			if isinstance(key, compatible_types)
+			and not (isinstance(key, str) and key.startswith("!") and safe)
+		}
 	
 	if hasattr(obj, 'json'):
 		# json() is a friendly name for json-helper, it should return

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -15,6 +15,7 @@ import urllib.request
 import urllib.error
 import pathlib
 from datetime import datetime, date
+from enum import Enum
 from typing import Callable, Optional, Dict, Any, List, Union, Iterator, TYPE_CHECKING
 from select import epoll, EPOLLIN, EPOLLHUP
 
@@ -74,7 +75,8 @@ def serialize_to_dict(obj: Any, safe: bool = True) -> Any:
 			if isinstance(key, compatible_types)
 			and not (isinstance(key, str) and key.startswith("!") and safe)
 		}
-	
+	if isinstance(obj, Enum):
+		return obj.value
 	if hasattr(obj, 'json'):
 		# json() is a friendly name for json-helper, it should return
 		# a dictionary representation of the object so that it can be

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -92,7 +92,7 @@ def serialize_to_dict(obj: Any, safe: bool = True) -> Any:
 		return str(obj)
 	if hasattr(obj, "__dict__"):
 		return vars(obj)
-	return obj
+	return str(obj)
 
 class JSON(json.JSONEncoder, json.JSONDecoder):
 	"""

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -58,7 +58,7 @@ def clear_vt100_escape_codes(data :Union[bytes, str]) -> Union[bytes, str]:
 	return data
 
 
-def serialize_to_dict(obj: Any, safe: bool = True) -> Any:
+def jsonify(obj: Any, safe: bool = True) -> Any:
 	"""
 	Converts objects into json.dumps() compatible nested dictionaries.
 	Setting safe to True skips dictionary keys starting with a bang (!)
@@ -67,7 +67,7 @@ def serialize_to_dict(obj: Any, safe: bool = True) -> Any:
 	compatible_types = str, int, float, bool
 	if isinstance(obj, dict):
 		return {
-			key: serialize_to_dict(value, safe)
+			key: jsonify(value, safe)
 			for key, value in obj.items()
 			if isinstance(key, compatible_types)
 			and not (isinstance(key, str) and key.startswith("!") and safe)
@@ -78,13 +78,13 @@ def serialize_to_dict(obj: Any, safe: bool = True) -> Any:
 		# json() is a friendly name for json-helper, it should return
 		# a dictionary representation of the object so that it can be
 		# processed by the json library.
-		return serialize_to_dict(obj.json(), safe)
+		return jsonify(obj.json(), safe)
 	if hasattr(obj, '__dump__'):
 		return obj.__dump__()
 	if isinstance(obj, (datetime, date)):
 		return obj.isoformat()
 	if isinstance(obj, (list, set, tuple)):
-		return [serialize_to_dict(item, safe) for item in obj]
+		return [jsonify(item, safe) for item in obj]
 	if isinstance(obj, pathlib.Path):
 		return str(obj)
 	if hasattr(obj, "__dict__"):
@@ -97,7 +97,7 @@ class JSON(json.JSONEncoder, json.JSONDecoder):
 	"""
 
 	def encode(self, obj: Any) -> str:
-		return super().encode(serialize_to_dict(obj))
+		return super().encode(jsonify(obj))
 
 
 class UNSAFE_JSON(json.JSONEncoder, json.JSONDecoder):
@@ -106,7 +106,7 @@ class UNSAFE_JSON(json.JSONEncoder, json.JSONDecoder):
 	"""
 
 	def encode(self, obj: Any) -> str:
-		return super().encode(serialize_to_dict(obj, safe=False))
+		return super().encode(jsonify(obj, safe=False))
 
 
 class SysCommandWorker:

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -71,8 +71,6 @@ def serialize_to_dict(obj: Any, safe: bool = True) -> Any:
 
 		copy = {}
 		for key, val in obj.items():
-			val = serialize_to_dict(val, safe)
-
 			# These are the only types supported by json.dumps function.
 			# Anything else, especially unhashable types must be avoided.
 			if not isinstance(key, (str, int, float, bool)):
@@ -80,10 +78,9 @@ def serialize_to_dict(obj: Any, safe: bool = True) -> Any:
 
 			if safe and isinstance(key, str) and key.startswith('!'):
 				continue
-			
 			# These above key datatypes are primitives,
 			# we do not need to serialize them.
-			copy[key] = val
+			copy[key] = serialize_to_dict(val, safe)
 		return copy
 	
 	if hasattr(obj, 'json'):


### PR DESCRIPTION
- This fix issue: #1860

## PR Description:

The `JsonEncoder` class with its static methods is replaced by a simple `jsonify` function. It recursively walks through a data structure or an instance to create nested dictionaries, excluding values whose keys begin with a bang (`!`) when the safe property is `True`. Unhashable types and types incompatible with `json.dumps` are avoided from being used as dictionary keys.

For non-dictionary objects, systematically check for methods like `json`, `__dump__`, `__dict__` before defaulting to returning the object as is.

The `JSON` and `UNSAFE_JSON` thunk classes simply use the `jsonify` function and encode the returned dictionary.

## Tests and Checks
- [x] I have tested the code!<br>