### PR TITLE
Fix Bootloader installation

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -117,6 +117,10 @@ class DeviceHandler(object):
 				return part
 		return None
 
+	def get_parent_device_path(self, dev_path: Path) -> Path:
+		lsblk = get_lsblk_info(dev_path)
+		return Path(f'/dev/{lsblk.pkname}')
+
 	def get_uuid_for_path(self, path: Path) -> Optional[str]:
 		partition = self.find_partition(path)
 		return partition.partuuid if partition else None

--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -1080,7 +1080,6 @@ def get_lsblk_info(dev_path: Union[Path, str]) -> LsblkInfo:
 def get_all_lsblk_info() -> List[LsblkInfo]:
 	return _fetch_lsblk_info()
 
-
 def get_lsblk_by_mountpoint(mountpoint: Path, as_prefix: bool = False) -> List[LsblkInfo]:
 	def _check(infos: List[LsblkInfo]) -> List[LsblkInfo]:
 		devices = []

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -972,6 +972,8 @@ When = PostTransaction
 Exec = /usr/bin/cp /usr/share/limine/BOOTX64.EFI /boot/EFI/BOOT/
 			""")
 		else:
+			parent_dev_path = disk.device_handler.get_parent_device_path(boot_partition.safe_dev_path)
+
 			try:
 				# The `limine.sys` file, contains stage 3 code.
 				cmd = f'/usr/bin/arch-chroot' \
@@ -987,7 +989,7 @@ Exec = /usr/bin/cp /usr/share/limine/BOOTX64.EFI /boot/EFI/BOOT/
 					f' {self.target}' \
 					f' limine' \
 					f' bios-install' \
-					f' {boot_partition.dev_path}'
+					f' {parent_dev_path}'
 
 				SysCommand(cmd, peek_output=True)
 			except SysCallError as err:


### PR DESCRIPTION
This fixes:
- Fix #1966 
- Fix #1982 
- Fix #1985 
- Fix #2013 
- Fix #2017 
- Fix #2019 


When installing the bootloader, the respective device was searched by the boot partition path. However, the search was only conducted on the in-memory device cache which is not updated after any partitioning and will therefore not contain the newly created partitions. 

We'll have therefore have to retrieve the parent partition path from a new lsblk call.