### PR TITLE
Added enum 'All open-source (default)' for compatibility with older config versions

### DIFF
--- a/archinstall/lib/profile/profile_model.py
+++ b/archinstall/lib/profile/profile_model.py
@@ -32,6 +32,9 @@ class ProfileConfiguration:
 		greeter = arg.get('greeter', None)
 		gfx_driver = arg.get('gfx_driver', None)
 
+		if gfx_driver == 'All open-source (default)':
+			gfx_driver = 'All open-source'
+
 		return ProfileConfiguration(
 			profile,
 			GfxDriver(gfx_driver) if gfx_driver else None,


### PR DESCRIPTION
Old configuration versions of archinstall when choosing graphics drivers look for `All open-source (default)` value. Current enum value has `All open-source` value.

Fix should make older versions of archinstall configurations compatible with new version of enum.