### PR TITLE
Fix hyprland typo in file, classname, string

### DIFF
--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -7,9 +7,9 @@ if TYPE_CHECKING:
 	_: Any
 
 
-class HyperlandProfile(XorgProfile):
+class HyprlandProfile(XorgProfile):
 	def __init__(self):
-		super().__init__('Hyperland', ProfileType.DesktopEnv, description='')
+		super().__init__('Hyprland', ProfileType.DesktopEnv, description='')
 
 	@property
 	def packages(self) -> List[str]:


### PR DESCRIPTION
- This fix issue: #2007

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->
Rename desktop class and fix string value.

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
