### PR TITLE
Fix 2479 - remove unnecessary partiton info field

### DIFF
--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -669,10 +669,6 @@ class PartitionModification:
 	flags: List[PartitionFlag] = field(default_factory=list)
 	btrfs_subvols: List[SubvolumeModification] = field(default_factory=list)
 
-	# only set when modification was created from an existing
-	# partition info object to be able to reference it back
-	part_info: Optional[_PartitionInfo] = None
-
 	# only set if the device was created or exists
 	dev_path: Optional[Path] = None
 	partn: Optional[int] = None
@@ -743,8 +739,7 @@ class PartitionModification:
 			uuid=partition_info.uuid,
 			flags=partition_info.flags,
 			mountpoint=mountpoint,
-			btrfs_subvols=subvol_mods,
-			part_info=partition_info
+			btrfs_subvols=subvol_mods
 		)
 
 	@property


### PR DESCRIPTION
This fixes #2479 

The `PartitionModification` class contained a `part_info` field that is not compatible for `deepcopy` and therefore the error. It seems that this field isn't actually used anywhere and therefore should be save to be removed