### PR TITLE
Enable pre-commit renovate support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "pre-commit": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
This enables renovate support for the pre-commit file `.pre-commit-config.yaml`.
Currently renovate only updates `pyproject.yaml` which means that `mypy` and `flake8` from that config and the pre-commit versions can be out of sync which is annoying at times. 

Documentation for the feature: https://docs.renovatebot.com/modules/manager/pre-commit/