### PR TITLE
Added kitty, dolphin, wofi to hyprland

### DIFF
--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -26,6 +26,9 @@ class HyprlandProfile(XorgProfile):
 		return [
 			"hyprland",
 			"dunst",
+			"kitty",
+			"dolphin",
+			"wofi",
 			"xdg-desktop-portal-hyprland",
 			"qt5-wayland",
 			"qt6-wayland"


### PR DESCRIPTION
After our conversations in #1824, this will add three apps for hyprland:
* kitty
* dolphin
* wofi

As these are the pre-configured default apps:
![img](https://user-images.githubusercontent.com/43317083/269924240-d7d4e99e-f581-4247-ac1c-1fca5dcf448f.png)