### PR TITLE
Mkinitcpio turn on output

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -569,7 +569,7 @@ class Installer:
 			mkinit.write(f"HOOKS=({' '.join(self._hooks)})\n")
 
 		try:
-			SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}')
+			SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}', peek_output=True)
 			return True
 		except SysCallError:
 			return False

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -572,7 +572,8 @@ class Installer:
 			SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}', peek_output=True)
 			return True
 		except SysCallError as error:
-			log(error.worker._trace_log.decode())
+			if error.worker:
+				log(error.worker._trace_log.decode())
 			return False
 
 	def minimal_installation(

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -571,7 +571,8 @@ class Installer:
 		try:
 			SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}', peek_output=True)
 			return True
-		except SysCallError:
+		except SysCallError as error:
+			log(error.worker._trace_log.decode())
 			return False
 
 	def minimal_installation(
@@ -664,7 +665,8 @@ class Installer:
 		# TODO: Use python functions for this
 		SysCommand(f'/usr/bin/arch-chroot {self.target} chmod 700 /root')
 
-		self.mkinitcpio(['-P'], locale_config)
+		if not self.mkinitcpio(['-P'], locale_config):
+			error(f"Error generating initramfs (continuing anyway)")
 
 		self.helper_flags['base'] = True
 


### PR DESCRIPTION
This turns out progress for `mkinitcpio` + prints error messages if they happen.
Because we continue on errors, it's important for the user to see them, and to be able to make wise decisions.

See example: https://github.com/archlinux/archinstall/issues/1960#issuecomment-1657246467

Where archinstall fails, but manually executing works.
Install is not broken, but needs additional steps on tight tolerances in disk allocation.