### PR TITLE
plasma-workspace replaces plasma-wayland-session

### DIFF
--- a/archinstall/default_profiles/desktops/kde.py
+++ b/archinstall/default_profiles/desktops/kde.py
@@ -19,7 +19,7 @@ class KdeProfile(XorgProfile):
 			"kwrite",
 			"dolphin",
 			"ark",
-			"plasma-wayland-session",
+			"plasma-workspace",
 			"egl-wayland"
 		]
 


### PR DESCRIPTION
- This fixes KDE not installing correctly

## PR Description:

plasma-workspace replaces plasma-wayland-session.

https://archlinux.org/packages/extra/x86_64/plasma-workspace/

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
