### PR TITLE
Remove git install from `build_iso.sh`

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -31,7 +31,7 @@ cat <<- _EOF_ | tee /tmp/archlive/airootfs/root/.zprofile
 	echo "Type archinstall to launch the installer."
 _EOF_
 
-pacman --noconfirm -S git archiso
+pacman --noconfirm -S archiso
 
 cp -r /usr/share/archiso/configs/releng/* /tmp/archlive
 


### PR DESCRIPTION
Installation of the git package in the environment that the script is executed in is superfluous since the script does not contain any git commands.
