### PR TITLE
Rename "Kde" profile to the correct "KDE Plasma" / "Plasma"

### DIFF
--- a/archinstall/default_profiles/desktop.py
+++ b/archinstall/default_profiles/desktop.py
@@ -15,7 +15,7 @@ class DesktopProfile(Profile):
 		super().__init__(
 			'Desktop',
 			ProfileType.Desktop,
-			description=str(_('Provides a selection of desktop environments and tiling window managers, e.g. gnome, kde, sway')),
+			description=str(_('Provides a selection of desktop environments and tiling window managers, e.g. GNOME, Plasma, Sway')),
 			current_selection=current_selection,
 			support_greeter=True
 		)

--- a/archinstall/default_profiles/desktop.py
+++ b/archinstall/default_profiles/desktop.py
@@ -15,7 +15,7 @@ class DesktopProfile(Profile):
 		super().__init__(
 			'Desktop',
 			ProfileType.Desktop,
-			description=str(_('Provides a selection of desktop environments and tiling window managers, e.g. GNOME, Plasma, Sway')),
+			description=str(('Provides a selection of desktop environments and tiling window managers, e.g. GNOME, KDE Plasma, Sway')),
 			current_selection=current_selection,
 			support_greeter=True
 		)

--- a/archinstall/default_profiles/desktop.py
+++ b/archinstall/default_profiles/desktop.py
@@ -15,7 +15,7 @@ class DesktopProfile(Profile):
 		super().__init__(
 			'Desktop',
 			ProfileType.Desktop,
-			description=str(('Provides a selection of desktop environments and tiling window managers, e.g. GNOME, KDE Plasma, Sway')),
+			description=str(_('Provides a selection of desktop environments and tiling window managers, e.g. GNOME, KDE Plasma, Sway')),
 			current_selection=current_selection,
 			support_greeter=True
 		)

--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -6,10 +6,30 @@ from archinstall.default_profiles.xorg import XorgProfile
 if TYPE_CHECKING:
 	_: Any
 
-
 class PlasmaProfile(XorgProfile):
 	def __init__(self):
-		super().__init__('Plasma', ProfileType.DesktopEnv, description='')
+		super().__init__('KDE Plasma', ProfileType.DesktopEnv, description='')
+
+	@property
+	def packages(self) -> List[str]:
+		return [
+			"plasma-meta",
+			"konsole",
+			"kwrite",
+			"dolphin",
+			"ark",
+			"plasma-workspace",
+			"egl-wayland"
+		]
+
+	@property
+	def default_greeter_type(self) -> Optional[GreeterType]:
+		return GreeterType.Sddm
+
+# 2024-04-16 TODO deprecated Class with old naming, remove in a future version
+class KdeProfile(XorgProfile):
+	def __init__(self):
+		super().__init__('Kde', ProfileType.DesktopEnv, description='[Deprecated] Alias to KDE Plasma')
 
 	@property
 	def packages(self) -> List[str]:

--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -25,24 +25,3 @@ class PlasmaProfile(XorgProfile):
 	@property
 	def default_greeter_type(self) -> Optional[GreeterType]:
 		return GreeterType.Sddm
-
-# 2024-04-16 TODO deprecated Class with old naming, remove in a future version
-class KdeProfile(XorgProfile):
-	def __init__(self):
-		super().__init__('Kde', ProfileType.DesktopEnv, description='[Deprecated] Alias to KDE Plasma')
-
-	@property
-	def packages(self) -> List[str]:
-		return [
-			"plasma-meta",
-			"konsole",
-			"kwrite",
-			"dolphin",
-			"ark",
-			"plasma-workspace",
-			"egl-wayland"
-		]
-
-	@property
-	def default_greeter_type(self) -> Optional[GreeterType]:
-		return GreeterType.Sddm

--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -7,9 +7,9 @@ if TYPE_CHECKING:
 	_: Any
 
 
-class KdeProfile(XorgProfile):
+class PlasmaProfile(XorgProfile):
 	def __init__(self):
-		super().__init__('Kde', ProfileType.DesktopEnv, description='')
+		super().__init__('Plasma', ProfileType.DesktopEnv, description='')
 
 	@property
 	def packages(self) -> List[str]:

--- a/archinstall/lib/models/network_configuration.py
+++ b/archinstall/lib/models/network_configuration.py
@@ -20,7 +20,7 @@ class NicType(Enum):
 			case NicType.ISO:
 				return str(_('Copy ISO network configuration to installation'))
 			case NicType.NM:
