### PR TITLE
Fix 2307 - Custom mirrors

### DIFF
--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -77,28 +77,25 @@ class MirrorConfiguration:
 			'custom_mirrors': [c.json() for c in self.custom_mirrors]
 		}
 
-	def _server_config(self, name: str, url: str) -> str:
-		return f'\n\n## {name}\nServer = {url}'
-
-	def mirror_list_config(self) -> str:
+	def mirrorlist_config(self) -> str:
 		config = ''
 
 		for region, mirrors in self.mirror_regions.items():
 			for mirror in mirrors:
-				config += self._server_config(region, mirror)
+				config += f'\n\n## {region}\nServer = {mirror}\n'
 
 		for cm in self.custom_mirrors:
-			config += self._server_config(cm.name, cm.url)
+			config += f'\n\n## {cm.name}\nServer = {cm.url}\n'
 
 		return config
 
-	def custom_mirrors_to_config(self) -> str:
+	def pacman_config(self) -> str:
 		config = ''
 
 		for mirror in self.custom_mirrors:
 			config += f'\n\n[{mirror.name}]\n'
 			config += f'SigLevel = {mirror.sign_check.value} {mirror.sign_option.value}\n'
-			config += f'Server = {mirror.url}'
+			config += f'Server = {mirror.url}\n'
 
 		return config
 

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -132,7 +132,7 @@ def perform_installation(mountpoint: Path):
 				installation.generate_key_files()
 
 		if mirror_config := archinstall.arguments.get('mirror_config', None):
-			installation.set_local_mirrors(mirror_config)
+			installation.set_mirrors(mirror_config, on_target=False)
 
 		installation.minimal_installation(
 			testing=enable_testing,
@@ -143,7 +143,7 @@ def perform_installation(mountpoint: Path):
 		)
 
 		if mirror_config := archinstall.arguments.get('mirror_config', None):
-			installation.set_target_mirrors(mirror_config)
+			installation.set_mirrors(mirror_config, on_target=True)
 
 		if archinstall.arguments.get('swap'):
 			installation.setup_swap('zram')

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -10,7 +10,6 @@ from archinstall.lib.global_menu import GlobalMenu
 from archinstall.lib.configuration import ConfigurationOutput
 from archinstall.lib.installer import Installer
 from archinstall.lib.menu import Menu
-from archinstall.lib.mirrors import use_mirrors, add_custom_mirrors
 from archinstall.lib.models import AudioConfiguration
 from archinstall.lib.models.bootloader import Bootloader
 from archinstall.lib.models.network_configuration import NetworkConfiguration
@@ -132,12 +131,8 @@ def perform_installation(mountpoint: Path):
 				# generate encryption key files for the mounted luks devices
 				installation.generate_key_files()
 
-		# Set mirrors used by pacstrap (outside of installation)
 		if mirror_config := archinstall.arguments.get('mirror_config', None):
-			if mirror_config.mirror_regions:
-				use_mirrors(mirror_config.mirror_regions)
-			if mirror_config.custom_mirrors:
-				add_custom_mirrors(mirror_config.custom_mirrors)
+			installation.set_local_mirrors(mirror_config)
 
 		installation.minimal_installation(
 			testing=enable_testing,
@@ -148,7 +143,7 @@ def perform_installation(mountpoint: Path):
 		)
 
 		if mirror_config := archinstall.arguments.get('mirror_config', None):
-			installation.set_mirrors(mirror_config)  # Set the mirrors in the installation medium
+			installation.set_target_mirrors(mirror_config)
 
 		if archinstall.arguments.get('swap'):
 			installation.setup_swap('zram')

--- a/archinstall/scripts/swiss.py
+++ b/archinstall/scripts/swiss.py
@@ -188,7 +188,7 @@ def perform_installation(mountpoint: Path, exec_mode: ExecutionMode):
 					installation.generate_key_files()
 
 			if mirror_config := archinstall.arguments.get('mirror_config', None):
-				installation.set_local_mirrors(mirror_config)
+				installation.set_mirrors(mirror_config)
 
 			installation.minimal_installation(
 				testing=enable_testing,
@@ -198,7 +198,7 @@ def perform_installation(mountpoint: Path, exec_mode: ExecutionMode):
 			)
 
 			if mirror_config := archinstall.arguments.get('mirror_config', None):
