### PR TITLE
Add applications to Hyprland desktop profile

### DIFF
--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -31,7 +31,10 @@ class HyprlandProfile(XorgProfile):
 			"wofi",
 			"xdg-desktop-portal-hyprland",
 			"qt5-wayland",
-			"qt6-wayland"
+			"qt6-wayland",
+			"polkit-kde-agent",
+			"grim",
+			"slurp"
 		]
 
 	@property


### PR DESCRIPTION
- This fix issue: Adds essential applications.
 
## PR Description:
- polkit-kde-agent, grim and slurp are essential applications required for Hyprland. 
- These are also listed in `archinstall/archinstall/default_profiles/desktops/sway.py`.
- Wiki references: [Authentication agent](https://wiki.hyprland.org/Useful-Utilities/Must-have/#authentication-agent) and [Screenshot tools](https://wiki.hyprland.org/FAQ/#how-do-i-screenshot)


## Tests and Checks
- [x] I have tested the code!<br>
