### PR TITLE
Fix name of Hyperland to Hyprland

### DIFF
--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -7,9 +7,9 @@ if TYPE_CHECKING:
 	_: Any
 
 
-class HyperlandProfile(XorgProfile):
+class HyprlandProfile(XorgProfile):
 	def __init__(self):
-		super().__init__('Hyperland', ProfileType.DesktopEnv, description='')
+		super().__init__('Hyprland', ProfileType.DesktopEnv, description='')
 
 	@property
 	def packages(self) -> List[str]:


### PR DESCRIPTION
- This fix issue: #2027 

## PR Description:
This is just a simple PR with name changes. I just fixed the typo in the profile name from **Hyperland** to **Hyprland**


- [x] I have tested the code!

  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
