### PR TITLE
Using VCS as `pyparted` version lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "simple-term-menu==1.6.4",
-    "pyparted==3.13.0",
+    "pyparted @ https://github.com//dcantrell/pyparted/archive/v3.13.0.tar.gz#sha512=26819e28d73420937874f52fda03eb50ab1b136574ea9867a69d46ae4976d38c4f26a2697fa70597eed90dd78a5ea209bafcc3227a17a7a5d63cff6d107c2b11",
 ]
 
 [project.urls]


### PR DESCRIPTION
Changing to use github archive as dependency-url for pyparted as there hasn't been an update on pypi.org for pyparted in almost 12 months.

Tracking issue: https://github.com/dcantrell/pyparted/issues/106

Instead of downloading, I think it's a safe bet that we should stop hoping for upstream to listen. Or at least I need to get this out of my ever growing backlog - as it occupies mental realestate like crazy.

So.. In PEP 508 spirit - [despite it being against red hats own bloody guidelines](https://github.com/ansible/molecule/discussions/4067) *where `@dcantrell` seemingly work* - let's use the github archive as a version lock.. at least for `pip` users. Because downgrading really isn't an option. We'll keep using `VCS` or pypi wherever possible, but for pip this is the only decent workaround.

renovate-bot appears to honor PEP508 - but I haven't tested it if truth be told.

This superseeds:
 * https://github.com/archlinux/archinstall/pull/2282