### PR TITLE
add the option to use ly as display manager

### DIFF
--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -34,6 +34,7 @@ class GreeterType(Enum):
 	Lightdm = 'lightdm'
 	Sddm = 'sddm'
 	Gdm = 'gdm'
+	Ly = 'ly'
 
 
 class SelectResult(Enum):

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -185,6 +185,9 @@ class ProfileHandler:
 			case GreeterType.Gdm:
 				packages = ['gdm']
 				service = ['gdm']
+			case GreeterType.Ly:
+				packages = ['ly']
+				service = ['ly']
 
 		if packages:
 			install_session.add_additional_packages(packages)


### PR DESCRIPTION
fixes https://github.com/archlinux/archinstall/issues/2000

## PR Description:

This pull request allows to select [`extra/ly`](https://archlinux.org/packages/extra/x86_64/ly/) as a display manager as requested in the linked issue.

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code! (i have tested by building my fork with `aur/archinstall-git` and running it on the 2023-08-01 live iso in a vm)<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
