### PR TITLE
Fix 1971 - manual partitioning

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -242,7 +242,7 @@ class DeviceHandler(object):
 		info(f'luks2 locking device: {dev_path}')
 		luks_handler.lock()
 
-	def _validate(self, device_mod: DeviceModification):
+	def _validate_partitions(self, partitions: List[PartitionModification]):
 		checks = {
 			# verify that all partitions have a path set (which implies that they have been created)
 			lambda x: x.dev_path is None: ValueError('When formatting, all partitions must have a path set'),
@@ -253,7 +253,7 @@ class DeviceHandler(object):
 		}
 
 		for check, exc in checks.items():
-			found = next(filter(check, device_mod.partitions), None)
+			found = next(filter(check, partitions), None)
 			if found is not None:
 				raise exc
 
@@ -266,12 +266,16 @@ class DeviceHandler(object):
 		Format can be given an overriding path, for instance /dev/null to test
 		the formatting functionality and in essence the support for the given filesystem.
 		"""
-		self._validate(device_mod)
+
+		# don't touch existing partitions
+		filtered_part = [p for p in device_mod.partitions if not p.exists()]
+
+		self._validate_partitions(filtered_part)
 
 		# make sure all devices are unmounted
-		self._umount_all_existing(device_mod)
+		self._umount_all_existing(device_mod.device_path)
 
-		for part_mod in device_mod.partitions:
+		for part_mod in filtered_part:
 			# partition will be encrypted
 			if enc_conf is not None and part_mod in enc_conf.partitions:
 				self._perform_enc_formatting(
@@ -442,10 +446,10 @@ class DeviceHandler(object):
 
 		return luks_handler
 
-	def _umount_all_existing(self, modification: DeviceModification):
-		info(f'Unmounting all partitions: {modification.device_path}')
+	def _umount_all_existing(self, device_path: Path):
+		info(f'Unmounting all existing partitions: {device_path}')
 
-		existing_partitions = self._devices[modification.device_path].partition_infos
+		existing_partitions = self._devices[device_path].partition_infos
 
 		for partition in existing_partitions:
 			debug(f'Unmounting: {partition.path}')
@@ -472,7 +476,7 @@ class DeviceHandler(object):
 				raise DiskError('Too many partitions on disk, MBR disks can only have 3 primary partitions')
 
 		# make sure all devices are unmounted
-		self._umount_all_existing(modification)
+		self._umount_all_existing(modification.device_path)
 
 		# WARNING: the entire device will be wiped and all data lost
 		if modification.wipe:
@@ -485,13 +489,10 @@ class DeviceHandler(object):
 
 		info(f'Creating partitions: {modification.device_path}')
 
-		# TODO sort by delete first
+		# don't touch existing partitions
+		filtered_part = [p for p in modification.partitions if not p.exists()]
 
-		for part_mod in modification.partitions:
-			# don't touch existing partitions
-			if part_mod.exists():
-				continue
-
+		for part_mod in filtered_part:
 			# if the entire disk got nuked then we don't have to delete
 			# any existing partitions anymore because they're all gone already
 			requires_delete = modification.wipe is False

--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -95,6 +95,7 @@ class DiskLayoutConfiguration:
 					length=Size.parse_args(partition['length']),
 					mount_options=partition['mount_options'],
 					mountpoint=Path(partition['mountpoint']) if partition['mountpoint'] else None,
+					dev_path=Path(partition['dev_path']) if partition['dev_path'] else None,
 					type=PartitionType(partition['type']),
 					flags=[PartitionFlag[f] for f in partition.get('flags', [])],
 					btrfs_subvols=SubvolumeModification.parse_args(partition.get('btrfs', [])),
@@ -747,6 +748,7 @@ class PartitionModification:
 			'mountpoint': str(self.mountpoint) if self.mountpoint else None,
 			'mount_options': self.mount_options,
 			'flags': [f.name for f in self.flags],
+			'dev_path': str(self.dev_path) if self.dev_path else None,
 			'btrfs': [vol.__dump__() for vol in self.btrfs_subvols]
 		}
 

--- a/archinstall/lib/disk/partitioning_menu.py
+++ b/archinstall/lib/disk/partitioning_menu.py
@@ -347,7 +347,7 @@ def manual_partitioning(
 		manual_preset = preset
 
 	menu_list = PartitioningList(prompt, device, manual_preset)
-	partitions = menu_list.run()
+	partitions: List[PartitionModification] = menu_list.run()
 
 	if menu_list.is_last_choice_cancel():
 		return preset


### PR DESCRIPTION
This fixes: 
- Fix  #1971 
- Fix #2016 

This should also fix #1992 and no longer delete existing partitions if nothing changed. 

Investigation work was done by @codefiles https://github.com/archlinux/archinstall/issues/1971#issuecomment-1666673560

In addition, this also fixes another minor bug that happens when doing manual partitioning as in the main problem, saving the configuration and then loading the configuration. The reason is that saving the config will not save the `dev_path` of existing/modified partitions which is essential to create the objects. So when loading the config objects can't be crated because the `dev_path` is missing.

With this PR all existing partitions will be excluded from any validation and also any formatting actions.
