### PR TITLE
add xwaylandvideobridge to plasma install

### DIFF
--- a/archinstall/default_profiles/desktops/kde.py
+++ b/archinstall/default_profiles/desktops/kde.py
@@ -20,7 +20,8 @@ class KdeProfile(XorgProfile):
 			"dolphin",
 			"ark",
 			"plasma-workspace",
-			"egl-wayland"
+			"egl-wayland",
+			"xwaylandvideobridge"
 		]
 
 	@property


### PR DESCRIPTION
Allows discord screen recording of specific apps in default KDE Plasma Wayland session

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [yes] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
