### PR TITLE
removed str() around objects to be serialized. As None should stay intact rather than become 'None'

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -79,7 +79,8 @@ def jsonify(obj: Any, safe: bool = True) -> Any:
 		return str(obj)
 	if hasattr(obj, "__dict__"):
 		return vars(obj)
-	return str(obj)
+
+	return obj
 
 class JSON(json.JSONEncoder, json.JSONDecoder):
 	"""


### PR DESCRIPTION
- This fix issue: #1930 

## PR Description:

After #1871 the `else` clause causes a last effort attempt to cast everything to a string, causing `None` to become `'None'` etc.

I missed this when merging so I'm correcting it in this PR.