### PR TITLE
Fix ArchInstall ISO build

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -6,7 +6,9 @@ packages_file="/tmp/archlive/packages.x86_64"
 
 # Packages to add to the archiso profile packages
 packages=(
+	gcc
 	git
+	pkgconfig
 	python
 	python-pip
 	python-build
@@ -24,7 +26,7 @@ cat <<- _EOF_ | tee /tmp/archlive/airootfs/root/.zprofile
 	rm -rf dist
 
 	python -m build --wheel --no-isolation
-	pip install dist/archinstall*.whl
+	pip install dist/archinstall*.whl --break-system-packages
 
 	echo "This is an unofficial ISO for development and testing of archinstall. No support will be provided."
 	echo "This ISO was built from Git SHA $GITHUB_SHA"


### PR DESCRIPTION
- This is an attempt to fix the issue of the Arch development ISOs not properly installing archinstall

## PR Description:

Add dependencies and a flag to make pip install the archinstall wheel despite Python being externally managed. This is fine because it's a live environment and these are development ISOs.

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
