### PR TITLE
Replace encryption password

### DIFF
--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import re
 from enum import Enum
 
 from pathlib import Path
@@ -305,6 +306,12 @@ def log(
 	_check_log_permissions()
 
 	text = orig_string = ' '.join([str(x) for x in msgs])
+
+	# Replace encryption password such that it 
+	# is not copied over to the target system log
+	search = r'(\"encryption_password\":\ )\"([^\"]+)\"'
+	replacement = r'\1"****************"'
+	orig_string = re.sub(search, replacement, orig_string)
 
 	# Attempt to colorize the output if supported
 	# Insert default colors and override with **kwargs

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -307,7 +307,7 @@ def log(
 
 	text = orig_string = ' '.join([str(x) for x in msgs])
 
-	# Replace encryption password such that it 
+	# Replace encryption password such that it
 	# is not copied over to the target system log
 	search = r'(\"encryption_password\":\ )\"([^\"]+)\"'
 	replacement = r'\1"****************"'


### PR DESCRIPTION
- This fixes issue: #1111 

## PR Description:
The encryption password should not be copied to the target system log. Passing it to `Journald` in plain text should be OK on the installation system.

This is achieved by replacing the password when writing the log file.

## Tests and Checks
- [ ] I have tested the code!<br>

