### PR TITLE
Handling encryption logic when only one non-root partition is encrypted (such as /home)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 count = True
 # Several of the following could be autofixed or improved by running the code through psf/black
-ignore = E123,E126,E128,E203,E231,E261,E302,E402,E722,F541,W191,W292,W293,W503,W504
+ignore = E123,E126,E128,E203,E227,E231,E261,E302,E402,E722,F541,W191,W292,W293,W503,W504
 max-complexity = 40
 max-line-length = 236
 show-source = True

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -354,9 +354,13 @@ class Installer:
 			disk.device_handler.mount(dev_path, mountpoint, options=mount_options)
 
 	def generate_key_files(self) -> None:
+		warn("Deprecation warning: generate_key_files() has been renamed to setup_luks_unlock() and generate_key_files will be removed.")
+		return this.setup_luks_unlock(self)
+
+	def setup_luks_unlock(self) -> None:
 		match self._disk_encryption.encryption_type:
 			case disk.EncryptionType.Luks:
-				self._generate_key_files_partitions()
+				self._setup_luks_unlock_partitions()
 			case disk.EncryptionType.LuksOnLvm:
 				self._generate_key_file_lvm_volumes()
 			case disk.EncryptionType.LvmOnLuks:
@@ -365,7 +369,11 @@ class Installer:
 				# so we won't need any keyfile generation atm
 				pass
 
-	def _generate_key_files_partitions(self):
+	def _generate_key_files_partitions(self) -> None:
+		warn("Deprecation warning: _generate_key_files_partitions() has been renamed to _setup_luks_unlock_partitions() and _generate_key_files_partitions will be removed.")
+		return this._setup_luks_unlock_partitions(self)
+
+	def _setup_luks_unlock_partitions(self) -> None:
 		for part_mod in self._disk_encryption.partitions:
 			gen_enc_file = self._disk_encryption.should_generate_encryption_file(part_mod)
 
@@ -386,6 +394,8 @@ class Installer:
 						part_mod.safe_dev_path,
 						self._disk_encryption.encryption_password
 					)
+
+			luks_handler.create_crypttab(self.target)
 
 	def _generate_key_file_lvm_volumes(self):
 		for vol in self._disk_encryption.lvm_volumes:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -355,7 +355,7 @@ class Installer:
 
 	def generate_key_files(self) -> None:
 		warn("Deprecation warning: generate_key_files() has been renamed to setup_luks_unlock() and generate_key_files will be removed.")
-		return this.setup_luks_unlock(self)
+		return self.setup_luks_unlock(self)
 
 	def setup_luks_unlock(self) -> None:
 		match self._disk_encryption.encryption_type:
@@ -371,7 +371,7 @@ class Installer:
 
 	def _generate_key_files_partitions(self) -> None:
 		warn("Deprecation warning: _generate_key_files_partitions() has been renamed to _setup_luks_unlock_partitions() and _generate_key_files_partitions will be removed.")
-		return this._setup_luks_unlock_partitions(self)
+		return self._setup_luks_unlock_partitions(self)
 
 	def _setup_luks_unlock_partitions(self) -> None:
 		for part_mod in self._disk_encryption.partitions:
@@ -385,7 +385,9 @@ class Installer:
 
 			if gen_enc_file and not part_mod.is_root():
 				debug(f'Creating key-file: {part_mod.dev_path}')
-				luks_handler.create_keyfile(self.target)
+				key_file = luks_handler.create_keyfile(self.target)
+			else:
+				key_file = None
 
 			if part_mod.is_root() and not gen_enc_file:
 				if self._disk_encryption.hsm_device:
@@ -395,7 +397,10 @@ class Installer:
 						self._disk_encryption.encryption_password
 					)
 
-			luks_handler.create_crypttab(self.target)
+			luks_handler.create_crypttab(
+				target_path=self.target,
+				key_file=key_file
+			)
 
 	def _generate_key_file_lvm_volumes(self):
 		for vol in self._disk_encryption.lvm_volumes:

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -191,11 +191,16 @@ class Luks2:
 
 		self._mapper_dev = None
 
