### PR TITLE
Add Pylint support and enable Pylint CI checks

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,0 +1,22 @@
+on: [ push, pull_request ]
+name: Pylint linting
+jobs:
+    pylint:
+        runs-on: ubuntu-latest
+        container:
+            image: archlinux/archlinux:latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Prepare arch
+              run: |
+                pacman-key --init
+                pacman --noconfirm -Sy archlinux-keyring
+                pacman --noconfirm -Syyu
+                pacman --noconfirm -Sy python-pip python-pyparted python-simple-term-menu pkgconfig gcc
+            - run: pip install --break-system-packages --upgrade pip
+            - name: Install Pylint and Pylint plug-ins
+              run: pip install --break-system-packages .[dev]
+            - run: python --version
+            - run: pylint --version
+            - name: Lint with Pylint
+              run: pylint .

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -61,8 +61,8 @@ def ask_for_audio_selection(
 	current: Optional[AudioConfiguration] = None
 ) -> Optional[AudioConfiguration]:
 	choices = [
-		Audio.Pipewire.name,
-		Audio.Pulseaudio.name,
+		Audio.Pipewire.name,  # pylint: disable=no-member
+		Audio.Pulseaudio.name,  # pylint: disable=no-member
 		Audio.no_audio_text()
 	]
 

--- a/archinstall/lib/models/users.py
+++ b/archinstall/lib/models/users.py
@@ -13,7 +13,7 @@ class PasswordStrength(Enum):
 	STRONG = 'strong'
 
 	@property
-	def value(self) -> str:
+	def value(self) -> str:  # pylint: disable=invalid-overridden-method
 		match self:
 			case PasswordStrength.VERY_WEAK: return str(_('very weak'))
 			case PasswordStrength.WEAK: return str(_('weak'))

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -113,4 +113,4 @@ def installed_package(package: str) -> LocalPackage:
 	except SysCallError:
 		pass
 
-	return LocalPackage({field.name: package_info.get(field.name) for field in dataclasses.fields(LocalPackage)})  # type: ignore
+	return LocalPackage({field.name: package_info.get(field.name) for field in dataclasses.fields(LocalPackage)})  # type: ignore  # pylint: disable=no-value-for-parameter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dev = [
     "flake8==7.1.1",
     "pre-commit==4.0.1",
     "ruff==0.7.2",
+    "pylint==3.3.1",
+    "pylint-pydantic==0.3.2",
 ]
 doc = ["sphinx"]
 
@@ -119,6 +121,53 @@ ignore_missing_imports = true
 [tool.bandit]
 targets = ["archinstall"]
 exclude = ["/tests"]
+
+[tool.pylint.main]
+ignore-paths = [
+    "^build/",
+    "^docs/",
+]
+load-plugins = ["pylint_pydantic"]
+persistent = false
+py-version = "3.11"
+recursive = true
+
+[tool.pylint.format]
+max-line-length = 220
+
+[tool.pylint."messages control"]
+disable = [
+    "C",
+    "R",
+    "arguments-renamed",
+    "attribute-defined-outside-init",
+    "bad-indentation",
+    "bare-except",
+    "broad-exception-caught",
+    "cell-var-from-loop",
+    "comparison-with-callable",
+    "dangerous-default-value",
+    "expression-not-assigned",
+    "f-string-without-interpolation",
+    "fixme",
+    "protected-access",
+    "raise-missing-from",
+    "redefined-builtin",
+    "redefined-outer-name",
+    "self-assigning-variable",
+    "unnecessary-lambda",
+    "unreachable",
+    "unspecified-encoding",
+    "unused-argument",
+    "unused-variable",
+    "useless-parent-delegation",
+]
+
+[tool.pylint.refactoring]
+score = false
+
+[tool.pylint.variables]
+additional-builtins = ["_"]
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
## PR Description:

Pylint can help catch issues like #2625:

```
************* Module archinstall.default_profiles.server
archinstall/default_profiles/server.py:34:4: E1101: Instance of 'ServerProfile' has no 'set_current_selection' member (no-member)
```

I didn't add the Pylint checks to the pre-commit config because they might be a bit too slow to run on each commit.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
