### PR TITLE
Update mkinitcpio.conf hooks for upstream consistency

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -83,8 +83,8 @@ class Installer:
 		# systemd, sd-vconsole and sd-encrypt will be replaced by udev, keymap and encrypt
 		# if HSM is not used to encrypt the root volume. Check mkinitcpio() function for that override.
 		self._hooks: List[str] = [
-			"base", "systemd", "autodetect", "microcode", "keyboard",
-			"sd-vconsole", "modconf", "block", "filesystems", "fsck"
+			"base", "systemd", "autodetect", "microcode", "modconf", "kms", "keyboard",
+			"sd-vconsole", "block", "filesystems", "fsck"
 		]
 		self._kernel_params: List[str] = []
 		self._fstab_entries: List[str] = []
@@ -709,7 +709,7 @@ class Installer:
 				# This is purely for stability reasons, we're going away from this.
 				# * systemd -> udev
 				# * sd-vconsole -> keymap
-				self._hooks = [hook.replace('systemd', 'udev').replace('sd-vconsole', 'keymap') for hook in self._hooks]
+				self._hooks = [hook.replace('systemd', 'udev').replace('sd-vconsole', 'keymap consolefont') for hook in self._hooks]
 
 			mkinit.write(f"HOOKS=({' '.join(self._hooks)})\n")
 


### PR DESCRIPTION
This PR addresses upstream commits:
1.   [mkinitcpio.conf: add kms to the default HOOKS array](https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/b99eb1c0d5704ed0a0d220d0abcbbbeec10a3b76)
2.  [mkinitcpio.conf: adjust the placement of the modconf hook for consistency](https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/0b052b14615fefbb61ee3d813e3acd365332ee35)


Additionally, it replaces the missing `consolefont` hook if the `keyboard` hook is used instead of the `sd-vconsole` hook.
For more details, see the Arch Wiki: [dm-crypt/System configuration - 1.1 mkinitcpio](https://wiki.archlinux.org/title/Dm-crypt/System_configuration#mkinitcpio)

## PR Description:
This PR adjusts the hooks in mkinitcpio.conf to follow the changes in the upstream mkinitcpio repository.
It also add the consolefont hook if udev is used instead of systemd.

- Old archinstall default hooks list :

```
base systemd autodetect microcode keyboard sd-vconsole modconf block filesystems fsck
```

- Updated archinstall default hooks list :
```
base systemd autodetect microcode modconf kms keyboard sd-vconsole block filesystems fsck
```
&nbsp;
- Add missing `consolefont` hook :
```python
self._hooks = [hook.replace('systemd', 'udev').replace('sd-vconsole', 'keymap') for hook in self._hooks]
```
Updated to:
```python
self._hooks = [hook.replace('systemd', 'udev').replace('sd-vconsole', 'keymap consolefont') for hook in self._hooks]
```

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
