### PR TITLE
Fix "Unable to determine new partition UUID" for NVMe devices

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -399,6 +399,8 @@ class DeviceHandler(object):
 			if lsblk_info.partn and lsblk_info.partuuid and lsblk_info.uuid:
 				break
 
+			self.partprobe()
+
 		if not lsblk_info:
 			debug(f'Unable to get partition information: {path}')
 			raise DiskError(f'Unable to get partition information: {path}')


### PR DESCRIPTION
Fixes #2286

## PR Description:

This patch reintroduces part of a previous [patch](https://github.com/archlinux/archinstall/pull/1770) for this issue; calling partprobe appears to refresh the block device info seen by lsblk sufficiently for the installer to get the partition UUIDs of NVMe storage devices after creating new partitions.

## Tests and Checks

Tested as described [here](https://github.com/archlinux/archinstall/issues/2286#issuecomment-1841394425).

See also:
https://github.com/archlinux/archinstall/issues/1759
https://github.com/archlinux/archinstall/issues/1759#issuecomment-1839950427
https://github.com/archlinux/archinstall/issues/2211
https://github.com/archlinux/archinstall/pull/2212