### PR TITLE
`disk.Size(1, disk.Unit.GiB, sector_size)` for issue #913

### DIFF
--- a/archinstall/lib/interactions/disk_conf.py
+++ b/archinstall/lib/interactions/disk_conf.py
@@ -207,13 +207,12 @@ def select_lvm_config(
 
 def _boot_partition(sector_size: disk.SectorSize, using_gpt: bool) -> disk.PartitionModification:
 	flags = [disk.PartitionFlag.Boot]
+	size = disk.Size(1, disk.Unit.GiB, sector_size)
 	if using_gpt:
 		start = disk.Size(1, disk.Unit.MiB, sector_size)
-		size = disk.Size(1, disk.Unit.GiB, sector_size)
 		flags.append(disk.PartitionFlag.ESP)
 	else:
 		start = disk.Size(3, disk.Unit.MiB, sector_size)
-		size = disk.Size(1, disk.Unit.GiB, sector_size)
 
 	# boot partition
 	return disk.PartitionModification(

--- a/archinstall/lib/interactions/disk_conf.py
+++ b/archinstall/lib/interactions/disk_conf.py
@@ -213,7 +213,7 @@ def _boot_partition(sector_size: disk.SectorSize, using_gpt: bool) -> disk.Parti
 		flags.append(disk.PartitionFlag.ESP)
 	else:
 		start = disk.Size(3, disk.Unit.MiB, sector_size)
-		size = disk.Size(203, disk.Unit.MiB, sector_size)
+		size = disk.Size(1, disk.Unit.GiB, sector_size)
 
 	# boot partition
 	return disk.PartitionModification(


### PR DESCRIPTION
- This fix issue: #913 

## PR Description:

This sets the default boot partition size to 1 GiB for non-GPT layouts just the same as the GPT layout default.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
