### PR TITLE
Fix 2496 - umounting all partitions

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -645,9 +645,6 @@ class DeviceHandler(object):
 			if partition_table.MBR and len(modification.partitions) > 3:
 				raise DiskError('Too many partitions on disk, MBR disks can only have 3 primary partitions')
 
-		# make sure all devices are unmounted
-		self.umount_all_existing(modification.device_path)
-
 		# WARNING: the entire device will be wiped and all data lost
 		if modification.wipe:
 			self.wipe_dev(modification.device)

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -58,6 +58,10 @@ class FilesystemHandler:
 		if SysInfo.has_uefi() is False:
 			partition_table = PartitionTable.MBR
 
+		# make sure all devices are unmounted
+		for mod in device_mods:
+			device_handler.umount_all_existing(mod.device_path)
+
 		for mod in device_mods:
 			device_handler.partition(mod, partition_table=partition_table)
 
@@ -96,9 +100,6 @@ class FilesystemHandler:
 		create_or_modify_parts = [p for p in partitions if p.is_create_or_modify()]
 
 		self._validate_partitions(create_or_modify_parts)
-
-		# make sure all devices are unmounted
-		device_handler.umount_all_existing(device_path)
 
 		for part_mod in create_or_modify_parts:
 			# partition will be encrypted
@@ -311,9 +312,6 @@ class FilesystemHandler:
 			filtered_part = [p for p in partitions if not p.exists()]
 
 			self._validate_partitions(filtered_part)
-
-			# make sure all devices are unmounted
-			device_handler.umount_all_existing(mod.device_path)
 
 			enc_mods = {}
 

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -244,4 +244,4 @@ fs_handler = disk.FilesystemHandler(
 
 fs_handler.perform_filesystem_operations()
 
-# perform_installation(archinstall.storage.get('MOUNT_POINT', Path('/mnt')))
+perform_installation(archinstall.storage.get('MOUNT_POINT', Path('/mnt')))

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -244,4 +244,4 @@ fs_handler = disk.FilesystemHandler(
 
 fs_handler.perform_filesystem_operations()
 
-perform_installation(archinstall.storage.get('MOUNT_POINT', Path('/mnt')))
+# perform_installation(archinstall.storage.get('MOUNT_POINT', Path('/mnt')))


### PR DESCRIPTION
This fixes #2496

I was able to reproduce the problem on the latest master and with this change it seems to be fixed. 

The problem is that during the partitioning/formatting the `umount_all_existing` is called multiple times, even after existing partitions have been deleted already which results in trying to umount these deleted partitions as a old reference object is used. 
There shouldn't be any need to call the umount each time a partitioning or formatting is performed but only once for each disk involved. 