### PR TITLE
pyproject.toml: add missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "simple-term-menu==1.6.3",
+    "pyparted==3.13.0",
 ]
 
 [project.urls]
@@ -27,6 +28,7 @@ Documentation = "https://archinstall.readthedocs.io/"
 Source = "https://github.com/archlinux/archinstall"
 
 [project.optional-dependencies]
+log = ["systemd_python==235"]
 dev = [
     "mypy==1.7.0",
     "pre-commit==3.5.0",


### PR DESCRIPTION

- This fix issue: we were missing 2 dependencies, pyparted and systemd-python(optional), that would lead pip installations to fail sometimes. 

## PR Description:
I added the missing dependencies and attributed systemd_python to a new optional dependency group called `log` since it only seems to be used for system logging:

https://github.com/archlinux/archinstall/blob/64c91cdbcba4b1dc5270c4cf4314943e5b151641/archinstall/lib/output.py#L133

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
