### PR TITLE
Ability to add other DKMS packages.

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -26,7 +26,7 @@ class GfxPackage(Enum):
 	Xf86VideoNouveau = 'xf86-video-nouveau'
 	Xf86VideoVmware = 'xf86-video-vmware'
 
-	def into_dkms(self) -> GfxPackage:
+	def into_dkms(self) -> 'GfxPackage':
 		match self:
 			case GfxPackage.Nvidia:
 				return GfxPackage.NvidiaDkms

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -17,12 +17,23 @@ class GfxPackage(Enum):
 	Mesa = "mesa"
 	Nvidia = 'nvidia'
 	NvidiaOpen = 'nvidia-open'
+	NvidiaDkms = 'nvidia-dkms'
+	NvidiaOpenDkms = 'nvidia-open-dkms'
 	VulkanIntel = 'vulkan-intel'
 	VulkanRadeon = 'vulkan-radeon'
 	Xf86VideoAmdgpu = "xf86-video-amdgpu"
 	Xf86VideoAti = "xf86-video-ati"
 	Xf86VideoNouveau = 'xf86-video-nouveau'
 	Xf86VideoVmware = 'xf86-video-vmware'
+
+	def into_dkms(self) -> GfxPackage:
+		match self:
+			case GfxPackage.Nvidia:
+				return GfxPackage.NvidiaDkms
+			case GfxPackage.NvidiaOpen:
+				return GfxPackage.NvidiaOpenDkms
+			case _:
+				return self
 
 
 class GfxDriver(Enum):
@@ -88,6 +99,9 @@ class GfxDriver(Enum):
 					GfxPackage.Mesa,
 					GfxPackage.Xf86VideoVmware
 				]
+
+	def dkms_packages(self) -> List[GfxPackage]:
+		return [pkg.into_dkms() for pkg in self.packages()]
 
 
 class _SysInfo:

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -190,20 +190,20 @@ class ProfileHandler:
 
 	def install_gfx_driver(self, install_session: 'Installer', driver: Optional[GfxDriver]):
 		# Default to the following if prep fails.
-		additional_pkg = ['xorg-server', 'xorg-xinit']
+		pkgs = ['xorg-server', 'xorg-xinit']
 		try:
 			if driver is not None:
-				driver_pkgs = driver.packages()
-				pkg_names = [p.value for p in driver_pkgs]
-				additional_pkg.extend(pkg_names)
-				for driver_pkg in {GfxPackage.Nvidia, GfxPackage.NvidiaOpen} & set(driver_pkgs):
-					for kernel in {"linux-lts", "linux-zen"} & set(install_session.kernels):
-						# Fixes https://github.com/archlinux/archinstall/issues/585
-						install_session.add_additional_packages(f"{kernel}-headers")
-					install_session.add_additional_packages(['dkms', 'xorg-server', 'xorg-xinit', f'{driver_pkg.value}-dkms'])
-					# Only one (or zero) nvidia driver can be used at a time, return after the first match
-					return
-				if 'amdgpu' in pkg_names:
+				if custom_kernels := {"linux-lts", "linux-zen"} & set(install_session.kernels):
+					driver_pkgs = driver.dkms_packages()
+					install_session.add_additional_packages('dkms')
+				else:
+					driver_pkgs = driver.packages()
+
+				pkgs.extend([pkg.value for pkg in driver_pkgs])
+				for kernel in custom_kernels:
+					# Fixes https://github.com/archlinux/archinstall/issues/585
+					install_session.add_additional_packages(f"{kernel}-headers")
+				if 'amdgpu' in pkgs:
 					# The order of these two are important if amdgpu is installed #808
 					if 'amdgpu' in install_session.modules:
 						install_session.modules.remove('amdgpu')
@@ -214,7 +214,7 @@ class ProfileHandler:
 					install_session.modules.append('radeon')
 		except Exception as err:
 			warn(f"Could not handle nvidia and linux-zen specific situations during xorg installation: {err}")
-		install_session.add_additional_packages(additional_pkg)
+		install_session.add_additional_packages(pkgs)
 
 	def install_profile_config(self, install_session: 'Installer', profile_config: ProfileConfiguration):
 		profile = profile_config.profile

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -11,7 +11,7 @@ from typing import List, TYPE_CHECKING, Any, Optional, Dict, Union
 
 from archinstall.default_profiles.profile import Profile, TProfile, GreeterType
 from .profile_model import ProfileConfiguration
-from ..hardware import GfxDriver, GfxPackage
+from ..hardware import GfxDriver
 from ..menu import MenuSelectionType, Menu, MenuSelection
 from ..networking import list_interfaces, fetch_data_from_url
 from ..output import error, debug, info, warn


### PR DESCRIPTION
This does not fix an issue <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

- A new method `into_dkms` is added to `GfxPackage` to convert a variant to its respective DKMS packages.
- A new method `dkms_packages` is added to `GfxDriver` to get a package list with the non-DKMS packages replaced with their DKMS counterparts.

This should simplify the logic for installing GFX drivers and make it easier for any future DKMS packages to be added.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
