### PR TITLE
Fix 1934 - audio server regression

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -237,6 +237,9 @@ def load_config():
 	if arguments.get('bootloader', None) is not None:
 		arguments['bootloader'] = models.Bootloader.from_arg(arguments['bootloader'])
 
+	if arguments.get('audio_config', None) is not None:
+		arguments['audio_config'] = models.AudioConfiguration.parse_arg(arguments['audio_config'])
+
 	if arguments.get('disk_encryption', None) is not None and disk_config is not None:
 		password = arguments.get('encryption_password', '')
 		arguments['disk_encryption'] = disk.DiskEncryption.parse_arg(

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, List, Optional, Union, Dict, TYPE_CHECKING
+from typing import Any, List, Optional, Dict, TYPE_CHECKING
 
 from . import disk
 from .general import secret
@@ -9,6 +9,7 @@ from .menu import Selector, AbstractMenu
 from .mirrors import MirrorConfiguration, MirrorMenu
 from .models import NetworkConfiguration, NicType
 from .models.bootloader import Bootloader
+from .models.audio_configuration import Audio, AudioConfiguration
 from .models.users import User
 from .output import FormattedOutput
 from .profile.profile_menu import ProfileConfiguration
@@ -109,12 +110,11 @@ class GlobalMenu(AbstractMenu):
 				display_func=lambda x: x.profile.name if x else '',
 				preview_func=self._prev_profile
 			)
