### PR TITLE
Rework `_get_kernel_params()` for `_add_grub_bootloader()`

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -881,9 +881,6 @@ class Installer:
 		grub_default = self.target / 'etc/default/grub'
 		config = grub_default.read_text()
 
-		if root_partition in self._disk_encryption.partitions:
-			config = re.sub(r'#(GRUB_ENABLE_CRYPTODISK=y\n)', r'\1', config, 1)
-
 		kernel_parameters = ' '.join(self._get_kernel_params(root_partition, False, False))
 		config = re.sub(r'(GRUB_CMDLINE_LINUX=")("\n)', rf'\1{kernel_parameters}\2', config, 1)
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -713,41 +713,59 @@ class Installer:
 				return root
 		return None
 
-	def _get_kernel_params(self, root_partition: disk.PartitionModification) -> List[str]:
+	def _get_kernel_params(
+		self,
+		root_partition: disk.PartitionModification,
+		id_root: bool = True,
+		partuuid: bool = True
+	) -> List[str]:
 		kernel_parameters = []
 
 		if root_partition in self._disk_encryption.partitions:
 			# TODO: We need to detect if the encrypted device is a whole disk encryption,
 			#       or simply a partition encryption. Right now we assume it's a partition (and we always have)
-			debug('Root partition is an encrypted device, identifying by PARTUUID: {root_partition.partuuid}')
 
 			if self._disk_encryption and self._disk_encryption.hsm_device:
-				# Note: lsblk UUID must be used, not PARTUUID for sd-encrypt to work
-				kernel_parameters.append(f'rd.luks.name={root_partition.uuid}=luksdev')
+				debug(f'Root partition is an encrypted device, identifying by UUID: {root_partition.uuid}')
+				# Note: UUID must be used, not PARTUUID for sd-encrypt to work
+				kernel_parameters.append(f'rd.luks.name={root_partition.uuid}=root')
 				# Note: tpm2-device and fido2-device don't play along very well:
 				# https://github.com/archlinux/archinstall/pull/1196#issuecomment-1129715645
 				kernel_parameters.append('rd.luks.options=fido2-device=auto,password-echo=no')
+			elif partuuid:
+				debug(f'Root partition is an encrypted device, identifying by PARTUUID: {root_partition.partuuid}')
+				kernel_parameters.append(f'cryptdevice=PARTUUID={root_partition.partuuid}:root')
 			else:
-				kernel_parameters.append(f'cryptdevice=PARTUUID={root_partition.partuuid}:luksdev')
+				debug(f'Root partition is an encrypted device, identifying by UUID: {root_partition.uuid}')
+				kernel_parameters.append(f'cryptdevice=UUID={root_partition.uuid}:root')
 
-			kernel_parameters.append('root=/dev/mapper/luksdev')
-		else:
-			debug(f'Identifying root partition by PARTUUID: {root_partition.partuuid}')
-			kernel_parameters.append(f'root=PARTUUID={root_partition.partuuid}')
+			if id_root:
+				kernel_parameters.append('root=/dev/mapper/root')
+		elif id_root:
+			if partuuid:
+				debug(f'Identifying root partition by PARTUUID: {root_partition.partuuid}')
+				kernel_parameters.append(f'root=PARTUUID={root_partition.partuuid}')
+			else:
+				debug(f'Identifying root partition by UUID: {root_partition.uuid}')
+				kernel_parameters.append(f'root=UUID={root_partition.uuid}')
 
 		# Zswap should be disabled when using zram.
 		# https://github.com/archlinux/archinstall/issues/881
 		if self._zram_enabled:
 			kernel_parameters.append('zswap.enabled=0')
 
-		for sub_vol in root_partition.btrfs_subvols:
-			if sub_vol.is_root():
-				kernel_parameters.append(f'rootflags=subvol={sub_vol.name}')
-				break
+		if id_root:
+			for sub_vol in root_partition.btrfs_subvols:
+				if sub_vol.is_root():
+					kernel_parameters.append(f'rootflags=subvol={sub_vol.name}')
+					break
 
-		kernel_parameters.append('rw')
+			kernel_parameters.append('rw')
+
 		kernel_parameters.append(f'rootfstype={root_partition.safe_fs_type.fs_type_mount}')
 		kernel_parameters.extend(self._kernel_params)
+
+		debug(f'kernel parameters: {" ".join(kernel_parameters)}')
 
 		return kernel_parameters
 
@@ -863,16 +881,12 @@ class Installer:
 		grub_default = self.target / 'etc/default/grub'
 		config = grub_default.read_text()
 
-		cmdline_linux = []
-
 		if root_partition in self._disk_encryption.partitions:
-			debug(f"Using UUID {root_partition.uuid} as encrypted root identifier")
-
-			cmdline_linux.append(f'cryptdevice=UUID={root_partition.uuid}:cryptlvm')
 			config = re.sub(r'#(GRUB_ENABLE_CRYPTODISK=y\n)', r'\1', config, 1)
 
-		cmdline_linux.append(f'rootfstype={root_partition.safe_fs_type.value}')
-		config = re.sub(r'(GRUB_CMDLINE_LINUX=")("\n)', rf'\1{" ".join(cmdline_linux)}\2', config, 1)
+		kernel_parameters = ' '.join(self._get_kernel_params(root_partition, False, False))
+		config = re.sub(r'(GRUB_CMDLINE_LINUX=")("\n)', rf'\1{kernel_parameters}\2', config, 1)
+
 		grub_default.write_text(config)
 
 		info(f"GRUB boot partition: {boot_partition.dev_path}")


### PR DESCRIPTION
By default `grub-mkconfig` will determine the `root=` parameter (this appears to also detect and add the parameter for a default BTRFS subvolume when in use). The _id_root_ bool has been added to `_get_kernel_params()` to account for this and in the case that it is set to false, kernel parameters that are irrelevant in this condition will be omitted. Kernel parameters required for encryption (not including the `root=` parameter if _id_root_ is false) will be included in either case. The default is true, to add kernel parameters that identify the root. This could also be useful if support is added for systemd [GPT partition automounting](https://wiki.archlinux.org/title/Systemd#GPT_partition_automounting) where "if the root partition is automounted, then `root=` can be omitted from the kernel command line."

If the _partuuid_ bool is set to false `_get_kernel_params()` will use a UUID instead of a GPT partition UUID, which is the default.

The `_add_grub_bootloader()` function will now make use of kernel parameters for HSM and zram when necessary. The `_kernel_params` variable will also now be included.

Changed `cryptdevice=` parameter to end in _root_ following the colon instead of the previous _luksdev_ and _cryptlvm_, same with `root=/dev/mapper/` and those endings. This change is to conform with the ArchWiki guidance on [configuring the boot loader](https://wiki.archlinux.org/title/Dm-crypt/Encrypting_an_entire_system#Configuring_the_boot_loader) for _LUKS on a partition_.

Removed uncommenting of the line _#GRUB_ENABLE_CRYPTODISK=y_ in `/etc/default/grub` since archinstall does not support [encrypted /boot](https://wiki.archlinux.org/title/GRUB#Encrypted_/boot) as seen discussed here #1271.
