### PR TITLE
Use the current layout instead of the us layout

### DIFF
--- a/archinstall/lib/locale/locale_menu.py
+++ b/archinstall/lib/locale/locale_menu.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, Any, TYPE_CHECKING, Optional
 
-from .utils import list_keyboard_languages, list_locales, set_kb_layout
+from .utils import list_keyboard_languages, list_locales, set_kb_layout, get_kb_layout
 from ..menu import Selector, AbstractSubMenu, MenuSelectionType, Menu
 
 if TYPE_CHECKING:
@@ -16,7 +16,10 @@ class LocaleConfiguration:
 
 	@staticmethod
 	def default() -> 'LocaleConfiguration':
-		return LocaleConfiguration('us', 'en_US', 'UTF-8')
+		layout = get_kb_layout()
+		if layout == "":
+			return LocaleConfiguration('us', 'en_US', 'UTF-8')
+		return LocaleConfiguration(layout, 'en_US', 'UTF-8')
 
 	def json(self) -> Dict[str, str]:
 		return {

--- a/archinstall/lib/locale/utils.py
+++ b/archinstall/lib/locale/utils.py
@@ -44,6 +44,27 @@ def verify_x11_keyboard_layout(layout :str) -> bool:
 	return False
 
 
+def get_kb_layout() -> str:
+	lines = SysCommand(
+		"localectl --no-pager status",
+		environment_vars={'SYSTEMD_COLORS': '0'}
+	).decode().splitlines()
+
+	vcline = ""
+	for l in lines:
+		if "VC Keymap: " in l:
+			vcline = l
+	
+	if vcline == "":
+		return ""
+
+	layout = vcline.split(": ")[1]
+	if not verify_keyboard_layout(layout):
+		return ""
+
+	return layout
+
+
 def set_kb_layout(locale :str) -> bool:
 	if len(locale.strip()):
 		if not verify_keyboard_layout(locale):

--- a/archinstall/lib/locale/utils.py
+++ b/archinstall/lib/locale/utils.py
@@ -45,15 +45,18 @@ def verify_x11_keyboard_layout(layout :str) -> bool:
 
 
 def get_kb_layout() -> str:
-	lines = SysCommand(
-		"localectl --no-pager status",
-		environment_vars={'SYSTEMD_COLORS': '0'}
-	).decode().splitlines()
+	try:
+		lines = SysCommand(
+			"localectl --no-pager status",
+			environment_vars={'SYSTEMD_COLORS': '0'}
+		).decode().splitlines()
+	except:
+		return ""
 
 	vcline = ""
-	for l in lines:
-		if "VC Keymap: " in l:
-			vcline = l
+	for line in lines:
+		if "VC Keymap: " in line:
+			vcline = line
 	
 	if vcline == "":
 		return ""


### PR DESCRIPTION
- This fix issue: none

## PR Description:

By default, the installer selects the "us" layout. With this simple enhancement, it selects the current layout (acquired by parsing `localectl status` output) instead of "us".

So if the user runs `loadkeys` or `localectl set-keymap` before running `archinstall`, they won't have to set their keymap again.

## Tests and Checks
- [x] I have tested the code! (on my local machine, there is no link to the ISO)<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