-				return str(_('Use NetworkManager (necessary to configure internet graphically in GNOME and Plasma)'))
+				return str(_('Use NetworkManager (necessary to configure internet graphically in GNOME and KDE Plasma)'))
 			case NicType.MANUAL:
 				return str(_('Manual configuration'))
 

--- a/archinstall/lib/models/network_configuration.py
+++ b/archinstall/lib/models/network_configuration.py
@@ -20,7 +20,7 @@ class NicType(Enum):
 			case NicType.ISO:
 				return str(_('Copy ISO network configuration to installation'))
 			case NicType.NM:
-				return str(_('Use NetworkManager (necessary to configure internet graphically in GNOME and KDE)'))
+				return str(_('Use NetworkManager (necessary to configure internet graphically in GNOME and Plasma)'))
 			case NicType.MANUAL:
 				return str(_('Manual configuration'))
 

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -107,6 +107,11 @@ class ProfileHandler:
 
 		if details:
 			for detail in filter(None, details):
+				# [2024-04-19] TODO: Backwards compatibility after naming change: https://github.com/archlinux/archinstall/pull/2421
+				#                    'Kde' is deprecated, remove this block in a future version
+				if detail == 'Kde':
+					detail = 'KDE Plasma'
+
 				if sub_profile := self.get_profile_by_name(detail):
 					valid_sub_profiles.append(sub_profile)
 				else:

--- a/examples/config-sample.json
+++ b/examples/config-sample.json
@@ -106,7 +106,7 @@
         "greeter": "sddm",
         "profile": {
             "details": [
-                "Plasma"
+                "KDE Plasma"
             ],
             "main": "Desktop"
         }

--- a/examples/config-sample.json
+++ b/examples/config-sample.json
@@ -106,7 +106,7 @@
         "greeter": "sddm",
         "profile": {
             "details": [
-                "Kde"
+                "Plasma"
             ],
             "main": "Desktop"
         }

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -66,10 +66,10 @@ exclude = (?x)(
     | ^archinstall/profiles/enlightenment\.py$
     | ^archinstall/profiles/gnome\.py$
     | ^archinstall/profiles/i3\.py$
-    | ^archinstall/profiles/kde\.py$
     | ^archinstall/profiles/lxqt\.py$
     | ^archinstall/profiles/mate\.py$
     | ^archinstall/profiles/minimal\.py$
+    | ^archinstall/profiles/plasma\.py$
     | ^archinstall/profiles/qtile\.py$
     | ^archinstall/profiles/server\.py$
     | ^archinstall/profiles/sway\.py$
@@ -86,10 +86,10 @@ exclude = (?x)(
     | ^profiles/enlightenment\.py$
     | ^profiles/gnome\.py$
     | ^profiles/i3\.py$
-    | ^profiles/kde\.py$
     | ^profiles/lxqt\.py$
     | ^profiles/mate\.py$
     | ^profiles/minimal\.py$
+    | ^profiles/plasma\.py$
     | ^profiles/qtile\.py$
     | ^profiles/server\.py$
     | ^profiles/sway\.py$

--- a/schema.json
+++ b/schema.json
@@ -129,7 +129,7 @@
                 ]
             },
             "details": {
-                "description": "Specific profile to be installed based on the 'main' selection; these profiles are present in profiles_v2/, use the name of a profile to install it (case insensitive)",
+                "description": "Specific profile to be installed based on the 'main' selection; these profiles are present in default_profiles/, use the file name of a profile without the extension to install it (case insensitive)",
                 "type": "string",
                 "enum": [
                     "awesome",
@@ -142,7 +142,7 @@
                     "enlightenment",
                     "gnome",
                     "i3-wm",
-                    "kde",
+                    "plasma",
                     "lxqt",
                     "mate",
                     "sway",

--- a/schema.json
+++ b/schema.json
@@ -142,7 +142,6 @@
                     "enlightenment",
                     "gnome",
                     "i3-wm",
-                    "i3-gasp",
                     "kde",
                     "lxqt",
                     "mate",


### PR DESCRIPTION

## PR Description:

Just like shorthand for `Microsoft Office` is `Office`, shorthand for `KDE Plasma` is `Plasma`.

Rename files and code as such, capitalize existing code.

This also removes a dead misspelled profile from schema.json and fixes up the profile description there.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
