### PR TITLE
Added a advanced=bool flag to Profile() class and enabled it on the cosmic-epoch profile

### DIFF
--- a/archinstall/default_profiles/desktops/cosmic.py
+++ b/archinstall/default_profiles/desktops/cosmic.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class CosmicProfile(XorgProfile):
 	def __init__(self):
-		super().__init__('cosmic-epoch', ProfileType.DesktopEnv, description='')
+		super().__init__('cosmic-epoch', ProfileType.DesktopEnv, description='', advanced=True)
 
 	@property
 	def packages(self) -> List[str]:

--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -34,7 +34,10 @@ class GreeterType(Enum):
 	Sddm = 'sddm'
 	Gdm = 'gdm'
 	Ly = 'ly'
-	CosmicSession = "cosmic-greeter"
+
+	# .. todo:: Remove when we un-hide cosmic behind --advanced
+	if storage['arguments'].get('advanced', False) is True:
+		CosmicSession = "cosmic-greeter"
 
 class SelectResult(Enum):
 	NewSelection = auto()
@@ -96,6 +99,13 @@ class Profile:
 		"""
 		return None
 
+	def _advanced_check(self):
+		"""
+		Used to control if the Profile() should be visible or not in different contexts.
+		Returns True if --advanced is given on a Profile(advanced=True) instance.
+		"""
+		return self.advanced is False or storage['arguments'].get('advanced', False) is True
+
 	def install(self, install_session: 'Installer'):
 		"""
 		Performs installation steps when this profile was selected
@@ -141,16 +151,16 @@ class Profile:
 		return self.profile_type in top_levels
 
 	def is_desktop_profile(self) -> bool:
-		return self.profile_type == ProfileType.Desktop if self.advanced is False or storage['arguments'].get('advanced', False) is True else False
+		return self.profile_type == ProfileType.Desktop if self._advanced_check() else False
 
 	def is_server_type_profile(self) -> bool:
 		return self.profile_type == ProfileType.ServerType
 
 	def is_desktop_type_profile(self) -> bool:
-		return (self.profile_type == ProfileType.DesktopEnv or self.profile_type == ProfileType.WindowMgr) if self.advanced is False or storage['arguments'].get('advanced', False) is True else False
+		return (self.profile_type == ProfileType.DesktopEnv or self.profile_type == ProfileType.WindowMgr) if self._advanced_check() else False
 
 	def is_xorg_type_profile(self) -> bool:
-		return self.profile_type == ProfileType.Xorg if self.advanced is False or storage['arguments'].get('advanced', False) is True else False
+		return self.profile_type == ProfileType.Xorg if self._advanced_check() else False
 
 	def is_tailored(self) -> bool:
 		return self.profile_type == ProfileType.Tailored

--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from enum import Enum, auto
 from typing import List, Optional, Any, Dict, TYPE_CHECKING
 
@@ -36,7 +37,7 @@ class GreeterType(Enum):
 	Ly = 'ly'
 
 	# .. todo:: Remove when we un-hide cosmic behind --advanced
-	if storage['arguments'].get('advanced', False) is True:
+	if '--advanced' in sys.argv:
 		CosmicSession = "cosmic-greeter"
 
 class SelectResult(Enum):

--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from enum import Enum, auto
 from typing import List, Optional, Any, Dict, TYPE_CHECKING
 
-from archinstall.lib.utils.util import format_cols
+from ..lib.utils.util import format_cols
+from ..lib.storage import storage
 
 if TYPE_CHECKING:
-	from archinstall.lib.installer import Installer
+	from ..lib.installer import Installer
 	_: Any
 
 
@@ -51,12 +52,14 @@ class Profile:
 		packages: List[str] = [],
 		services: List[str] = [],
 		support_gfx_driver: bool = False,
-		support_greeter: bool = False
+		support_greeter: bool = False,
+		advanced: bool = False
 	):
 		self.name = name
 		self.description = description
 		self.profile_type = profile_type
 		self.custom_settings: Dict[str, Any] = {}
+		self.advanced = advanced
 
 		self._support_gfx_driver = support_gfx_driver
 		self._support_greeter = support_greeter
@@ -138,16 +141,16 @@ class Profile:
 		return self.profile_type in top_levels
 
 	def is_desktop_profile(self) -> bool:
-		return self.profile_type == ProfileType.Desktop
+		return self.profile_type == ProfileType.Desktop if self.advanced is False or storage['arguments'].get('advanced', False) is True else False
 
 	def is_server_type_profile(self) -> bool:
 		return self.profile_type == ProfileType.ServerType
 
 	def is_desktop_type_profile(self) -> bool:
-		return self.profile_type == ProfileType.DesktopEnv or self.profile_type == ProfileType.WindowMgr
+		return (self.profile_type == ProfileType.DesktopEnv or self.profile_type == ProfileType.WindowMgr) if self.advanced is False or storage['arguments'].get('advanced', False) is True else False
 
 	def is_xorg_type_profile(self) -> bool:
-		return self.profile_type == ProfileType.Xorg
+		return self.profile_type == ProfileType.Xorg if self.advanced is False or storage['arguments'].get('advanced', False) is True else False
 
 	def is_tailored(self) -> bool:
 		return self.profile_type == ProfileType.Tailored

--- a/archinstall/default_profiles/xorg.py
+++ b/archinstall/default_profiles/xorg.py
@@ -12,12 +12,14 @@ class XorgProfile(Profile):
 		name: str = 'Xorg',
 		profile_type: ProfileType = ProfileType.Xorg,
 		description: str = str(_('Installs a minimal system as well as xorg and graphics drivers.')),
+		advanced: bool = False
 	):
 		super().__init__(
 			name,
 			profile_type,
 			description=description,
-			support_gfx_driver=True
+			support_gfx_driver=True,
+			advanced=advanced
 		)
 
 	def preview_text(self) -> Optional[str]:

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -194,6 +194,8 @@ class ProfileHandler:
 			case GreeterType.Ly:
 				packages = ['ly']
 				service = ['ly']
+			case GreeterType.CosmicSession:
+				packages = ['cosmic-greeter']
 
 		if packages:
 			install_session.add_additional_packages(packages)

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -10,7 +10,7 @@ from tempfile import NamedTemporaryFile
 from types import ModuleType
 from typing import List, TYPE_CHECKING, Any, Optional, Dict, Union
 
-from archinstall.default_profiles.profile import Profile, GreeterType
+from ...default_profiles.profile import Profile, GreeterType
 from .profile_model import ProfileConfiguration
 from ..hardware import GfxDriver
 from ..menu import MenuSelectionType, Menu, MenuSelection
@@ -329,6 +329,8 @@ class ProfileHandler:
 					return self._load_profile_class(imported)
 		except Exception as e:
 			error(f'Unable to parse file {file}: {e}')
+			import time
+			time.sleep(10)
 
 		return []
 

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -329,8 +329,6 @@ class ProfileHandler:
 					return self._load_profile_class(imported)
 		except Exception as e:
 			error(f'Unable to parse file {file}: {e}')
-			import time
-			time.sleep(10)
 
 		return []
 


### PR DESCRIPTION
This is to be able to hide certain profiles behind `--advanced`.
We also enabled it on the `cosmic-epoch` due to it being pre-release alpha still with a note on the upstream repo:

> incomplete **alpha**

This complements issue: #2358 and thus #2615