### PR TITLE
Fix readthedocs runner

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,14 @@
 
 version: 2
 
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
 sphinx_rtd_theme
+libparted
+simple-term-menu


### PR DESCRIPTION
The `requirements.txt` was missing dependencies. This is a compliment to #2230 