### PR TITLE
Restore docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,14 +4,6 @@
 
 version: 2
 
-python:
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-sphinx_rtd_theme
-pyparted
-simple-term-menu


### PR DESCRIPTION
After #2242, #2243, #2244 and #2245 - we can now restore the docs.
All previous documentation pages now successfully redirect to the new documentation quarters.