### PR TITLE
Move device after options in lsblk command

### DIFF
--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -1431,14 +1431,14 @@ def _fetch_lsblk_info(
 	fields = [_clean_field(f, CleanType.Lsblk) for f in LsblkInfo.fields()]
 	cmd = ['lsblk', '--json', '--bytes', '--output', '+' + ','.join(fields)]
 
-	if dev_path:
-		cmd.append(str(dev_path))
-
 	if reverse:
 		cmd.append('--inverse')
 
 	if full_dev_path:
 		cmd.append('--paths')
+
+	if dev_path:
+		cmd.append(str(dev_path))
 
 	try:
 		result = SysCommand(cmd).decode()


### PR DESCRIPTION
Conform to the arguments order in the [man page](https://man.archlinux.org/man/lsblk.8).

> ### [SYNOPSIS](https://man.archlinux.org/man/lsblk.8#SYNOPSIS)
>     lsblk [options] [device...]
