### PR TITLE
Define ret as `Optional[str]` before reassignment in get_fido2_devices

### DIFF
--- a/archinstall/lib/disk/fido.py
+++ b/archinstall/lib/disk/fido.py
@@ -36,9 +36,9 @@ class Fido2:
 		# to prevent continous reloading which will slow
 		# down moving the cursor in the menu
 		if not cls._loaded or reload:
-			ret = ""
+			ret: Optional[str] = None
 			try:
-				ret = Optional[str] = SysCommand(f"systemd-cryptenroll --fido2-device=list").decode('UTF-8')
+				ret = SysCommand("systemd-cryptenroll --fido2-device=list").decode('UTF-8')
 			except:
 				error('fido2 support is most likely not installed')
 			if not ret:


### PR DESCRIPTION
- This fixes a mypy error

## PR Description:

In `get_fido2_devices`, `ret` is mistakenly assigned a datatype as a value instead of defining it with that type:

```py
ret = Optional[str] = SysCommand("...")
```

must be

```py
ret: Optional[str] = None
ret = SysCommand("...")
```

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
