### PR TITLE
Fix 1916

### DIFF
--- a/archinstall/lib/disk/fido.py
+++ b/archinstall/lib/disk/fido.py
@@ -38,11 +38,10 @@ class Fido2:
 		if not cls._loaded or reload:
 			ret: Optional[str] = None
 			try:
+				raise ValueError('????')
 				ret = SysCommand("systemd-cryptenroll --fido2-device=list").decode('UTF-8')
-			except:
+			except Exception:
 				error('fido2 support is most likely not installed')
-			if not ret:
-				error('Unable to retrieve fido2 devices')
 				return []
 
 			fido_devices: str = clear_vt100_escape_codes(ret)  # type: ignore

--- a/archinstall/lib/disk/fido.py
+++ b/archinstall/lib/disk/fido.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from .device_model import PartitionModification, Fido2Device
 from ..general import SysCommand, SysCommandWorker, clear_vt100_escape_codes
 from ..output import error, info
+from ..exceptions import SysCallError
 
 
 class Fido2:
@@ -38,7 +39,7 @@ class Fido2:
 		if not cls._loaded or reload:
 			try:
 				ret: Optional[str] = SysCommand("systemd-cryptenroll --fido2-device=list").decode('UTF-8')
-			except Exception:
+			except SysCallError:
 				error('fido2 support is most likely not installed')
 				raise ValueError('HSM devices can not be detected, is libfido2 installed?')
 

--- a/archinstall/lib/disk/fido.py
+++ b/archinstall/lib/disk/fido.py
@@ -36,12 +36,13 @@ class Fido2:
 		# to prevent continous reloading which will slow
 		# down moving the cursor in the menu
 		if not cls._loaded or reload:
-			ret: Optional[str] = None
 			try:
-				raise ValueError('????')
-				ret = SysCommand("systemd-cryptenroll --fido2-device=list").decode('UTF-8')
+				ret: Optional[str] = SysCommand("systemd-cryptenroll --fido2-device=list").decode('UTF-8')
 			except Exception:
 				error('fido2 support is most likely not installed')
+				raise ValueError('HSM devices can not be detected, is libfido2 installed?')
+
+			if not ret:
 				return []
 
 			fido_devices: str = clear_vt100_escape_codes(ret)  # type: ignore

--- a/archinstall/lib/menu/menu.py
+++ b/archinstall/lib/menu/menu.py
@@ -34,6 +34,11 @@ class MenuSelection:
 
 
 class Menu(TerminalMenu):
+	_menu_is_active: bool = False
+
+	@staticmethod
+	def is_menu_active() -> bool:
+		return Menu._menu_is_active
 
 	@classmethod
 	def back(cls) -> str:
@@ -260,6 +265,8 @@ class Menu(TerminalMenu):
 			return MenuSelection(type_=MenuSelectionType.Skip)
 
 	def run(self) -> MenuSelection:
+		Menu._menu_is_active = True
+
 		selection = self._show()
 
 		if selection.type_ == MenuSelectionType.Reset:
@@ -276,6 +283,8 @@ class Menu(TerminalMenu):
 			if selection.value == self.back():
 				selection.type_ = MenuSelectionType.Skip
 				selection.value = None
+
+		Menu._menu_is_active = False
 
 		return selection
 

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -318,9 +318,11 @@ def log(
 
 	Journald.log(text, level=level)
 
-	# Finally, print the log unless we skipped it based on level.
-	# We use sys.stdout.write()+flush() instead of print() to try and
-	# fix issue #94
-	if level != logging.DEBUG or storage.get('arguments', {}).get('verbose', False):
-		sys.stdout.write(f"{text}\n")
-		sys.stdout.flush()
+	from .menu import Menu
+	if not Menu.is_menu_active():
+		# Finally, print the log unless we skipped it based on level.
+		# We use sys.stdout.write()+flush() instead of print() to try and
+		# fix issue #94
+		if level != logging.DEBUG or storage.get('arguments', {}).get('verbose', False):
+			sys.stdout.write(f"{text}\n")
+			sys.stdout.flush()


### PR DESCRIPTION
@codefiles this should fix #1916 for both producing stdout while a menu is active as well as the particular case of HSM. 

When the menu is triggered it will set itself to active and when it's done it will reset it. Any output that happens during that period is only written to the log file. 

In addition, the HSM libfido2 problem is handled more gracefully now. I think it's a fair trade-off as it will show a visual indication of the problem in the installer. 
If anyone wants to use the function in their own custom script, then it should throw a exception to give a straight forward indication of what's wrong and we can probably mention in some docs that the lib is required for using the HSM capability.