### PR TITLE
Fixes for prev PR

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 	_: Any
 
 
-__version__ = "2.6.4"
+__version__ = "2.6.3"
 storage['__version__'] = __version__
 
 # add the custom _ as a builtin, it can now be used anywhere in the

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 	_: Any
 
 
-__version__ = "2.6.3"
+__version__ = "2.6.4"
 storage['__version__'] = __version__
 
 # add the custom _ as a builtin, it can now be used anywhere in the
@@ -89,6 +89,8 @@ def define_arguments():
 	parser.add_argument("--no-pkg-lookups", action="store_true", default=False,
 						help="Disabled package validation specifically prior to starting installation.")
 	parser.add_argument("--plugin", nargs="?", type=str)
+	parser.add_argument("--skip-version-check", action="store_true",
+						help="Skip the version check when running archinstall")
 
 
 def parse_unspecified_argument_list(unknowns: list, multiple: bool = False, err: bool = False) -> dict:
@@ -280,8 +282,20 @@ def plugin(f, *args, **kwargs):
 
 def _check_new_version():
 	info("Checking version...")
-	Pacman.run("-Sy")
-	upgrade = Pacman.run("-Qu archinstall").decode()
+
+	try:
+		Pacman.run("-Sy")
+	except Exception as e:
+		debug(f'Failed to perform version check: {e}')
+		info(f'Arch Linux mirrors are not reachable. Please check your internet connection')
+		exit(1)
+
+	upgrade = None
+
+	try:
+		upgrade = Pacman.run("-Qu archinstall").decode()
+	except Exception as e:
+		debug(f'Failed determine pacman version: {e}')
 
 	if upgrade:
 		text = f'New version available: {upgrade}'
