### PR TITLE
Fix 2215 | Display installed packages for all profile submenus

### DIFF
--- a/archinstall/default_profiles/desktops/bspwm.py
+++ b/archinstall/default_profiles/desktops/bspwm.py
@@ -25,28 +25,3 @@ class BspwmProfile(XorgProfile):
 	@property
 	def default_greeter_type(self) -> Optional[GreeterType]:
 		return GreeterType.Lightdm
-
-	def preview_text(self) -> Optional[str]:
-		text = str(_('Environment type: {}')).format(self.profile_type.value)
-		return text + '\n' + self.packages_text()
-
-		# The wiki specified xinit, but we already use greeter?
-		# https://wiki.archlinux.org/title/Bspwm#Starting
-		#
-		# # TODO: check if we selected a greeter, else run this:
-		# with open(f"{install_session.target}/etc/X11/xinit/xinitrc", 'r') as xinitrc:
-		# 	xinitrc_data = xinitrc.read()
-
-		# for line in xinitrc_data.split('\n'):
-		# 	if "twm &" in line:
-		# 		xinitrc_data = xinitrc_data.replace(line, f"# {line}")
-		# 	if "xclock" in line:
-		# 		xinitrc_data = xinitrc_data.replace(line, f"# {line}")
-		# 	if "xterm" in line:
-		# 		xinitrc_data = xinitrc_data.replace(line, f"# {line}")
-
-		# xinitrc_data += '\n'
-		# xinitrc_data += 'exec bspwn\n'
-
-		# with open(f"{install_session.target}/etc/X11/xinit/xinitrc", 'w') as xinitrc:
-		# 	xinitrc.write(xinitrc_data)

--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -178,15 +178,28 @@ class Profile:
 
 	def preview_text(self) -> Optional[str]:
 		"""
-		Used for preview text in profiles_bck. If a description is set for a
-		profile it will automatically display that one in the preview.
-		If no preview or a different text should be displayed just
+		Override this method to provide a preview text for the profile
 		"""
-		if self.description:
-			return self.description
-		return None
+		return self.packages_text()
 
-	def packages_text(self) -> str:
+	def packages_text(self, include_sub_packages: bool = False) -> Optional[str]:
 		header = str(_('Installed packages'))
-		output = format_cols(self.packages, header)
-		return output
+
+		text = ''
+		packages = []
+
+		if self.packages:
+			packages = self.packages
+
+		if include_sub_packages:
+			for p in self.current_selection:
+				if p.packages:
+					packages += p.packages
+
+		text += format_cols(sorted(set(packages)))
+
+		if text:
+			text = f'{header}: \n{text}'
+			return text
+
+		return None

--- a/archinstall/default_profiles/xorg.py
+++ b/archinstall/default_profiles/xorg.py
@@ -22,7 +22,10 @@ class XorgProfile(Profile):
 
 	def preview_text(self) -> Optional[str]:
 		text = str(_('Environment type: {}')).format(self.profile_type.value)
-		return text + '\n' + self.packages_text()
+		if packages := self.packages_text():
+			text += f'\n{packages}'
+
+		return text
 
 	@property
 	def packages(self) -> List[str]:

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -2,12 +2,16 @@ import os
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, TYPE_CHECKING, Any
 
 from .exceptions import SysCallError
 from .general import SysCommand
 from .networking import list_interfaces, enrich_iface_types
 from .output import debug
+from .utils.util import format_cols
+
+if TYPE_CHECKING:
+	_: Any
 
 
 class CpuVendor(Enum):
@@ -72,6 +76,12 @@ class GfxDriver(Enum):
 				return True
 			case _:
 				return False
+
+	def packages_text(self) -> str:
+		text = str(_('Installed packages')) + ':\n'
+		pkg_names = [p.value for p in self.gfx_packages()]
+		text += format_cols(sorted(pkg_names))
+		return text
 
 	def gfx_packages(self) -> List[GfxPackage]:
 		packages = [GfxPackage.XorgServer, GfxPackage.XorgXinit]

