### PR TITLE
Fix disk encryption crash when libfido2 is not installed

### DIFF
--- a/archinstall/lib/disk/fido.py
+++ b/archinstall/lib/disk/fido.py
@@ -36,7 +36,11 @@ class Fido2:
 		# to prevent continous reloading which will slow
 		# down moving the cursor in the menu
 		if not cls._loaded or reload:
-			ret: Optional[str] = SysCommand(f"systemd-cryptenroll --fido2-device=list").decode('UTF-8')
+			ret = ""
+			try:
+				ret = Optional[str] = SysCommand(f"systemd-cryptenroll --fido2-device=list").decode('UTF-8')
+			except:
+				error('fido2 support is most likely not installed')
 			if not ret:
 				error('Unable to retrieve fido2 devices')
 				return []


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

This PR makes one very simple change - it places the call to ```systemd-cryptenroll --fido2-device=list``` into a try/except block to prevent the encryption setup from failing when libfido2 is not installed. Unless in a try/except block, the call fails because any command that exits with a non-zero code throws an exception as per SysCommand. When libfido2 is not installed, the mentioned command fails with code 1, unlike when the library is installed, it exits with code 0 regardless of whether there are fido2 devices present or not.

I have tested the code on my machine, and this change allows me to proceed further in the installation process while using disk encryption without the libfido2 package installed. The reason I'm making this change is because libfido2 should not be a hard dependency of archinstall, however, disk encryption can't be used without it (in the current state of the program).

If you want me to make any changes, or explain anything else, I will be happy to cooperate.

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
