### PR TITLE
Document new pip install flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ you can replace the version of archinstall with a new version and run that with 
 4. Now clone the latest repository with `git clone https://github.com/archlinux/archinstall`
 5. Enter the repository with `cd archinstall`
    *At this stage, you can choose to check out a feature branch for instance with `git checkout v2.3.1-rc1`*
-6. Build the project and install it using `pip install`
+6. Build the project and install it using `pip install --break-operating-system .`
 
 After this, running archinstall with `python -m archinstall` will run against whatever branch you chose in step 5.
 


### PR DESCRIPTION
See [this thead](https://github.com/archlinux/archinstall/issues/1734#issuecomment-1605709792) 

Including `--break-operating-system` flag in `pip install` instructions in doc.

- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
