### PR TITLE
Add beta label to LVM support

### DIFF
--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -41,7 +41,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu):
 			)
 		self._menu_options['lvm_config'] = \
 			Selector(
-				_('Logical Volume Management (LVM)'),
+				f'{_('LVM - Logical Volume Management')} (BETA)',
 				lambda x: self._select_lvm_config(x),
 				display_func=lambda x: self.defined_text if x else '',
 				preview_func=self._prev_lvm_config,


### PR DESCRIPTION
Adds the BETA label to the LVM menu option to indicate that this should be used with caution until there is more certainty that it's working 