### PR TITLE
Add `/etc/hosts` config to `set_hostname()`

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -389,6 +389,16 @@ class Installer:
 	def set_hostname(self, hostname: str, *args: str, **kwargs: str) -> None:
 		with open(f'{self.target}/etc/hostname', 'w') as fh:
 			fh.write(hostname + '\n')
+		hosts_entries = [
+				'# Created by: archinstall',
+				f'# Created on: {self.init_time}',
+				'See hosts(5) for details.',
+				'127.0.0.1	localhost.localdomain	localhost',
+				'::1		localhost.localdomain	localhost',
+				f'127.0.1.1	{hostname}.localdomain	{hostname}'
+			]
+		with open(f'{self.target}/etc/hosts', 'w') as fh:
+			fh.write('\n'.join(hosts_entries) + '\n')
 
 	def set_locale(self, locale_config: LocaleConfiguration) -> bool:
 		modifier = ''


### PR DESCRIPTION
- This fix issue:  #2331

## PR Description:

This PR adds a basic configuration of the `/etc/hosts` file to the `set_hostname()` function.
The file will look like this after installation (with hostname "archlinux"):
```
# Created by: archinstall
# Created on: 2024-01-13_18-12-28
See hosts(5) for details.
127.0.0.1       localhost.localdomain   localhost
::1             localhost.localdomain   localhost
127.0.1.1       archlinux.localdomain   archlinux
```

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
