### PR TITLE
fix: fstrim no longer needs to be manually enabled

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -440,11 +440,6 @@ class Installer:
 		info('Enabling espeakup.service for speech synthesis (accessibility)')
 		self.enable_service('espeakup')
 
-	def enable_periodic_trim(self) -> None:
-		info("Enabling periodic TRIM")
-		# fstrim is owned by util-linux, a dependency of both base and systemd.
-		self.enable_service("fstrim.timer")
-
 	def enable_service(self, services: Union[str, List[str]]) -> None:
 		if isinstance(services, str):
 			services = [services]
@@ -645,13 +640,6 @@ class Installer:
 		self.helper_flags['base-strapped'] = True
 
 		pacman_conf.persist()
-
-		# Periodic TRIM may improve the performance and longevity of SSDs whilst
-		# having no adverse effect on other devices. Most distributions enable
-		# periodic TRIM by default.
-		#
-		# https://github.com/archlinux/archinstall/issues/880
-		self.enable_periodic_trim()
 
 		# TODO: Support locale and timezone
 		# os.remove(f'{self.target}/etc/localtime')


### PR DESCRIPTION
- This fix issue: #1837 

## PR Description:

This PR removes the code to manually enable the fstrim service since SSD optimizations are enabled by default in the kernel since version 6.2. Refer to the kernel source [here](https://elixir.bootlin.com/linux/v6.4/source/fs/btrfs/disk-io.c#L3688) which enables `discard=async`

This PR also marks #897 obsolete.

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