-				installation.set_target_mirrors(mirror_config)
+				installation.set_mirrors(mirror_config, on_target=True)
 
 			if archinstall.arguments.get('swap'):
 				installation.setup_swap('zram')

--- a/archinstall/scripts/swiss.py
+++ b/archinstall/scripts/swiss.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import archinstall
 from archinstall import SysInfo, info, debug
-from archinstall.lib import mirrors
 from archinstall.lib import models
 from archinstall.lib import disk
 from archinstall.lib import locale
@@ -188,12 +187,8 @@ def perform_installation(mountpoint: Path, exec_mode: ExecutionMode):
 					# generate encryption key files for the mounted luks devices
 					installation.generate_key_files()
 
-			# Set mirrors used by pacstrap (outside of installation)
 			if mirror_config := archinstall.arguments.get('mirror_config', None):
-				if mirror_config.mirror_regions:
-					mirrors.use_mirrors(mirror_config.mirror_regions)
-				if mirror_config.custom_mirrors:
-					mirrors.add_custom_mirrors(mirror_config.custom_mirrors)
+				installation.set_local_mirrors(mirror_config)
 
 			installation.minimal_installation(
 				testing=enable_testing,
@@ -203,7 +198,7 @@ def perform_installation(mountpoint: Path, exec_mode: ExecutionMode):
 			)
 
 			if mirror_config := archinstall.arguments.get('mirror_config', None):
-				installation.set_mirrors(mirror_config)  # Set the mirrors in the installation medium
+				installation.set_target_mirrors(mirror_config)
 
 			if archinstall.arguments.get('swap'):
 				installation.setup_swap('zram')

--- a/examples/interactive_installation.py
+++ b/examples/interactive_installation.py
@@ -5,7 +5,6 @@ import archinstall
 from archinstall import Installer
 from archinstall import profile
 from archinstall import SysInfo
-from archinstall import mirrors
 from archinstall import disk
 from archinstall import menu
 from archinstall import models
@@ -109,12 +108,8 @@ def perform_installation(mountpoint: Path):
 				# generate encryption key files for the mounted luks devices
 				installation.generate_key_files()
 
-		# Set mirrors used by pacstrap (outside of installation)
 		if mirror_config := archinstall.arguments.get('mirror_config', None):
-			if mirror_config.mirror_regions:
-				mirrors.use_mirrors(mirror_config.mirror_regions)
-			if mirror_config.custom_mirrors:
-				mirrors.add_custom_mirrors(mirror_config.custom_mirrors)
+			installation.set_local_mirrors(mirror_config)
 
 		installation.minimal_installation(
 			testing=enable_testing,
@@ -124,7 +119,7 @@ def perform_installation(mountpoint: Path):
 		)
 
 		if mirror_config := archinstall.arguments.get('mirror_config', None):
-			installation.set_mirrors(mirror_config)  # Set the mirrors in the installation medium
+			installation.set_target_mirrors(mirror_config)
 
 		if archinstall.arguments.get('swap'):
 			installation.setup_swap('zram')

--- a/examples/interactive_installation.py
+++ b/examples/interactive_installation.py
@@ -109,7 +109,7 @@ def perform_installation(mountpoint: Path):
 				installation.generate_key_files()
 
 		if mirror_config := archinstall.arguments.get('mirror_config', None):
-			installation.set_local_mirrors(mirror_config)
+			installation.set_mirrors(mirror_config)
 
 		installation.minimal_installation(
 			testing=enable_testing,
@@ -119,7 +119,7 @@ def perform_installation(mountpoint: Path):
 		)
 
 		if mirror_config := archinstall.arguments.get('mirror_config', None):
-			installation.set_target_mirrors(mirror_config)
+			installation.set_mirrors(mirror_config, on_target=True)
 
 		if archinstall.arguments.get('swap'):
 			installation.setup_swap('zram')


### PR DESCRIPTION
This should fix #2307 

The custom mirror was only written to the `pacman.conf` on the target, with this change the server will also be added to the `/etc/pacman.d/mirrorlist`
