### PR TITLE
fix custom-commands issue #2025

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -460,10 +460,12 @@ def _pid_exists(pid: int) -> bool:
 def run_custom_user_commands(commands :List[str], installation :Installer) -> None:
 	for index, command in enumerate(commands):
 		script_path = f"/var/tmp/user-command.{index}.sh"
-		chroot_path = installation.target / script_path
+		chroot_path = f"{installation.target}/{script_path}"
 		
 		info(f'Executing custom command "{command}" ...')
-		chroot_path.write_text(command)
+		with open(chroot_path, "w") as user_script:
+			user_script.write(command)
+			
 		SysCommand(f"arch-chroot {installation.target} bash {script_path}")
 		
 		os.unlink(chroot_path)


### PR DESCRIPTION
- This fix issue: #2025 

## PR Description:

Fixes broken refacotring in `lib/general.py` function `run_custom_user_commands` that caused custom-commands to fail.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
  I did manual testing but do not see a link (yet) for downloading an ISO to test with.