@@ -295,7 +309,8 @@ def main():
 	OR straight as a module: python -m archinstall
 	In any case we will be attempting to load the provided script to be run from the scripts/ folder
 	"""
-	_check_new_version()
+	if not arguments.get('skip_version_check', False):
+		_check_new_version()
 
 	script = arguments.get('script', None)
 

--- a/archinstall/lib/exceptions.py
+++ b/archinstall/lib/exceptions.py
@@ -4,19 +4,19 @@ if TYPE_CHECKING:
 	from .general import SysCommandWorker
 
 
-class RequirementError(BaseException):
+class RequirementError(Exception):
 	pass
 
 
-class DiskError(BaseException):
+class DiskError(Exception):
 	pass
 
 
-class UnknownFilesystemFormat(BaseException):
+class UnknownFilesystemFormat(Exception):
 	pass
 
 
-class SysCallError(BaseException):
+class SysCallError(Exception):
 	def __init__(self, message :str, exit_code :Optional[int] = None, worker :Optional['SysCommandWorker'] = None) -> None:
 		super(SysCallError, self).__init__(message)
 		self.message = message
@@ -24,17 +24,17 @@ class SysCallError(BaseException):
 		self.worker = worker
 
 
-class HardwareIncompatibilityError(BaseException):
+class HardwareIncompatibilityError(Exception):
 	pass
 
 
-class ServiceException(BaseException):
+class ServiceException(Exception):
 	pass
 
 
-class PackageError(BaseException):
+class PackageError(Exception):
 	pass
 
 
-class Deprecated(BaseException):
+class Deprecated(Exception):
 	pass

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 from urllib.request import urlopen
 
 from .exceptions import SysCallError
-from .output import error, info, debug
+from .output import error, info
 from .pacman import Pacman
 
 
@@ -30,19 +30,6 @@ def list_interfaces(skip_loopback :bool = True) -> Dict[str, str]:
 		interfaces[mac] = iface
 
 	return interfaces
-
-
-def check_mirror_reachable() -> bool:
-	info("Testing connectivity to the Arch Linux mirrors...")
-	try:
-		Pacman.run("-Sy")
-		return True
-	except SysCallError as err:
-		if os.geteuid() != 0:
-			error("check_mirror_reachable() uses 'pacman -Sy' which requires root.")
-		debug(f'exit_code: {err.exit_code}, Error: {err.message}')
-
-	return False
 
 
 def update_keyring() -> bool:

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Any, TYPE_CHECKING, Optional
 
@@ -15,7 +14,6 @@ from archinstall.lib.mirrors import use_mirrors, add_custom_mirrors
 from archinstall.lib.models import AudioConfiguration
 from archinstall.lib.models.bootloader import Bootloader
 from archinstall.lib.models.network_configuration import NetworkConfiguration
-from archinstall.lib.networking import check_mirror_reachable
 from archinstall.lib.profile.profiles_handler import profile_handler
 
 if TYPE_CHECKING:
@@ -224,11 +222,6 @@ def perform_installation(mountpoint: Path):
 
 	debug(f"Disk states after installing: {disk.disk_layouts()}")
 
-
-if archinstall.arguments.get('skip-mirror-check', False) is False and check_mirror_reachable() is False:
-	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
-	info(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'.")
-	exit(1)
 
 if not archinstall.arguments.get('silent'):
 	ask_user_questions()

--- a/archinstall/scripts/only_hd.py
+++ b/archinstall/scripts/only_hd.py
@@ -1,16 +1,10 @@
-import os
 from pathlib import Path
 
 import archinstall
-from archinstall import info, debug
+from archinstall import debug
 from archinstall.lib.installer import Installer
 from archinstall.lib.configuration import ConfigurationOutput
 from archinstall.lib import disk
-from archinstall.lib.networking import check_mirror_reachable
-
-if archinstall.arguments.get('help'):
-	print("See `man archinstall` for help.")
-	exit(0)
 
 
 def ask_user_questions():
@@ -57,11 +51,6 @@ def perform_installation(mountpoint: Path):
 	# For support reasons, we'll log the disk layout post installation (crash or no crash)
 	debug(f"Disk states after installing: {disk.disk_layouts()}")
 
-
-if archinstall.arguments.get('skip-mirror-check', False) is False and check_mirror_reachable() is False:
-	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
-	info(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'")
-	exit(1)
 
 if not archinstall.arguments.get('silent'):
 	ask_user_questions()

--- a/archinstall/scripts/swiss.py
+++ b/archinstall/scripts/swiss.py
@@ -1,4 +1,3 @@
-import os
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
@@ -10,7 +9,6 @@ from archinstall.lib import models
 from archinstall.lib import disk
 from archinstall.lib import locale
 from archinstall.lib.models import AudioConfiguration
-from archinstall.lib.networking import check_mirror_reachable
 from archinstall.lib.profile.profiles_handler import profile_handler
 from archinstall.lib import menu
 from archinstall.lib.global_menu import GlobalMenu
@@ -19,11 +17,6 @@ from archinstall.lib.configuration import ConfigurationOutput
 
 if TYPE_CHECKING:
 	_: Any
-
-
-if archinstall.arguments.get('help'):
-	print("See `man archinstall` for help.")
-	exit(0)
 
 
 class ExecutionMode(Enum):
@@ -289,11 +282,6 @@ def perform_installation(mountpoint: Path, exec_mode: ExecutionMode):
 
 		debug(f"Disk states after installing: {disk.disk_layouts()}")
 
-
-if not check_mirror_reachable():
-	log_file = os.path.join(archinstall.storage.get('LOG_PATH', None), archinstall.storage.get('LOG_FILE', None))
-	info(f"Arch Linux mirrors are not reachable. Please check your internet connection and the log file '{log_file}'")
-	exit(1)
 
 param_mode = archinstall.arguments.get('mode', ExecutionMode.Full.value).lower()
 


### PR DESCRIPTION
@codefiles @Torxed fixes for the previous PR

- Fix https://github.com/archlinux/archinstall/issues/2170: Refactor the code a bit to only perform `pacman -Sy` once which made the check mirror function obsolete and introduce an official new archinstall parameter `--skip-version-check` 
- Fix https://github.com/archlinux/archinstall/issues/2171: Fail open in case we're dealing with a `pip` installed version of archinstall; the major relevance for the version check is for folks running it in a old ISO
- Fix https://github.com/archlinux/archinstall/issues/2172: Changed the inherritence of the custom Exceptions