-		self._menu_options['audio'] = \
+		self._menu_options['audio_config'] = \
 			Selector(
 				_('Audio'),
 				lambda preset: self._select_audio(preset),
-				display_func=lambda x: x if x else '',
-				default=None
+				display_func=lambda x: self._display_audio(x)
 			)
 		self._menu_options['parallel downloads'] = \
 			Selector(
@@ -421,13 +421,18 @@ class GlobalMenu(AbstractMenu):
 		profile_config = ProfileMenu(store, preset=current_profile).run()
 		return profile_config
 
-	def _select_audio(self, current: Union[str, None]) -> Optional[str]:
-		profile_config: Optional[ProfileConfiguration] = self._menu_options['profile_config'].current_selection
-		if profile_config and profile_config.profile:
-			is_desktop = profile_config.profile.is_desktop_profile() if profile_config else False
-			selection = ask_for_audio_selection(is_desktop, current)
-			return selection
-		return None
+	def _select_audio(
+		self,
+		current: Optional[AudioConfiguration] = None
+	) -> Optional[AudioConfiguration]:
+		selection = ask_for_audio_selection(current)
+		return selection
+
+	def _display_audio(self, current: Optional[AudioConfiguration]) -> str:
+		if not current:
+			return Audio.no_audio_text()
+		else:
+			return current.audio.name
 
 	def _create_user_account(self, defined_users: List[User]) -> List[User]:
 		users = ask_for_additional_users(defined_users=defined_users)

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -57,7 +57,7 @@ def ask_for_a_timezone(preset: Optional[str] = None) -> Optional[str]:
 
 
 def ask_for_audio_selection(
-	preset: Optional[AudioConfiguration] = None
+	current: Optional[AudioConfiguration] = None
 ) -> Optional[AudioConfiguration]:
 	choices = [
 		Audio.Pipewire.name,
@@ -65,7 +65,7 @@ def ask_for_audio_selection(
 		Audio.no_audio_text()
 	]
 
-	preset = preset.audio.value if preset else None
+	preset = current.audio.name if current else None
 
 	choice = Menu(
 		_('Choose an audio server'),
@@ -74,7 +74,7 @@ def ask_for_audio_selection(
 	).run()
 
 	match choice.type_:
-		case MenuSelectionType.Skip: return preset
+		case MenuSelectionType.Skip: return current
 		case MenuSelectionType.Selection:
 			value = choice.single_value
 			if value == Audio.no_audio_text():

--- a/archinstall/lib/models/__init__.py
+++ b/archinstall/lib/models/__init__.py
@@ -6,3 +6,4 @@ from .network_configuration import (
 from .bootloader import Bootloader
 from .gen import VersionDef, PackageSearchResult, PackageSearch, LocalPackage
 from .users import PasswordStrength, User
+from .audio_configuration import Audio, AudioConfiguration

--- a/archinstall/lib/models/audio_configuration.py
+++ b/archinstall/lib/models/audio_configuration.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, TYPE_CHECKING, Dict
+
+from ..hardware import SysInfo
+from ..output import info
+from ...default_profiles.applications.pipewire import PipewireProfile
+
+if TYPE_CHECKING:
+	_: Any
+
+
+@dataclass
+class Audio(Enum):
+	Pipewire = 'pipewire'
+	Pulseaudio = 'pulseaudio'
+
+	@staticmethod
+	def no_audio_text() -> str:
+		return str(_('No audio server'))
+
+
+@dataclass
+class AudioConfiguration:
+	audio: Audio
+
+	def __dump__(self) -> Dict[str, Any]:
+		return {
+			'audio': self.audio.value
+		}
+
+	@staticmethod
+	def parse_arg(arg: Dict[str, Any]) -> 'AudioConfiguration':
+		return AudioConfiguration(
+			Audio(arg['audio'])
+		)
+
+	def install_audio_config(
+		self,
+		installation: Any
+	):
+		info(f'Installing audio server: {self.audio.name}')
+
+		match self.audio:
+			case Audio.Pipewire:
+				PipewireProfile().install(installation)
+			case Audio.Pulseaudio:
+				installation.add_additional_packages("pulseaudio")
+
+		if SysInfo.requires_sof_fw():
+			installation.add_additional_packages('sof-firmware')
+
+		if SysInfo.requires_alsa_fw():
+			installation.add_additional_packages('alsa-firmware')

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -8,11 +8,11 @@ from archinstall import SysInfo
 from archinstall.lib import locale
 from archinstall.lib import disk
 from archinstall.lib.global_menu import GlobalMenu
-from archinstall.default_profiles.applications.pipewire import PipewireProfile
 from archinstall.lib.configuration import ConfigurationOutput
 from archinstall.lib.installer import Installer
 from archinstall.lib.menu import Menu
 from archinstall.lib.mirrors import use_mirrors, add_custom_mirrors
+from archinstall.lib.models import AudioConfiguration
 from archinstall.lib.models.bootloader import Bootloader
 from archinstall.lib.models.network_configuration import NetworkConfiguration
 from archinstall.lib.networking import check_mirror_reachable
@@ -70,7 +70,7 @@ def ask_user_questions():
 	global_menu.enable('profile_config')
 
 	# Ask about audio server selection if one is not already set
-	global_menu.enable('audio')
+	global_menu.enable('audio_config')
 
 	# Ask for preferred kernel:
 	global_menu.enable('kernels', mandatory=True)
@@ -172,18 +172,9 @@ def perform_installation(mountpoint: Path):
 		if users := archinstall.arguments.get('!users', None):
 			installation.create_users(users)
 
-		if audio := archinstall.arguments.get('audio', None):
-			info(f'Installing audio server: {audio}')
-			if audio == 'pipewire':
-				PipewireProfile().install(installation)
-			elif audio == 'pulseaudio':
-				installation.add_additional_packages("pulseaudio")
-
-			if SysInfo.requires_sof_fw():
-				installation.add_additional_packages('sof-firmware')
-
-			if SysInfo.requires_alsa_fw():
-				installation.add_additional_packages('alsa-firmware')
+		audio_config: Optional[AudioConfiguration] = archinstall.arguments.get('audio_config', None)
+		if audio_config:
+			audio_config.install_audio_config(installation)
 		else:
 			info("No audio server will be installed")
 

--- a/docs/installing/guided.rst
+++ b/docs/installing/guided.rst
@@ -53,7 +53,7 @@ There are three different configuration files, all of which are optional.
 .. code-block:: json
 
     {
-        "audio": "pipewire",
+        "audio_config": {"audio": "pipewire"},
         "bootloader": "systemd-bootctl",
         "custom-commands": [
             "cd /home/devel; git clone https://aur.archlinux.org/paru.git",

--- a/examples/config-sample.json
+++ b/examples/config-sample.json
@@ -2,7 +2,7 @@
     "config_version": "2.5.2",
     "additional-repositories": [],
     "archinstall-language": "English",
-    "audio": "pipewire",
+    "audio_config": {"audio": "pipewire"},
     "bootloader": "Systemd-boot",
     "debug": false,
     "disk_config": {
@@ -99,19 +99,13 @@
             "http://archlinux.mirror.digitalpacific.com.au/$repo/os/$arch": true,
         }
     },
-    "network_config": {
-        "nics": [
-            {
-                "dhcp": false,
-                "dns": [
-                    "3.3.3.3"
-                ],
-                "gateway": "2.2.2.2",
-                "iface": "enp0s31f6",
-                "ip": "1.1.1.1"
-            }
-        ],
-        "type": "manual"
+    "nic": {
+        "dhcp": true,
+        "dns": null,
+        "gateway": null,
+        "iface": null,
+        "ip": null,
+        "type": "nm"
     },
     "no_pkg_lookups": false,
     "ntp": true,

--- a/examples/custom-command-sample.json
+++ b/examples/custom-command-sample.json
@@ -1,6 +1,5 @@
 {
     "dry_run": true,
-    "audio": "none",
     "bootloader": "systemd-bootctl",
     "debug": false,
     "harddrives": [

--- a/schema.json
+++ b/schema.json
@@ -12,14 +12,19 @@
                 "testing"
             ]
         },
-        "audio": {
+        "audio_config": {
             "description": "Audio server to be installed",
-            "type": "string",
-            "enum": [
-                "pipewire",
-                "pulseaudio",
-                "none"
-            ]
+            "type": "object",
+            "properties": {
+                "audio": {
+                    "description": "Audio server to be installed",
+                    "type": "string",
+                    "enum": [
+                        "pipewire",
+                        "pulseaudio"
+                    ]
+                }
+            },
         },
         "bootloader": {
             "description": "Bootloader  to be installed",


### PR DESCRIPTION
This fixes #1934 

- Make audio server always selectable regardless of the profile selection by decoupling the setting completely from the profile
- Introduce a new `AudioConfiguration` wrapper that makes it easier to extend in the future and to facilitate a single installation logic 

New audio configuration setting `audio_config` 
```
"audio_config": { "audio": "pulseaudio"}
```