### PR TITLE
Update budgie.py

### DIFF
--- a/archinstall/default_profiles/desktops/budgie.py
+++ b/archinstall/default_profiles/desktops/budgie.py
@@ -18,7 +18,7 @@ class BudgieProfile(XorgProfile):
 			"budgie",
 			"mate-terminal",
 			"nemo",
-			"papirus-icon-theme",
+			"papirus-icon-theme"
 		]
 
 	@property


### PR DESCRIPTION
Bug with the installation of the budgie because of an extra comma in the file

- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

Removed the comma after the "papirus-icon-theme" package, since it is the final package

```
	@property
	def packages(self) -> List[str]:
		return [
			"arc-gtk-theme",
			"budgie",
			"mate-terminal",
			"nemo",
			"papirus-icon-theme" # Removed comma
		]
```

## Tests and Checks
- [🮱] I have tested the code!<br>
