### PR TITLE
Enable systemd-oomd - Update installer.py

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -458,6 +458,10 @@ class Installer:
 		# fstrim is owned by util-linux, a dependency of both base and systemd.
 		self.enable_service("fstrim.timer")
 
+	def enable_systemd_oomd(self) -> None:
+		info('Enabling systemd-oomd.service to handle OOM events')
+		self.enable_service('systemd-oomd')
+
 	def enable_service(self, services: Union[str, List[str]]) -> None:
 		if isinstance(services, str):
 			services = [services]

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -198,6 +198,10 @@ def perform_installation(mountpoint: Path):
 		if (root_pw := archinstall.arguments.get('!root-password', None)) and len(root_pw):
 			installation.user_set_pw('root', root_pw)
 
+		installation.enable_system_oomd()
+		#Enables systemd-oomd
+			
+
 		# This step must be after profile installs to allow profiles_bck to install language pre-requisites.
 		# After which, this step will set the language both for console and x11 if x11 was installed for instance.
 		installation.set_keyboard_language(locale_config.kb_layout)


### PR DESCRIPTION
Enables systemd-oomd during the install process. As is, archinstall does not enable an OOM killer by default. This is a significant oversight which has undoubtedly resulted in many system freezes and lost work. However, systemd-oomd has been criticized for being too aggressive, which could also result in lost work. Personally, I think it's better than nothing. Also, I have tested the code, and it appears that systemd-oomd is enabled and running after booting into arch.