### PR TITLE
Update lxqt.py

### DIFF
--- a/archinstall/default_profiles/desktops/lxqt.py
+++ b/archinstall/default_profiles/desktops/lxqt.py
@@ -23,7 +23,7 @@ class LxqtProfile(XorgProfile):
 			"xdg-utils",
 			"ttf-freefont",
 			"leafpad",
-			"slock",
+			"slock"
 		]
 
 	@property


### PR DESCRIPTION
Bug with the installation of the lxqt because of an extra comma in the file

- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

Removed the comma after the "slock" package, since it is the final package
```
	@property
	def packages(self) -> List[str]:
		return [
			"lxqt",
			"breeze-icons",
			"oxygen-icons",
			"xdg-utils",
			"ttf-freefont",
			"leafpad",
			"slock" # Removed comma
		]
```
## Tests and Checks
- [🮱] I have tested the code!<br>
