### PR TITLE
Fix Btrfs mount options

### DIFF
--- a/archinstall/lib/disk/subvolume_menu.py
+++ b/archinstall/lib/disk/subvolume_menu.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any, TYPE_CHECKING
 
 from .device_model import SubvolumeModification
-from ..menu import Menu, TextInput, MenuSelectionType, ListManager
+from ..menu import TextInput, ListManager
 from ..output import FormattedOutput
 
 if TYPE_CHECKING:
@@ -36,23 +36,6 @@ class SubvolumeMenu(ListManager):
 	def selected_action_display(self, subvolume: SubvolumeModification) -> str:
 		return str(subvolume.name)
 
-	def _prompt_options(self, editing: Optional[SubvolumeModification] = None) -> List[str]:
-		preset_options = []
-		if editing:
-			preset_options = editing.mount_options
-
-		choice = Menu(
-			str(_("Select the desired subvolume options ")),
-			['nodatacow', 'compress'],
-			skip=True,
-			preset_values=preset_options,
-		).run()
-
-		if choice.type_ == MenuSelectionType.Selection:
-			return choice.value  # type: ignore
-
-		return []
-
 	def _add_subvolume(self, editing: Optional[SubvolumeModification] = None) -> Optional[SubvolumeModification]:
 		name = TextInput(f'\n\n{_("Subvolume name")}: ', editing.name if editing else '').run()
 
@@ -64,13 +47,7 @@ class SubvolumeMenu(ListManager):
 		if not mountpoint:
 			return None
 
-		options = self._prompt_options(editing)
-
-		subvolume = SubvolumeModification(Path(name), Path(mountpoint))
-		subvolume.compress = 'compress' in options
-		subvolume.nodatacow = 'nodatacow' in options
-
-		return subvolume
+		return SubvolumeModification(Path(name), Path(mountpoint))
 
 	def handle_action(
 		self,

--- a/docs/cli_parameters/config/disk_config.rst
+++ b/docs/cli_parameters/config/disk_config.rst
@@ -186,34 +186,24 @@ This example contains both subvolumes and compression.
    {
       "btrfs": [
           {
-              "compress": false,
               "mountpoint": "/",
               "name": "@",
-              "nodatacow": false
           },
           {
-              "compress": false,
               "mountpoint": "/home",
               "name": "@home",
-              "nodatacow": false
           },
           {
-              "compress": false,
               "mountpoint": "/var/log",
               "name": "@log",
-              "nodatacow": false
           },
           {
-              "compress": false,
               "mountpoint": "/var/cache/pacman/pkg",
               "name": "@pkg",
-              "nodatacow": false
           },
           {
-              "compress": false,
               "mountpoint": "/.snapshots",
               "name": "@.snapshots",
-              "nodatacow": false
           }
       ],
       "dev_path": null,


### PR DESCRIPTION
Fixes #1571

In [btrfs(5)](https://man.archlinux.org/man/core/btrfs-progs/btrfs.5.en) under _MOUNT OPTIONS_ there is this note:

> Most mount options apply to the whole filesystem and only options in the first mounted subvolume will take effect. This is due to lack of implementation and may change in the future. This means that (for example) you can't set per-subvolume nodatacow, nodatasum, or compress using mount options. This should eventually be fixed, but it has proved to be difficult to implement correctly within the Linux VFS framework.

This pull request removes the ability to apply the compress and nodatacow mount options for individual subvolumes for this reason.

Selecting and toggling the nodatacow mount option for the file system has been added. Both the selection and toggle restrict compress and nodatacow from both being present since they conflict.
