### PR TITLE
add xwaylandvideobridge for plasma

### DIFF
--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -19,7 +19,8 @@ class PlasmaProfile(XorgProfile):
 			"dolphin",
 			"ark",
 			"plasma-workspace",
-			"egl-wayland"
+			"egl-wayland",
+			"xwaylandvideobridge"
 		]
 
 	@property


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

Fedora is shipping xwaylandvideobridge to KDE Plasma users by default

Debian plans to do the same
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1077654
- "This is a dependency of Plasma 6 and will be team maintained by the Qt/KDE team."

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
