### PR TITLE
Added a forced buffer flush on each worker stdin write

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -217,6 +217,7 @@ class SysCommandWorker:
 
 		if self.child_fd:
 			return os.write(self.child_fd, data + (b'\n' if line_ending else b''))
+			os.fsync(self.child_fd)
 
 		return 0
 


### PR DESCRIPTION
This will fix a *(I think)* unknown issue where secondary disk encryption keys are not set properly, and archinstall hangs indefinitely at: https://github.com/archlinux/archinstall/blob/06d46ac762f58d051b2dba1aea50a2e3314ab403/archinstall/lib/luks.py#L214-L221

## PR Description:

`os.fsync()` ensures that the input given to `SysCommandWorker` is flushed immediately after writing it, so that no clever buffer management holds the input for a while.