### PR TITLE
Created dwm.py

### DIFF
--- a/archinstall/default_profiles/desktops/dwm.py
+++ b/archinstall/default_profiles/desktops/dwm.py
@@ -1,0 +1,35 @@
+from typing import List, Optional, Any, TYPE_CHECKING
+
+from archinstall.default_profiles.profile import ProfileType, GreeterType
+from archinstall.default_profiles.xorg import XorgProfile
+
+if TYPE_CHECKING:
+	_: Any
+
+
+class BspwmProfile(XorgProfile):
+	def __init__(self):
+		super().__init__('Bspwm', ProfileType.WindowMgr, description='')
+
+	@property
+	def packages(self) -> List[str]:
+		return [
+			'dwm',
+			'st',
+			'dmenu',
+			'picom',
+			'xorg-xsetroot',
+      'xorg-xset',
+      'pywal',
+      'xdo',
+      'dunst',
+      'slock'
+		]
+
+	@property
+	def default_greeter_type(self) -> Optional[GreeterType]:
+		return GreeterType.Lightdm
+
+	def preview_text(self) -> Optional[str]:
+		text = str(_('Environment type: {}')).format(self.profile_type.value)
+		return text + '\n' + self.packages_text()


### PR DESCRIPTION
Created dwm.py for suckless users.

- Added new dwm.py at archinstall/default_profiles/desktops/.

## PR Description:

This will make easier for the dwm users to setup their suckless environment.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
