### PR TITLE
downgrade pyparted due to "unrelease"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "simple-term-menu==1.6.3",
-    "pyparted==3.13.0",
+    "pyparted>=3.12.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
somehow and for some reason, pyparted 3.13 is no longer available in pypi only in its git repository. To deal with this I downgraded the version requirement and updated to >= instead of the == exact version match

- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
