### PR TITLE
Testing github pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,27 @@
+name: documentation
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Install dependencies
+        run: |
+          pip install sphinx sphinx_rtd_theme pyparted simple-term-menu
+      - name: Sphinx build
+        run: |
+          sphinx-build docs _build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: try-github-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+      - name: Install pre-dependencies
+        run: |
+          apt update && apt install libparted-dev
       - name: Install dependencies
         run: |
           pip install sphinx sphinx_rtd_theme pyparted simple-term-menu

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,9 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+      - name: debug
+        run: |
+          whoami
       - name: Install pre-dependencies
         run: |
-          apt update && apt install libparted-dev
+          sudo apt update && sudo apt install libparted-dev
       - name: Install dependencies
         run: |
           pip install sphinx sphinx_rtd_theme pyparted simple-term-menu

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -27,7 +27,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
-          publish_branch: try-github-pages
+          publish_branch: master
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/
           force_orphan: true


### PR DESCRIPTION
readthedocs is a bit of a pain to get working with our dependencies.
Not to mention the recommended way of pushing dependencies with `requirements.txt` instead of `pyproject.toml`.