### PR TITLE
Docs build rules

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,6 +1,15 @@
 name: documentation
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths:
+      - "docs/**"
+
+  pull_request:
+    paths:
+      - "docs/**"
+
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description:

Causes github to build docs only when there are changes in the "docs" folder.

