### PR TITLE
Do not overwrite the contents of mkinitcpio.conf

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -698,10 +698,11 @@ class Installer:
 				if plugin.on_mkinitcpio(self):
 					return True
 
-		with open(f'{self.target}/etc/mkinitcpio.conf', 'w') as mkinit:
-			mkinit.write(f"MODULES=({' '.join(self._modules)})\n")
-			mkinit.write(f"BINARIES=({' '.join(self._binaries)})\n")
-			mkinit.write(f"FILES=({' '.join(self._files)})\n")
+		with open(f'{self.target}/etc/mkinitcpio.conf', 'r+') as mkinit:
+			content = mkinit.read()
+			content = re.sub("\nMODULES=(.*)", f"\nMODULES=({' '.join(self._modules)})", content)
+			content = re.sub("\nBINARIES=(.*)", f"\nBINARIES=({' '.join(self._binaries)})", content)
+			content = re.sub("\nFILES=(.*)", f"\nFILES=({' '.join(self._files)})", content)
 
 			if not self._disk_encryption.hsm_device:
 				# For now, if we don't use HSM we revert to the old
@@ -711,7 +712,9 @@ class Installer:
 				# * sd-vconsole -> keymap
 				self._hooks = [hook.replace('systemd', 'udev').replace('sd-vconsole', 'keymap consolefont') for hook in self._hooks]
 
-			mkinit.write(f"HOOKS=({' '.join(self._hooks)})\n")
+			content = re.sub("\nHOOKS=(.*)", f"\nHOOKS=({' '.join(self._hooks)})", content)
+			mkinit.seek(0)
+			mkinit.write(content)
 
 		try:
 			SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}', peek_output=True)


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->  N/A

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->
After  installation is complete, user may want to edit `/etc/mkinitcpio.conf` at will and may encounter a mismatch between the default configuration examples and what it has after installation since archinstall does not just change some values, but completely overwrites contents of the file removing all comments and other options. This PR fixes this by editing only parameters specified in code like hooks/modules/etc.

## Tests and Checks
- [x] I have tested the code!<br> (did not test install process, but tested the operation of a separate mkinitcpio function on default mkinitcpio.conf file).
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
