### PR TITLE
Fix 1973 - pipewire

### DIFF
--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -166,9 +166,6 @@ def perform_installation(mountpoint: Path):
 				archinstall.arguments.get('profile_config', None)
 			)
 
-		if archinstall.arguments.get('packages', None) and archinstall.arguments.get('packages', None)[0] != '':
-			installation.add_additional_packages(archinstall.arguments.get('packages', None))
-
 		if users := archinstall.arguments.get('!users', None):
 			installation.create_users(users)
 
@@ -177,6 +174,9 @@ def perform_installation(mountpoint: Path):
 			audio_config.install_audio_config(installation)
 		else:
 			info("No audio server will be installed")
+
+		if archinstall.arguments.get('packages', None) and archinstall.arguments.get('packages', None)[0] != '':
+			installation.add_additional_packages(archinstall.arguments.get('packages', None))
 
 		if profile_config := archinstall.arguments.get('profile_config', None):
 			profile_handler.install_profile_config(installation, profile_config)

--- a/archinstall/scripts/swiss.py
+++ b/archinstall/scripts/swiss.py
@@ -230,9 +230,6 @@ def perform_installation(mountpoint: Path, exec_mode: ExecutionMode):
 					archinstall.arguments.get('profile_config', None)
 				)
 
-			if archinstall.arguments.get('packages', None) and archinstall.arguments.get('packages', None)[0] != '':
-				installation.add_additional_packages(archinstall.arguments.get('packages', []))
-
 			if users := archinstall.arguments.get('!users', None):
 				installation.create_users(users)
 
@@ -241,6 +238,9 @@ def perform_installation(mountpoint: Path, exec_mode: ExecutionMode):
 				audio_config.install_audio_config(installation)
 			else:
 				info("No audio server will be installed")
+
+			if archinstall.arguments.get('packages', None) and archinstall.arguments.get('packages', None)[0] != '':
+				installation.add_additional_packages(archinstall.arguments.get('packages', []))
 
 			if profile_config := archinstall.arguments.get('profile_config', None):
 				profile_handler.install_profile_config(installation, profile_config)

--- a/examples/interactive_installation.py
+++ b/examples/interactive_installation.py
@@ -144,9 +144,6 @@ def perform_installation(mountpoint: Path):
 				archinstall.arguments.get('profile_config', None)
 			)
 
-		if archinstall.arguments.get('packages', None) and archinstall.arguments.get('packages', None)[0] != '':
-			installation.add_additional_packages(archinstall.arguments.get('packages', []))
-
 		if users := archinstall.arguments.get('!users', None):
 			installation.create_users(users)
 
@@ -155,6 +152,9 @@ def perform_installation(mountpoint: Path):
 			audio_config.install_audio_config(installation)
 		else:
 			info("No audio server will be installed")
+
+		if archinstall.arguments.get('packages', None) and archinstall.arguments.get('packages', None)[0] != '':
+			installation.add_additional_packages(archinstall.arguments.get('packages', []))
 
 		if profile_config := archinstall.arguments.get('profile_config', None):
 			profile.profile_handler.install_profile_config(installation, profile_config)


### PR DESCRIPTION
This fixes: 
- Fix #1973 
- Fix #1980 
- Fix #1989 
- Fix #1990 

The problem is caused by `pipewire-jack` vs `jack2` and `pipewire-media-session` vs `wireplumber`, those packages cannot be installed alongside each other and a choice needs to be made when one of them is already installed. 
`pacstrap` will prompt for a auto resolution 
```
pipewire-jack and jack2 are in conflict (jack). Remove jack2? [y/N]
```

but the current implementation of SysCommand doesn't allow for any interactive behavior and also `pacstrap` dosn't have any flag to auto approve. 

However, by simply changing the order of installation such that pipewire (if chosen as a menu option) will be installed first and any other packages that depend on it and/or bring `jack2` into the mix can make use of the already installed packages.  
Main pointpoints seem to be `Gnome` and `firefox`. 

This isn't a perfect solution as the installation process shouldn't depend on the order of packages installed but it'll do the trick for now. A possible rewrite of `SysCommand` to allow for interactive behavior is probably a better way forward. 

