### PR TITLE
fix(lib/installer.py) Patch mkinitcpio.conf encrypt position

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -804,10 +804,10 @@ class Installer:
 				self.pacman.strap('libfido2')
 
 				if 'sd-encrypt' not in self._hooks:
-					self._hooks.insert(self._hooks.index('lvm2') - 1, 'sd-encrypt')
+					self._hooks.insert(self._hooks.index('lvm2'), 'sd-encrypt')
 			else:
 				if 'encrypt' not in self._hooks:
-					self._hooks.insert(self._hooks.index('lvm2') - 1, 'encrypt')
+					self._hooks.insert(self._hooks.index('lvm2'), 'encrypt')
 
 	def minimal_installation(
 		self,


### PR DESCRIPTION
Fixes https://github.com/archlinux/archinstall/issues/2600

## PR Description:

This PR change the order `encrypt` and  `sd-encrypt` are placed in `mkinitcpio.conf`. The `keymap` hook must be placed before to load the language layout before the encryption happened. Otherwise, the user won't be able to use his custom keyboard layout.

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
