### PR TITLE
Add ruff linting support

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,12 @@
+on: [ push, pull_request ]
+name: ruff linting
+jobs:
+    ruff:
+        runs-on: ubuntu-latest
+        container:
+            image: archlinux/archlinux:latest
+        steps:
+            - uses: actions/checkout@v4
+            - run: pacman --noconfirm -Syu ruff
+            - name: Lint with ruff
+              run: ruff check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,7 @@ repos:
     hooks:
     - id: mypy
       fail_fast: true
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.2
+    hooks:
+      - id: ruff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ There might therefore be older code which does not follow the coding convention 
 
 ## Git hooks
 
-`archinstall` ships pre-commit hooks that make it easier to run check such as `mypy` and `flake8` locally.
+`archinstall` ships pre-commit hooks that make it easier to run checks such as `mypy`, `ruff check`, and `flake8` locally.
 The checks are listed in `.pre-commit-config.yaml` and can be installed via
 ```
 pre-commit install

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -287,7 +287,7 @@ def error(
 
 def warn(
 	*msgs: str,
-	level: int = logging.WARN,
+	level: int = logging.WARNING,
 	fg: str = 'yellow',
 	bg: Optional[str] = None,
 	reset: bool = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "mypy==1.11.2",
     "flake8==7.1.1",
     "pre-commit==3.8.0",
+    "ruff==0.6.2",
 ]
 doc = ["sphinx"]
 
@@ -118,3 +119,39 @@ ignore_missing_imports = true
 [tool.bandit]
 targets = ["archinstall"]
 exclude = ["/tests"]
+
+[tool.ruff]
+target-version = "py311"
+builtins = ["_"]
+line-length = 220
+
+[tool.ruff.lint]
+select = [
+    "ASYNC",  # flake8-async
+    "C90",    # mccabe
+    "E",      # pycodestyle errors
+    "EXE",    # flake8-executable
+    "F",      # Pyflakes
+    "FLY",    # flynt
+    "G",      # flake8-logging-format
+    "ICN",    # flake8-import-conventions
+    "LOG",    # flake8-logging
+    "PIE",    # flake8-pie
+    "PLC",    # Pylint conventions
+    "PLE",    # Pylint errors
+    "RSE",    # flake8-raise
+    "SLOT",   # flake8-slot
+    "T10",    # flake8-debugger
+    "W",      # pycodestyle warnings
+    "YTT",    # flake8-2020
+]
+
+ignore = [
+    "E701",  # multiple-statements-on-one-line-colon
+    "E722",  # bare-except
+    "F401",  # unused-import
+    "W191",  # tab-indentation
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 40


### PR DESCRIPTION
## PR Description:

This PR adds ruff to the CI checks and pre-commit checks.

Only linting is enabled, no auto-formatting is performed. (#1681 is related work.)

More rules can be enabled in the future (after the relevant code is fixed):
- https://docs.astral.sh/ruff/rules/

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
