### PR TITLE
Always verify permissions and check for log dir

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -20,10 +20,7 @@ from . import default_profiles
 
 from .lib.hardware import SysInfo, AVAILABLE_GFX_DRIVERS
 from .lib.installer import Installer, accessibility_tools_in_use
-from .lib.output import (
-	FormattedOutput, log, error,
-	check_log_permissions, debug, warn, info
-)
+from .lib.output import FormattedOutput, log, error, debug, warn, info
 from .lib.storage import storage
 from .lib.global_menu import GlobalMenu
 from .lib.boot import Boot
@@ -49,8 +46,6 @@ storage['__version__'] = __version__
 # add the custome _ as a builtin, it can now be used anywhere in the
 # project to mark strings as translatable with _('translate me')
 DeferredTranslation.install()
-
-check_log_permissions()
 
 # Log various information about hardware before starting the installation. This might assist in troubleshooting
 debug(f"Hardware model detected: {SysInfo.sys_vendor()} {SysInfo.product_name()}; UEFI mode: {SysInfo.has_uefi()}")

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -135,7 +135,7 @@ class Journald:
 		log_adapter.log(level, message)
 
 
-def check_log_permissions():
+def _check_log_permissions():
 	filename = storage.get('LOG_FILE', None)
 	log_dir = storage.get('LOG_PATH', Path('./'))
 
@@ -292,6 +292,10 @@ def log(
 	reset: bool = False,
 	font: List[Font] = []
 ):
+	# leave this check here as we need to setup the logging
+	# right from the beginning when the modules are loaded
+	_check_log_permissions()
+
 	text = orig_string = ' '.join([str(x) for x in msgs])
 
 	# Attempt to colorize the output if supported


### PR DESCRIPTION
Fix #1865 
This should fix the non existent log dir when archinstall fails on module loading