-	def create_crypttab(self, target_path: Path, override: bool = False):
+	def create_crypttab(self, target_path: Path, key_file: Path|None = None, options: List[str] = None, override: bool = False):
 		crypttab_path = target_path / 'etc/crypttab'
-		self._crypttab(crypttab_path, kf_path, options=["luks", "key-slot=1"], override=override)
+		self._crypttab(
+			crypttab_path,
+			key_file=key_file,
+			options=options or ["luks", "key-slot=1"],
+			override=override
+		)
 
-	def create_keyfile(self, target_path: Path, override: bool = False):
+	def create_keyfile(self, target_path: Path, override: bool = False) -> Path:
 		"""
 		Routine to create keyfiles, so it can be moved elsewhere
 		"""
@@ -223,6 +228,8 @@ class Luks2:
 
 		self._add_key(key_file)
 
+		return kf_path
+
 	def _add_key(self, key_file: Path):
 		debug(f'Adding additional key-file {key_file}')
 
@@ -241,8 +248,8 @@ class Luks2:
 	def _crypttab(
 		self,
 		crypttab_path: Path,
-		key_file: Path,
 		options: List[str],
+		key_file: Path|None = None,
 		override: bool = False
 	) -> None:
 		debug(f'Adding crypttab entry for key {key_file}')
@@ -251,7 +258,7 @@ class Luks2:
 			existing_data = crypttab.readlines()
 			opt = ','.join(options)
 			uuid = self._get_luks_uuid()
-			new_row = f"{self.mapper_name} UUID={uuid} {key_file} {opt}\n"
+			new_row = f"{self.mapper_name} UUID={uuid} {key_file or 'none'} {opt}\n"
 
 			for index, existing_row in enumerate(existing_data):
 				if uuid in existing_row:

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -263,7 +263,7 @@ class Luks2:
 			for index, existing_row in enumerate(existing_data):
 				if uuid in existing_row:
 					if override is False:
-						print(f"Found {uuid} in {existing_row}")
+						debug(f"Found {uuid} in {existing_row}")
 						return True
 					else:
 						existing_data.pop(index)
@@ -274,8 +274,6 @@ class Luks2:
 				existing_data.append('\n')
 
 			existing_data.append(new_row)
-
-			print(f"Writing {existing_data}")
 
 			crypttab.seek(0)
 			crypttab.truncate()

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -191,7 +191,7 @@ class Luks2:
 
 		self._mapper_dev = None
 
-	def create_crypttab(self, target_path: Path, key_file: Path|None = None, options: List[str] = None, override: bool = False):
+	def create_crypttab(self, target_path: Path, key_file: Path|None = None, options: List[str]|None = None, override: bool = False):
 		crypttab_path = target_path / 'etc/crypttab'
 		self._crypttab(
 			crypttab_path,
@@ -215,7 +215,7 @@ class Luks2:
 		if key_file.exists():
 			if not override:
 				info(f'Key file {key_file} already exists, keeping existing')
-				return
+				return kf_path
 			else:
 				info(f'Key file {key_file} already exists, overriding')
 

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -128,7 +128,7 @@ def perform_installation(mountpoint: Path):
 		if disk_config.config_type != disk.DiskLayoutType.Pre_mount:
 			if disk_encryption and disk_encryption.encryption_type != disk.EncryptionType.NoEncryption:
 				# generate encryption key files for the mounted luks devices
-				installation.generate_key_files()
+				installation.setup_luks_unlock()
 
 		if mirror_config := archinstall.arguments.get('mirror_config', None):
 			installation.set_mirrors(mirror_config, on_target=False)


### PR DESCRIPTION
- This fix issue: #2539 

## PR Description:

This should make single-non-root-encrypted-partitions be unlocked via `/etc/crypttab` instead of via keyfile, as the keyfile would be unprotected.

## Tests and Checks
- [ ] I have tested the code!<br>