### PR TITLE
Unify json functions

### DIFF
--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -49,10 +49,10 @@ class DiskLayoutConfiguration:
 		if self.config_type == DiskLayoutType.Pre_mount and self.relative_mountpoint is None:
 			raise ValueError('Must set a relative mountpoint when layout type is pre-mount"')
 
-	def __dump__(self) -> Dict[str, Any]:
+	def json(self) -> Dict[str, Any]:
 		return {
 			'config_type': self.config_type.value,
-			'device_modifications': [mod.__dump__() for mod in self.device_modifications]
+			'device_modifications': [mod.json() for mod in self.device_modifications]
 		}
 
 	@classmethod
@@ -171,12 +171,12 @@ class Size:
 			raise ValueError('Percent unit size must specify a total size')
 		return self.total_size  # type: ignore
 
-	def __dump__(self) -> Dict[str, Any]:
+	def json(self) -> Dict[str, Any]:
 		return {
 			'value': self.value,
 			'unit': self.unit.name,
-			'sector_size': self.sector_size.__dump__() if self.sector_size else None,
-			'total_size': self._total_size.__dump__() if self._total_size else None
+			'sector_size': self.sector_size.json() if self.sector_size else None,
+			'total_size': self._total_size.json() if self._total_size else None
 		}
 
 	@classmethod
@@ -457,7 +457,7 @@ class SubvolumeModification:
 			return self.mountpoint == Path('/')
 		return False
 
-	def __dump__(self) -> Dict[str, Any]:
+	def json(self) -> Dict[str, Any]:
 		return {
 			'name': str(self.name),
 			'mountpoint': str(self.mountpoint),
@@ -466,12 +466,7 @@ class SubvolumeModification:
 		}
 
 	def table_data(self) -> Dict[str, Any]:
-		return {
-			'name': str(self.name),
-			'mountpoint': str(self.mountpoint),
-			'compress': self.compress,
-			'nodatacow': self.nodatacow
-		}
+		return self.json()
 
 
 class DeviceGeometry:
@@ -755,14 +750,14 @@ class PartitionModification:
 			'obj_id': self.obj_id,
 			'status': self.status.value,
 			'type': self.type.value,
-			'start': self.start.__dump__(),
-			'length': self.length.__dump__(),
+			'start': self.start.json(),
+			'length': self.length.json(),
 			'fs_type': self.fs_type.value if self.fs_type else '',
 			'mountpoint': str(self.mountpoint) if self.mountpoint else None,
 			'mount_options': self.mount_options,
 			'flags': [f.name for f in self.flags],
 			'dev_path': str(self.dev_path) if self.dev_path else None,
-			'btrfs': [vol.__dump__() for vol in self.btrfs_subvols]
+			'btrfs': [vol.json() for vol in self.btrfs_subvols]
 		}
 
 	def table_data(self) -> Dict[str, Any]:
@@ -830,7 +825,7 @@ class DeviceModification:
 		filtered = filter(lambda x: x.is_root(relative_path), self.partitions)
 		return next(filtered, None)
 
-	def __dump__(self) -> Dict[str, Any]:
+	def json(self) -> Dict[str, Any]:
 		"""
 		Called when generating configuration files
 		"""
@@ -920,6 +915,13 @@ class Fido2Device:
 			'path': str(self.path),
 			'manufacturer': self.manufacturer,
 			'product': self.product
+		}
+
+	def table_data(self) -> Dict[str, str]:
+		return {
+			'Path': str(self.path),
+			'Manufacturer': self.manufacturer,
+			'Product': self.product
 		}
 
 	@classmethod

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -69,8 +69,6 @@ def jsonify(obj: Any, safe: bool = True) -> Any:
 		# a dictionary representation of the object so that it can be
 		# processed by the json library.
 		return jsonify(obj.json(), safe)
-	if hasattr(obj, '__dump__'):
-		return obj.__dump__()
 	if isinstance(obj, (datetime, date)):
 		return obj.isoformat()
 	if isinstance(obj, (list, set, tuple)):
@@ -462,13 +460,13 @@ def run_custom_user_commands(commands :List[str], installation :Installer) -> No
 	for index, command in enumerate(commands):
 		script_path = f"/var/tmp/user-command.{index}.sh"
 		chroot_path = f"{installation.target}/{script_path}"
-		
+
 		info(f'Executing custom command "{command}" ...')
 		with open(chroot_path, "w") as user_script:
 			user_script.write(command)
-			
+
 		SysCommand(f"arch-chroot {installation.target} bash {script_path}")
-		
+
 		os.unlink(chroot_path)
 
 

--- a/archinstall/lib/models/audio_configuration.py
+++ b/archinstall/lib/models/audio_configuration.py
@@ -24,7 +24,7 @@ class Audio(Enum):
 class AudioConfiguration:
 	audio: Audio
 
-	def __dump__(self) -> Dict[str, Any]:
+	def json(self) -> Dict[str, Any]:
 		return {
 			'audio': self.audio.value
 		}

--- a/archinstall/lib/models/bootloader.py
+++ b/archinstall/lib/models/bootloader.py
@@ -14,12 +14,12 @@ class Bootloader(Enum):
 	Efistub = 'Efistub'
 	Limine = 'Limine'
 
-	def json(self):
+	def json(self) -> str:
 		return self.value
 
-	@classmethod
-	def values(cls) -> List[str]:
-		return [e.value for e in cls]
+	@staticmethod
+	def values() -> List[str]:
+		return [e.value for e in Bootloader]
 
 	@classmethod
 	def get_default(cls) -> Bootloader:

--- a/archinstall/lib/models/network_configuration.py
+++ b/archinstall/lib/models/network_configuration.py
@@ -42,7 +42,7 @@ class Nic:
 			'dns': self.dns
 		}
 
-	def __dump__(self) -> Dict[str, Any]:
+	def json(self) -> Dict[str, Any]:
 		return {
 			'iface': self.iface,
 			'ip': self.ip,
@@ -94,10 +94,10 @@ class NetworkConfiguration:
 	type: NicType
 	nics: List[Nic] = field(default_factory=list)
 
-	def __dump__(self) -> Dict[str, Any]:
+	def json(self) -> Dict[str, Any]:
 		config: Dict[str, Any] = {'type': self.type.value}
 		if self.nics:
-			config['nics'] = [n.__dump__() for n in self.nics]
+			config['nics'] = [n.json() for n in self.nics]
 
 		return config
 

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -38,8 +38,6 @@ class FormattedOutput:
 			raise ValueError('Unsupported formatting call')
 		elif hasattr(o, 'table_data'):
 			return o.table_data()
-		elif hasattr(o, 'json'):
-			return o.json()
 		elif is_dataclass(o):
 			return asdict(o)
 		else:


### PR DESCRIPTION
Housekeeping PR to make the definitions for configurations less complex
- Remove `__dump__` function support
- Move all configuration relevant exports to `json()`
- Remove `json()` function support from the table formatter