### PR TITLE
Add option to use slick-greeter with lightdm

### DIFF
--- a/archinstall/default_profiles/desktops/budgie.py
+++ b/archinstall/default_profiles/desktops/budgie.py
@@ -23,4 +23,4 @@ class BudgieProfile(XorgProfile):
 
 	@property
 	def default_greeter_type(self) -> Optional[GreeterType]:
-		return GreeterType.Lightdm
+		return GreeterType.LightdmSlick

--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -31,7 +31,8 @@ class ProfileType(Enum):
 
 
 class GreeterType(Enum):
-	Lightdm = 'lightdm'
+	Lightdm = 'lightdm-gtk-greeter'
+	LightdmSlick = 'lightdm-slick-greeter'
 	Sddm = 'sddm'
 	Gdm = 'gdm'
 

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -176,6 +176,9 @@ class ProfileHandler:
 		service = None
 
 		match greeter:
+			case GreeterType.LightdmSlick:
+				packages = ['lightdm', 'lightdm-slick-greeter']
+				service = ['lightdm']
 			case GreeterType.Lightdm:
 				packages = ['lightdm', 'lightdm-gtk-greeter']
 				service = ['lightdm']
@@ -190,6 +193,17 @@ class ProfileHandler:
 			install_session.add_additional_packages(packages)
 		if service:
 			install_session.enable_service(service)
+
+		# slick-greeter requires a config change
+		if greeter == GreeterType.LightdmSlick:
+			path = install_session.target.joinpath('etc/lightdm/lightdm.conf')
+			with open(path, 'r') as file:
+				filedata = file.read()
+
+			filedata = filedata.replace('#greeter-session=example-gtk-gnome', 'greeter-session=lightdm-slick-greeter')
+
+			with open(path, 'w') as file:
+				file.write(filedata)
 
 	def install_gfx_driver(self, install_session: 'Installer', driver: Optional[GfxDriver]):
 		try:


### PR DESCRIPTION
Resolves issue #1948.

## PR Description:

This PR changes the name of the `lightdm` greeter option to `lightdm-gtk-greeter`, and adds a `lightdm-slick-greeter` option. Additionally, the Budgie profile is switched over to use slick-greeter instead.

This is implemented in a somewhat hacky way, and I welcome implementation feedback.

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
