### PR TITLE
Added nvidia-dkms when installing propri driver to 

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -42,6 +42,7 @@ class GfxPackage(Enum):
 	LibvaMesaDriver = 'libva-mesa-driver'
 	Mesa = "mesa"
 	Nvidia = 'nvidia'
+	NvidiaDKMS = 'nvidia-dkms'
 	NvidiaOpen = 'nvidia-open'
 	VulkanIntel = 'vulkan-intel'
 	VulkanRadeon = 'vulkan-radeon'
@@ -108,7 +109,10 @@ class GfxDriver(Enum):
 					GfxPackage.LibvaMesaDriver
 				]
 			case GfxDriver.NvidiaProprietary:
-				return [GfxPackage.Nvidia]
+				return [
+					GfxPackage.Nvidia,
+					NvidiaDKMS
+				]
 			case GfxDriver.VMOpenSource:
 				return [
 					GfxPackage.Mesa,

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -111,7 +111,7 @@ class GfxDriver(Enum):
 			case GfxDriver.NvidiaProprietary:
 				return [
 					GfxPackage.Nvidia,
-					NvidiaDKMS
+					GfxPackage.NvidiaDKMS
 				]
 			case GfxDriver.VMOpenSource:
 				return [


### PR DESCRIPTION
This should fix #2233, #2214 and #2002

## PR Description:

The issue is not totally clear, but `nvidia-dkms` appears to be missing on some hardwares.
The solution would be to correctly identify when this is needed and only install it then.
But we don't have enough information to do that logic right now, and adding it appears to not harm users who don't need it. It can be safely cleaned up afterwards for now.