### PR TITLE
New format requires build.os instead of build.image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,21 +2,14 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: html
   configuration: docs/conf.py
+  fail_on_warning: true
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
-# Optionally build your docs in additional formats such as PDF
-formats:
-  - pdf
-
-# Optionally set the version of Python and requirements required to build your docs
-python:
-  version: 3.8
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"


### PR DESCRIPTION
Readthedocs have moved from `build.image` to `build.os` (https://blog.readthedocs.com/use-build-os-config/). This should conform with this change.