### PR TITLE
Convert partition path string to a Path object

### DIFF
--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -407,7 +407,7 @@ class _PartitionInfo:
 			name=partition.get_name(),
 			type=partition_type,
 			fs_type=fs_type,
-			path=partition.path,
+			path=Path(partition.path),
 			start=start,
 			length=length,
 			flags=flags,


### PR DESCRIPTION
The type hint is for a Path object but paths from pyparted are strings.

https://github.com/archlinux/archinstall/blob/15ee84b7c9fcfa0893e5efdffd3d69ef2e3bc7b4/archinstall/lib/disk/device_model.py#L344
