### PR TITLE
Adding python-simple-term-menu to the dependency list

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,6 +13,15 @@ license=(GPL3)
 depends=(
   'python'
   'systemd'
+  'procps-ng'
+  'pciutils'
+  'arch-install-scripts'
+  'e2fsprogs'
+  'util-linux'
+  'coreutils'
+  'cryptsetup'
+  'kbd'
+  'btrfs-progs'
   'python-pyparted'
   'python-simple-term-menu'
 )

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: demostanis worlds <demostanis@protonmail.com>
 
 pkgname=archinstall
-pkgver=2.5.6
+pkgver=2.6.0
 pkgrel=1
 pkgdesc="Just another guided/automated Arch Linux installer with a twist"
 arch=(any)

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,19 +11,19 @@ arch=(any)
 url="https://github.com/archlinux/archinstall"
 license=(GPL3)
 depends=(
-  'python'
-  'systemd'
-  'procps-ng'
-  'pciutils'
   'arch-install-scripts'
-  'e2fsprogs'
-  'util-linux'
+  'btrfs-progs'
   'coreutils'
   'cryptsetup'
+  'e2fsprogs'
   'kbd'
-  'btrfs-progs'
+  'pciutils'
+  'procps-ng'
+  'python'
   'python-pyparted'
   'python-simple-term-menu'
+  'systemd'
+  'util-linux'
 )
 makedepends=(
   'python-setuptools'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,6 +14,7 @@ depends=(
   'python'
   'systemd'
   'python-pyparted'
+  'python-simple-term-menu'
 )
 makedepends=(
   'python-setuptools'

--- a/README.md
+++ b/README.md
@@ -17,14 +17,19 @@ The installer also doubles as a python library to install Arch Linux and manage 
 
     $ sudo pacman -S archinstall
 
-Or simply `git clone` the repo as it has no external dependencies *(but there are optional ones)*.<br>
-Or use `pip install --upgrade archinstall` to use as a library.
+Alternative ways to install are `git clone` the repository or `pip install --upgrade archinstall`.
 
 ## Running the [guided](https://github.com/archlinux/archinstall/blob/master/archinstall/scripts/guided.py) installer
 
-Assuming you are on an Arch Linux live-ISO:
+Assuming you are on an Arch Linux live-ISO or installed via `pip`:
 
     # archinstall
+
+## Running the [guided](https://github.com/archlinux/archinstall/blob/master/archinstall/scripts/guided.py) installer using `git`
+
+    # cd archinstall-git
+    # cp archinstall/scripts/guided.py
+    # python guided.py
 
 #### Advanced
 Some additional options that are not needed by most users are hidden behind the `--advanced` flag.

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 	_: Any
 
 
-__version__ = "2.5.6"
+__version__ = "2.6.0rc1"
 storage['__version__'] = __version__
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ readme = "README.md"
 requires-python = ">=3.11"
 keywords = ["linux", "arch", "archinstall", "installer"]
 classifiers = [
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.11",
     "Operating System :: POSIX :: Linux",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,12 @@ authors = [
 ]
 license = {text = "GPL-3.0-only"}
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 keywords = ["linux", "arch", "archinstall", "installer"]
 classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
@@ -60,7 +60,7 @@ packages = ["archinstall"]
 # where = ["archinstall"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 files = "archinstall/"
 exclude = "tests"
 #check_untyped_defs=true


### PR DESCRIPTION
This PR addresses some new changes to upstream packaging.
Namely that we now can add dependencies to `python-simple-term-menu` as well as some other `depends` to binaries that we utilize *(this will hopefully enable us to get notifications if and I really mean **if** (as it's unlikely atm) binaries such as `ps` disappears)*

@svartkanin & @IngoMeyer441 *(of the upstream package https://github.com/IngoMeyer441/simple-term-menu)*: the AUR package is now removed and merged into `extra` repo. I appreciate the effort of maintaining the AUR package and the introduction of it into `archinstall` :)