### PR TITLE
Restore docs & Removed requirements from .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,14 +4,6 @@
 
 version: 2
 
-python:
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-
 sphinx:
   builder: html
   configuration: docs/conf.py


### PR DESCRIPTION
can we remove this file without readthedocs being sad?
This reverts #2242, #2243, #2244 and #2245.