### PR TITLE
Use `0` instead of `None` when the speedtest fails.

### DIFF
--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -47,13 +47,13 @@ class MirrorStatusEntryV3(pydantic.BaseModel):
 				debug(f"    speed: {self._speed} ({int(self._speed / 1024 / 1024 * 100) / 100}MiB/s)")
 			except http.client.IncompleteRead:
 				debug(f"    speed: <undetermined>")
-				self._speed = None
+				self._speed = 0
 			except urllib.error.URLError as error:
 				debug(f"    speed: <undetermined> ({error})")
-				self._speed = None
+				self._speed = 0
 			except Exception as error:
 				debug(f"    speed: <undetermined> ({error})")
-				self._speed = None
+				self._speed = 0
 
 		return self._speed
 


### PR DESCRIPTION
- This fix issue:
#2646 

## PR Description:
https://github.com/archlinux/archinstall/blob/master/archinstall/lib/mirrors.py#L290
If the speed is None, sorted will throw "TypeError: '<' not supported between instances of 'NoneType' and 'float'"
So use `0` instead of `None` when the speedtest fails.

## Tests and Checks
- [ ] I have tested the code!