--- a/archinstall/lib/interactions/system_conf.py
+++ b/archinstall/lib/interactions/system_conf.py
@@ -103,14 +103,15 @@ def select_driver(options: List[GfxDriver] = [], current_value: Optional[GfxDriv
 		if SysInfo.has_nvidia_graphics():
 			title += str(_('For the best compatibility with your Nvidia hardware, you may want to use the Nvidia proprietary driver.\n'))
 
-		title += str(_('\nSelect a graphics driver or leave blank to install all open-source drivers'))
-
 		preset = current_value.value if current_value else None
+
 		choice = Menu(
 			title,
 			drivers,
 			preset_values=preset,
-			default_option=GfxDriver.AllOpenSource.value
+			default_option=GfxDriver.AllOpenSource.value,
+			preview_command=lambda x: GfxDriver(x).packages_text(),
+			preview_size=0.3
 		).run()
 
 		if choice.type_ != MenuSelectionType.Selection:

--- a/archinstall/lib/menu/menu.py
+++ b/archinstall/lib/menu/menu.py
@@ -235,7 +235,9 @@ class Menu(TerminalMenu):
 		if preview_command:
 			if self._default_option is not None and self._default_menu_value == selection:
 				selection = self._default_option
-			return preview_command(selection)
+
+			if res := preview_command(selection):
+				return res.rstrip('\n')
 
 		return None
 

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -120,8 +120,7 @@ class ProfileMenu(AbstractSubMenu):
 		text = ''
 
 		if profile:
-			sub_profiles = profile.current_selection
-			if sub_profiles is not None:
+			if (sub_profiles := profile.current_selection) is not None:
 				text += str(_('Selected profiles: '))
 				text += ', '.join([p.name for p in sub_profiles]) + '\n'
 

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -40,6 +40,7 @@ class ProfileMenu(AbstractSubMenu):
 			lambda preset: self._select_gfx_driver(preset),
 			display_func=lambda x: x.value if x else None,
 			dependencies=['profile'],
+			preview_func=self._preview_gfx,
 			default=self._preset.gfx_driver if self._preset.profile and self._preset.profile.is_graphic_driver_supported() else None,
 			enabled=self._preset.profile.is_graphic_driver_supported() if self._preset.profile else False
 		)
@@ -67,6 +68,7 @@ class ProfileMenu(AbstractSubMenu):
 
 	def _select_profile(self, preset: Optional[Profile]) -> Optional[Profile]:
 		profile = select_profile(preset)
+
 		if profile is not None:
 			if not profile.is_graphic_driver_supported():
 				self._menu_options['gfx_driver'].set_enabled(False)
@@ -105,12 +107,29 @@ class ProfileMenu(AbstractSubMenu):
 
 		return driver
 
+	def _preview_gfx(self) -> Optional[str]:
+		driver: Optional[GfxDriver] = self._menu_options['gfx_driver'].current_selection
+
+		if driver:
+			return driver.packages_text()
+
+		return None
+
 	def _preview_profile(self) -> Optional[str]:
 		profile: Optional[Profile] = self._menu_options['profile'].current_selection
+		text = ''
 
 		if profile:
-			names = profile.current_selection_names()
-			return '\n'.join(names)
+			sub_profiles = profile.current_selection
+			if sub_profiles is not None:
+				text += str(_('Selected profiles: '))
+				text += ', '.join([p.name for p in sub_profiles]) + '\n'
+
+			if packages := profile.packages_text(include_sub_packages=True):
+				text += f'{packages}'
+
+			if text:
+				return text
 
 		return None
 

--- a/archinstall/lib/utils/util.py
+++ b/archinstall/lib/utils/util.py
@@ -31,18 +31,18 @@ def is_subpath(first: Path, second: Path):
 		return False
 
 
-def format_cols(items: List[str], header: Optional[str]) -> str:
+def format_cols(items: List[str], header: Optional[str] = None) -> str:
 	if header:
 		text = f'{header}:\n'
 	else:
 		text = ''
 
 	nr_items = len(items)
-	if nr_items <= 5:
+	if nr_items <= 4:
 		col = 1
-	elif nr_items <= 10:
+	elif nr_items <= 8:
 		col = 2
-	elif nr_items <= 15:
+	elif nr_items <= 12:
 		col = 3
 	else:
 		col = 4


### PR DESCRIPTION
This fixes #2215 

The packages to be installed are now displayed for 
* All profiles (Desktop, Server etc.)
* All sub-profile selections
* Gfx drivers

![image](https://github.com/archlinux/archinstall/assets/19396770/fdf5f6d4-3719-487d-a662-c11558816732)
![image](https://github.com/archlinux/archinstall/assets/19396770/8b2eb4e7-5673-419e-abc5-4ab932781d33)
