### PR TITLE
Use `/mirrors/status/json/` instead of `/mirrorlist/` to get mirror lists

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,11 @@
 [flake8]
 count = True
 # Several of the following could be autofixed or improved by running the code through psf/black
-ignore = E123,E126,E128,E203,E231,E261,E302,E402,E722,F541,W191,W292,W293,W503,W504
+ignore = E123,E126,E128,E203,E227,E231,E261,E302,E402,E722,F541,W191,W292,W293,W503,W504
 max-complexity = 40
 max-line-length = 236
 show-source = True
 statistics = True
 builtins = _
 per-file-ignores = __init__.py:F401,F403,F405 simple_menu.py:C901,W503 guided.py:C901 network_configuration.py:F821
+exclude = .git,__pycache__,docs,actions-runner

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -17,7 +17,7 @@ jobs:
           pacman-key --init
           pacman --noconfirm -Sy archlinux-keyring
           pacman --noconfirm -Syyu
-          pacman --noconfirm -Sy python-pip python-pyparted python-simple-term-menu pkgconfig gcc
+          pacman --noconfirm -Sy python-pip python-pydantic python-pyparted python-simple-term-menu pkgconfig gcc
       - name: Install build dependencies
         run: |
           python -m pip install --break-system-packages --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ venv
 /*.json
 requirements.txt
 /.gitconfig
-/actions-runner/
+/actions-runner
+/cmd_output.txt

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ venv
 /*.json
 requirements.txt
 /.gitconfig
+/actions-runner/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ venv
 /*.sig
 /*.json
 requirements.txt
+/.gitconfig

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,6 +22,7 @@ depends=(
   'pciutils'
   'procps-ng'
   'python'
+  'python-pydantic'
   'python-pyparted'
   'python-simple-term-menu'
   'systemd'

--- a/archinstall/lib/exceptions.py
+++ b/archinstall/lib/exceptions.py
@@ -38,3 +38,9 @@ class PackageError(Exception):
 
 class Deprecated(Exception):
 	pass
+
+
+class DownloadTimeout(Exception):
+	'''
+	Download timeout exception raised by DownloadTimer.
+	'''

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -493,7 +493,7 @@ class Installer:
 		if mirrorlist_config:
 			debug(f'Mirrorlist: {mirrorlist_config}')
 
-			with local_mirrorlist_conf.open('a') as fp:
+			with local_mirrorlist_conf.open('w') as fp:
 				fp.write(mirrorlist_config)
 
 	def genfstab(self, flags: str = '-pU'):

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -289,6 +289,13 @@ def _parse_mirror_list(mirrorlist: str) -> Dict[str, List[str]]:
 
 	for mirror in mirror_status.urls:
 		if mirror.url.startswith('http'):
+			if mirror.country == "":
+				# TODO: This should be removed once RFC!29 is merged and completed
+				# Until then, there are mirrors which lacks data in the backend
+				# and there is no way of knowing where they're located.
+				# So we have to assume world-wide
+				mirror.country = "Worldwide"
+
 			mirror_list.setdefault(mirror.country, []).append(mirror.url)
 
 	return mirror_list

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -290,7 +290,7 @@ def sort_mirrors_by_performance(mirror_list :List[MirrorStatusEntryV3]) -> List[
 	return sorted(mirror_list, key=lambda mirror: (mirror.score, mirror.speed))
 
 
-def _parse_mirror_list(mirrorlist: str) -> Dict[str, List[str]]:
+def _parse_mirror_list(mirrorlist: str) -> Dict[str, List[MirrorStatusEntryV3]]:
 	mirror_status = MirrorStatusListV3(**json.loads(mirrorlist))
 
 	sorting_placeholder: Dict[str, List[MirrorStatusEntryV3]] = {}
@@ -315,7 +315,7 @@ def _parse_mirror_list(mirrorlist: str) -> Dict[str, List[str]]:
 		if mirror.url.startswith('http'):
 			sorting_placeholder.setdefault(mirror.country, []).append(mirror)
 
-	sorted_by_regions: Dict[str, List[str]] = dict({
+	sorted_by_regions: Dict[str, List[MirrorStatusEntryV3]] = dict({
 		region: unsorted_mirrors
 		for region, unsorted_mirrors in sorted(sorting_placeholder.items(), key=lambda item: item[0])
 	})
@@ -323,8 +323,8 @@ def _parse_mirror_list(mirrorlist: str) -> Dict[str, List[str]]:
 	return sorted_by_regions
 
 
-def list_mirrors() -> Dict[str, List[str]]:
-	regions: Dict[str, List[str]] = {}
+def list_mirrors() -> Dict[str, List[MirrorStatusEntryV3]]:
+	regions: Dict[str, List[MirrorStatusEntryV3]] = {}
 
 	if storage['arguments']['offline']:
 		with pathlib.Path('/etc/pacman.d/mirrorlist').open('r') as fp:

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -272,7 +272,11 @@ def select_mirror_regions(preset_values: Dict[str, List[str]] = {}) -> Dict[str,
 		case MenuSelectionType.Skip:
 			return preset_values
 		case MenuSelectionType.Selection:
-			return {selected: mirrors[selected] for selected in choice.multi_value}
+			return {
+				selected: [
+					mirror.url for mirror in sort_mirrors_by_performance(mirrors[selected])
+				] for selected in choice.multi_value
+			}
 
 	return {}
 
@@ -282,7 +286,7 @@ def select_custom_mirror(prompt: str = '', preset: List[CustomMirror] = []):
 	return custom_mirrors
 
 
-def sort_mirror_list(mirror_list :List[MirrorStatusEntryV3]) -> List[MirrorStatusEntryV3]:
+def sort_mirrors_by_performance(mirror_list :List[MirrorStatusEntryV3]) -> List[MirrorStatusEntryV3]:
 	return sorted(mirror_list, key=lambda mirror: (mirror.score, mirror.speed))
 
 

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -282,11 +282,11 @@ def select_custom_mirror(prompt: str = '', preset: List[CustomMirror] = []):
 	return custom_mirrors
 
 
-def sort_mirror_list(mirror_list :List[MirrorStatusEntryV3], sorting_element :str = "url") -> List[MirrorStatusEntryV3]:
-	return sorted(mirror_list, key=lambda item: getattr(item, sorting_element))
+def sort_mirror_list(mirror_list :List[MirrorStatusEntryV3]) -> List[MirrorStatusEntryV3]:
+	return sorted(mirror_list, key=lambda mirror: (mirror.score, mirror.speed))
 
 
-def _parse_mirror_list(mirrorlist: str, sorting_element :str = "url") -> Dict[str, List[str]]:
+def _parse_mirror_list(mirrorlist: str) -> Dict[str, List[str]]:
 	mirror_status = MirrorStatusListV3(**json.loads(mirrorlist))
 
 	sorting_placeholder: Dict[str, List[MirrorStatusEntryV3]] = {}
@@ -311,14 +311,12 @@ def _parse_mirror_list(mirrorlist: str, sorting_element :str = "url") -> Dict[st
 		if mirror.url.startswith('http'):
 			sorting_placeholder.setdefault(mirror.country, []).append(mirror)
 
-	sorted_by_element: Dict[str, List[str]] = dict({
-		region: [
-			mirror.url for mirror in sort_mirror_list(unsorted_mirrors, sorting_element=sorting_element)
-		]
+	sorted_by_regions: Dict[str, List[str]] = dict({
+		region: unsorted_mirrors
 		for region, unsorted_mirrors in sorted(sorting_placeholder.items(), key=lambda item: item[0])
 	})
 
-	return sorted_by_element
+	return sorted_by_regions
 
 
 def list_mirrors() -> Dict[str, List[str]]:
@@ -335,4 +333,4 @@ def list_mirrors() -> Dict[str, List[str]]:
 			warn(f'Could not fetch an active mirror-list: {err}')
 			return regions
 
-	return _parse_mirror_list(mirrorlist, sorting_element="score")
+	return _parse_mirror_list(mirrorlist)

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -274,7 +274,7 @@ def select_mirror_regions(preset_values: Dict[str, List[str]] = {}) -> Dict[str,
 		case MenuSelectionType.Selection:
 			return {
 				selected: [
-					mirror.url for mirror in sort_mirrors_by_performance(mirrors[selected])
+					f"{mirror.url}$repo/os/$arch" for mirror in sort_mirrors_by_performance(mirrors[selected])
 				] for selected in choice.multi_value
 			}
 

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -69,8 +69,9 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 
 	@pydantic.model_validator(mode='after')
 	def debug_output(self, validation_info) -> 'MirrorStatusEntryV3':
-		self._hostname, *self._port = urllib.parse.urlparse(self.url).netloc.split(':', 1)
-		
+		self._hostname, *_port = urllib.parse.urlparse(self.url).netloc.split(':', 1)
+		self._port = int(_port[0]) if _port and len(_port) >= 1 else None
+
 		debug(f"Loaded mirror {self._hostname}" + (f" with current score of {round(self.score)}" if self.score else ''))
 		return self
 

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -33,7 +33,7 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 	_port :int|None = None
 
 	@property
-	def speed(self):
+	def speed(self) -> float|None:
 		if self._speed is None:
 			info(f"Checking download speed of {self._hostname}[{self.score}] by fetching: {self.url}core/os/x86_64/core.db")
 			req = urllib.request.Request(url=f"{self.url}core/os/x86_64/core.db")
@@ -46,7 +46,7 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 		return self._speed
 
 	@property
-	def latency(self):
+	def latency(self) -> float|None:
 		"""
 		Latency measures the miliseconds between one ICMP request & response.
 		It only does so once because we check if self._latency is None, and a ICMP timeout result in -1
@@ -60,7 +60,7 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 		return self._latency
 
 	@pydantic.field_validator('score', mode='before')
-	def validate_score(cls, value):
+	def validate_score(cls, value) -> int|None:
 		if value is not None:
 			value = round(value)
 			debug(f"    score: {value}")

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -70,7 +70,7 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 	def debug_output(cls, data: str|bool|int|datetime.datetime|float|None) -> str|bool|int|datetime.datetime|float|None:
 		parsed_uri = urllib.parse.urlparse(data['url'])
 		hostname, *port = parsed_uri.netloc.split(':', 1)
-		debug(f"Loaded mirror {hostname} with current score of {round(data['score'])}")
+		debug(f"Loaded mirror {hostname}" + (f"with current score of {round(data['score'])}" if data['score'] else ''))
 
 class MirrorStatusListV3(pydantic.BaseModel):
 	cutoff :int

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -30,11 +30,12 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 	_latency :float|None = None
 	_speed :float|None = None
 	_hostname :str|None = None
+	_port :int|None = None
 
 	@property
 	def speed(self):
 		if self._speed is None:
-			info(f"Checking download speed of {self._hostname} by getting {self.url}core/os/x86_64/core.db")
+			info(f"Checking download speed of {self._hostname}[{self.score}] by fetching: {self.url}core/os/x86_64/core.db")
 			req = urllib.request.Request(url=f"{self.url}core/os/x86_64/core.db")
 			with urllib.request.urlopen(req, None, 5) as handle, DownloadTimer(timeout=5) as timer:
 				size = len(handle.read())
@@ -70,6 +71,8 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 	def debug_output(cls, data: str|bool|int|datetime.datetime|float|None) -> str|bool|int|datetime.datetime|float|None:
 		parsed_uri = urllib.parse.urlparse(data['url'])
 		hostname, *port = parsed_uri.netloc.split(':', 1)
+		data['_hostname'] = hostname
+		data['_port'] = port
 		debug(f"Loaded mirror {hostname}" + (f"with current score of {round(data['score'])}" if data['score'] else ''))
 		return data
 

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -67,14 +67,12 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 
 		return value
 
-	@pydantic.model_validator(mode='before')
-	def debug_output(cls, data: str|bool|int|datetime.datetime|float|None) -> str|bool|int|datetime.datetime|float|None:
-		parsed_uri = urllib.parse.urlparse(data['url'])
-		hostname, *port = parsed_uri.netloc.split(':', 1)
-		data['_hostname'] = hostname
-		data['_port'] = port
-		debug(f"Loaded mirror {hostname}" + (f"with current score of {round(data['score'])}" if data['score'] else ''))
-		return data
+	@pydantic.model_validator(mode='after')
+	def debug_output(self, validation_info) -> 'MirrorStatusEntryV3':
+		self._hostname, *self._port = urllib.parse.urlparse(self.url).netloc.split(':', 1)
+		
+		debug(f"Loaded mirror {self._hostname}" + (f" with current score of {round(self.score)}" if self.score else ''))
+		return self
 
 class MirrorStatusListV3(pydantic.BaseModel):
 	cutoff :int

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -1,6 +1,15 @@
 import datetime
 import pydantic
-import typing
+import socket
+import urllib.parse
+import urllib.request
+from typing import (
+	Dict,
+	List
+)
+
+from ..networking import ping, DownloadTimer
+
 
 class MirrorStatusEntryV3(pydantic.BaseModel):
 	url :str
@@ -17,18 +26,53 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 	duration_avg :float|None = None
 	duration_stddev :float|None = None
 	completion_pct :float|None = None
-	score :float|None = None
+	score :int|None = None
+	_latency :float|None = None
+	_speed :float|None = None
+
+	@property
+	def speed(self):
+		if self._speed is None:
+			print(f"Checking download speed for {self.url}core/os/x86_64/core.db")
+			req = urllib.request.Request(url=f"{self.url}core/os/x86_64/core.db")
+			with urllib.request.urlopen(req, None, 5) as handle, DownloadTimer(timeout=5) as timer:
+				size = len(handle.read())
+
+			self._speed = size / timer.time
+
+		return self._speed
+
+	@property
+	def latency(self):
+		"""
+		Latency measures the miliseconds between one ICMP request & response.
+		It only does so once because we check if self._latency is None, and a ICMP timeout result in -1
+		We do this because some hosts blocks ICMP so we'll have to rely on .speed() instead which is slower.
+		"""
+		if self._latency is None:
+			print(f"Checking latency for {self.url}")
+			parsed_uri = urllib.parse.urlparse(self.url)
+			hostname, *port = parsed_uri.netloc.split(':', 1)
+			self._latency = ping(hostname, port=port, timeout=2)
+
+		return self._latency
+
+	@pydantic.field_validator('score', mode='before')
+	def score(cls, value):
+		if value is not None:
+			value = round(value)
+		return value
 
 class MirrorStatusListV3(pydantic.BaseModel):
 	cutoff :int
 	last_check :datetime.datetime
 	num_checks :int
-	urls :typing.List[MirrorStatusEntryV3]
+	urls :List[MirrorStatusEntryV3]
 	version :int
 
 	@pydantic.model_validator(mode='before')
 	@classmethod
-	def check_model(cls, data: typing.Dict[str, int|datetime.datetime|typing.List[MirrorStatusEntryV3]]) -> typing.Dict[str, int|datetime.datetime|typing.List[MirrorStatusEntryV3]]:
+	def check_model(cls, data: Dict[str, int|datetime.datetime|List[MirrorStatusEntryV3]]) -> Dict[str, int|datetime.datetime|List[MirrorStatusEntryV3]]:
 		if data.get('version') == 3:
 			return data
 

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -71,6 +71,7 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 		parsed_uri = urllib.parse.urlparse(data['url'])
 		hostname, *port = parsed_uri.netloc.split(':', 1)
 		debug(f"Loaded mirror {hostname}" + (f"with current score of {round(data['score'])}" if data['score'] else ''))
+		return data
 
 class MirrorStatusListV3(pydantic.BaseModel):
 	cutoff :int

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -1,0 +1,35 @@
+import datetime
+import pydantic
+import typing
+
+class MirrorStatusEntryV3(pydantic.BaseModel):
+	url :str
+	protocol :str
+	active :bool
+	country :str
+	country_code :str
+	isos :bool
+	ipv4 :bool
+	ipv6 :bool
+	details :str
+	delay :int|None = None
+	last_sync :datetime.datetime|None=None
+	duration_avg :float|None = None
+	duration_stddev :float|None = None
+	completion_pct :float|None = None
+	score :float|None = None
+
+class MirrorStatusListV3(pydantic.BaseModel):
+	cutoff :int
+	last_check :datetime.datetime
+	num_checks :int
+	urls :typing.List[MirrorStatusEntryV3]
+	version :int
+
+	@pydantic.model_validator(mode='before')
+	@classmethod
+	def check_model(cls, data: typing.Dict[str, int|datetime.datetime|typing.List[MirrorStatusEntryV3]]) -> typing.Dict[str, int|datetime.datetime|typing.List[MirrorStatusEntryV3]]:
+		if data.get('version') == 3:
+			return data
+
+		raise ValueError(f"MirrorStatusListV3 only accepts version 3 data from https://archlinux.org/mirrors/status/json/")

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -157,7 +157,7 @@ def build_icmp(payload):
 
 	return struct.pack('!BBHHH', 8, 0, checksum, 0, 1) + payload
 
-def ping(hostname, port=None, timeout=5):
+def ping(hostname, timeout=5):
 	watchdog = select.epoll()
 	started = time.time()
 	random_identifier = f'archinstall-{random.randint(1000, 9999)}'.encode()
@@ -169,7 +169,7 @@ def ping(hostname, port=None, timeout=5):
 	icmp_packet = build_icmp(random_identifier)
 
 	# Send the ICMP packet
-	icmp_socket.sendto(icmp_packet, (hostname, port or 0))
+	icmp_socket.sendto(icmp_packet, (hostname, 0))
 	latency = -1
 
 	# Gracefully wait for X amount of time

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -47,20 +47,21 @@ class DownloadTimer():
 		return self
 
 	def __exit__(self, typ, value, traceback):
-		time_delta = time.time() - self.start_time
-		signal.alarm(0)
-		self.time = time_delta
-		if self.timeout > 0:
-			signal.signal(signal.SIGALRM, self.previous_handler)
+		if self.start_time:
+			time_delta = time.time() - self.start_time
+			signal.alarm(0)
+			self.time = time_delta
+			if self.timeout > 0:
+				signal.signal(signal.SIGALRM, self.previous_handler)
 
-			previous_timer = self.previous_timer
-			if previous_timer > 0:
-				remaining_time = int(previous_timer - time_delta)
-				# The alarm should have been raised during the download.
-				if remaining_time <= 0:
-					signal.raise_signal(signal.SIGALRM)
-				else:
-					signal.alarm(remaining_time)
+				previous_timer = self.previous_timer
+				if previous_timer and previous_timer > 0:
+					remaining_time = int(previous_timer - time_delta)
+					# The alarm should have been raised during the download.
+					if remaining_time <= 0:
+						signal.raise_signal(signal.SIGALRM)
+					else:
+						signal.alarm(remaining_time)
 		self.start_time = None
 
 
@@ -182,7 +183,7 @@ def ping(hostname, timeout=5):
 
 				# Check if it's an Echo Reply (ICMP type 0)
 				if icmp_type == 0 and response[-len(random_identifier):] == random_identifier:
-					latency = (time.time() - started) * 1000
+					latency = round((time.time() - started) * 1000)
 					break
 		except socket.error as error:
 			print(f"Error: {error}")

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -2,14 +2,66 @@ import os
 import socket
 import ssl
 import struct
+import time
+import select
+import signal
+import random
 from typing import Union, Dict, Any, List, Optional
 from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import urlopen
 
-from .exceptions import SysCallError
+from .exceptions import SysCallError, DownloadTimeout
 from .output import error, info
 from .pacman import Pacman
+
+class DownloadTimer():
+	'''
+	Context manager for timing downloads with timeouts.
+	'''
+	def __init__(self, timeout=5):
+		'''
+		Args:
+			timeout:
+				The download timeout in seconds. The DownloadTimeout exception
+				will be raised in the context after this many seconds.
+		'''
+		self.time = None
+		self.start_time = None
+		self.timeout = timeout
+		self.previous_handler = None
+		self.previous_timer = None
+
+	def raise_timeout(self, signl, frame):
+		'''
+		Raise the DownloadTimeout exception.
+		'''
+		raise DownloadTimeout(f'Download timed out after {self.timeout} second(s).')
+
+	def __enter__(self):
+		if self.timeout > 0:
+			self.previous_handler = signal.signal(signal.SIGALRM, self.raise_timeout)
+			self.previous_timer = signal.alarm(self.timeout)
+
+		self.start_time = time.time()
+		return self
+
+	def __exit__(self, typ, value, traceback):
+		time_delta = time.time() - self.start_time
+		signal.alarm(0)
+		self.time = time_delta
+		if self.timeout > 0:
+			signal.signal(signal.SIGALRM, self.previous_handler)
+
+			previous_timer = self.previous_timer
+			if previous_timer > 0:
+				remaining_time = int(previous_timer - time_delta)
+				# The alarm should have been raised during the download.
+				if remaining_time <= 0:
+					signal.raise_signal(signal.SIGALRM)
+				else:
+					signal.alarm(remaining_time)
+		self.start_time = None
 
 
 def get_hw_addr(ifname :str) -> str:
@@ -81,3 +133,60 @@ def fetch_data_from_url(url: str, params: Optional[Dict] = None) -> str:
 		return data
 	except URLError:
 		raise ValueError(f'Unable to fetch data from url: {url}')
+
+
+def calc_checksum(icmp_packet):
+	# Calculate the ICMP checksum
+	checksum = 0
+	for i in range(0, len(icmp_packet), 2):
+		checksum += (icmp_packet[i] << 8) + (
+			struct.unpack('B', icmp_packet[i + 1:i + 2])[0]
+			if len(icmp_packet[i + 1:i + 2]) else 0
+		)
+
+	checksum = (checksum >> 16) + (checksum & 0xFFFF)
+	checksum = ~checksum & 0xFFFF
+	
+	return checksum
+
+def build_icmp(payload):
+	# Define the ICMP Echo Request packet
+	icmp_packet = struct.pack('!BBHHH', 8, 0, 0, 0, 1) + payload
+
+	checksum = calc_checksum(icmp_packet)
+
+	return struct.pack('!BBHHH', 8, 0, checksum, 0, 1) + payload
+
+def ping(hostname, port=None, timeout=5):
+	watchdog = select.epoll()
+	started = time.time()
+	random_identifier = f'archinstall-{random.randint(1000, 9999)}'.encode()
+	
+	# Create a raw socket (requires root, which should be fine on archiso)
+	icmp_socket = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
+	watchdog.register(icmp_socket, select.EPOLLIN | select.EPOLLHUP)
+
+	icmp_packet = build_icmp(random_identifier)
+
+	# Send the ICMP packet
+	icmp_socket.sendto(icmp_packet, (hostname, port or 0))
+	latency = -1
+
+	# Gracefully wait for X amount of time
+	# for a ICMP response or exit with no latency
+	while latency == -1 and time.time() - started < timeout:
+		try:
+			for fileno, event in watchdog.poll(0.1):
+				response, _ = icmp_socket.recvfrom(1024)
+				icmp_type = struct.unpack('!B', response[20:21])[0]
+
+				# Check if it's an Echo Reply (ICMP type 0)
+				if icmp_type == 0 and response[-len(random_identifier):] == random_identifier:
+					latency = (time.time() - started) * 1000
+					break
+		except socket.error as error:
+			print(f"Error: {error}")
+			break
+
+	icmp_socket.close()
+	return latency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "simple-term-menu==1.6.4",
     "pyparted @ https://github.com//dcantrell/pyparted/archive/v3.13.0.tar.gz#sha512=26819e28d73420937874f52fda03eb50ab1b136574ea9867a69d46ae4976d38c4f26a2697fa70597eed90dd78a5ea209bafcc3227a17a7a5d63cff6d107c2b11",
+    "pydantic==2.8.2"
 ]
 
 [project.urls]


### PR DESCRIPTION
## PR Description:

This is more of a performance tweak, as the `/json/` endpoint is cached in the backend and machine readable, whereas the ASCII human version of mirror status is not.

 * Improves mirror-list grab latency
 * Introduces `pydantic` as a dependency
 * Creates a MirrorStatus model *(with latency and speed performance checks)*
 * Emulates `reflector.service` behavior after mirror selection *(Sort order: `score` -> `download speed`)*
 * Fixes mirror selection overwriting mirrorlist, instead of appending it after mirrors *(making them never being used essentially)*
 * Implemented a dependency-free `ping()` function. We're currently not using `mirror.latency` but there's a possibility we could in the future if we wanted to.

Future improvements could be that we could use `pacman-mirrorlist` package as source, convert that to JSON that we could consume, solving potential issues such as [#2598](https://github.com/archlinux/archinstall/issues/2598).

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
