### PR TITLE
Fix github action

### DIFF
--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -6,7 +6,7 @@ jobs:
         container:
             image: archlinux:latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - run: pacman --noconfirm -Syu bandit
             - name: Security checkup with Bandit
               run: bandit -r archinstall || exit 0

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -6,7 +6,7 @@ jobs:
         container:
             image: archlinux:latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - run: pacman --noconfirm -Syu python python-pip
             - run: pip install --break-system-packages --upgrade pip
             - run: pip install --break-system-packages flake8

--- a/.github/workflows/iso-build.yaml
+++ b/.github/workflows/iso-build.yaml
@@ -26,7 +26,7 @@ jobs:
       image: archlinux:latest
       options: --privileged
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pwd
       - run: find .
       - run: cat /etc/os-release

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -6,7 +6,7 @@ jobs:
         container:
             image: archlinux:latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - run: pacman --noconfirm -Syu python mypy python-pip
             - run: pip install --break-system-packages --upgrade pip
             - run: pip install --break-system-packages fastapi pydantic

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,7 +7,7 @@ jobs:
             image: archlinux:latest
             options: --privileged
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - run: pacman --noconfirm -Syu python python-pip qemu gcc
             - run: python -m pip install --break-system-packages --upgrade pip
             - run: pip install --break-system-packages pytest

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -16,9 +16,11 @@ jobs:
         run: |
           pacman-key --init
           pacman --noconfirm -Sy archlinux-keyring
+          pacman --noconfirm -Syyu
           pacman --noconfirm -Sy python-pip python-pyparted python-simple-term-menu pkgconfig gcc
       - name: Install build dependencies
         run: |
+          python -m pip install --break-system-packages --upgrade pip
           pip install --break-system-packages --upgrade build twine wheel setuptools installer
           pip uninstall archinstall -y --break-system-packages
       - name: Build archinstall

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -19,7 +19,6 @@ jobs:
           pacman --noconfirm -Sy python-pip python-pyparted python-simple-term-menu pkgconfig gcc
       - name: Install build dependencies
         run: |
-          python -m pip install --break-system-packages --upgrade pip
           pip install --break-system-packages --upgrade build twine wheel setuptools installer
           pip uninstall archinstall -y --break-system-packages
       - name: Build archinstall

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -11,7 +11,7 @@ jobs:
       image: archlinux:latest
       options: --privileged
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare arch
         run: |
           pacman-key --init

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/translation-check.yaml
+++ b/.github/workflows/translation-check.yaml
@@ -12,7 +12,7 @@ jobs:
         container:
             image: archlinux:latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - run: pacman --noconfirm -Syu python
             - run: cd archinstall/locales
             - run: pwd


### PR DESCRIPTION
The deploy github action is currently broken due to 
```
 Post job cleanup.
/usr/bin/docker exec  ef93653e6a12f7f62a1b7a063100ca046efcad7a7e53578789110c77096d9df5 sh -c "cat /etc/*release | grep ^ID"
/__e/node16/bin/node: /usr/lib/libc.so.6: version `GLIBC_2.38' not found (required by /usr/lib/libstdc++.so.6)
```

this PR should fix that.

In addition, upgraded all `action/checkout` to v4. 

@Torxed we may wanna merge this in first before all the other fixes