### PR TITLE
nvidia-open double fix with nvidia-open-dkms

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -47,7 +47,6 @@ class GfxPackage(Enum):
 	LibvaMesaDriver = 'libva-mesa-driver'
 	Mesa = "mesa"
 	NvidiaDkms = 'nvidia-dkms'
-	NvidiaOpen = 'nvidia-open'
 	NvidiaOpenDkms = 'nvidia-open-dkms'
 	VulkanIntel = 'vulkan-intel'
 	VulkanRadeon = 'vulkan-radeon'

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -116,7 +116,6 @@ class GfxDriver(Enum):
 				]
 			case GfxDriver.NvidiaOpenKernel:
 				packages += [
-					GfxPackage.NvidiaOpen,
 					GfxPackage.Dkms,
 					GfxPackage.NvidiaOpenDkms
 				]


### PR DESCRIPTION
Fixing package duplication when installing nvidia-open driver, which is unnecessary because one of the packages is already present. In this case, nvidia-open and nvidia-open-dkms duplicate each other, which can lead to misunderstandings among inexperienced users when installing through a script and using a kernel other than generic linux.