### PR TITLE
Adds dosfstools to the PKGBUILD depends

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,6 +15,7 @@ depends=(
   'btrfs-progs'
   'coreutils'
   'cryptsetup'
+  'dosfstools'
   'e2fsprogs'
   'glibc'
   'kbd'


### PR DESCRIPTION
One of the tools needed by archinstall is mkfs.fatXX and this wasn't automatically installed.

- I don't know if this issue is present on the github. I'll open one if required; the contributing guideline did not impose a requirement for an existing issue.

## PR Description:
This adds dosfstools, which provides the mkfs.fat binary which is used in device_handler.py

## Tests and Checks
When I run `makepkg -s` on my system with or without this change, I receive an error that my build did not pass the "validity check". I don't know if this has bearing on the integrity of this change, so I left the following checklist for what I believe would be a good test of this change.

- [ ] Using archinstall as installed using `pacman -S archinstall` and try to format any partition using a code path that relies on mkfs.fat, archinstall will error because this tool is not installed.
- [ ] When I ran `makepkg -si`, dosfstools was installed on my system along with archinstall.
