### PR TITLE
Remove some deprecated typing.Dict and typing.List usage

### DIFF
--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Any, TYPE_CHECKING
+from typing import Union, Any, TYPE_CHECKING
 
 import archinstall
 
@@ -15,7 +15,7 @@ class PipewireProfile(Profile):
 		super().__init__('Pipewire', ProfileType.Application)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			'pipewire',
 			'pipewire-alsa',
@@ -27,7 +27,7 @@ class PipewireProfile(Profile):
 		]
 
 	def _enable_pipewire_for_all(self, install_session: 'Installer') -> None:
-		users: Union[User, List[User]] = archinstall.arguments.get('!users', [])
+		users: Union[User, list[User]] = archinstall.arguments.get('!users', [])
 		if not isinstance(users, list):
 			users = [users]
 

--- a/archinstall/default_profiles/desktops/awesome.py
+++ b/archinstall/default_profiles/desktops/awesome.py
@@ -1,4 +1,4 @@
-from typing import List, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -13,7 +13,7 @@ class AwesomeProfile(XorgProfile):
 		super().__init__('Awesome', ProfileType.WindowMgr, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return super().packages + [
 			'awesome',
 			'alacritty',

--- a/archinstall/default_profiles/desktops/bspwm.py
+++ b/archinstall/default_profiles/desktops/bspwm.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class BspwmProfile(XorgProfile):
 		super().__init__('Bspwm', ProfileType.WindowMgr, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		# return super().packages + [
 		return [
 			'bspwm',

--- a/archinstall/default_profiles/desktops/budgie.py
+++ b/archinstall/default_profiles/desktops/budgie.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class BudgieProfile(XorgProfile):
 		super().__init__('Budgie', ProfileType.DesktopEnv, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"arc-gtk-theme",
 			"budgie",

--- a/archinstall/default_profiles/desktops/cinnamon.py
+++ b/archinstall/default_profiles/desktops/cinnamon.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class CinnamonProfile(XorgProfile):
 		super().__init__('Cinnamon', ProfileType.DesktopEnv, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"cinnamon",
 			"system-config-printer",

--- a/archinstall/default_profiles/desktops/cosmic.py
+++ b/archinstall/default_profiles/desktops/cosmic.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class CosmicProfile(XorgProfile):
 		super().__init__('cosmic-epoch', ProfileType.DesktopEnv, description='', advanced=True)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"cosmic",
 		]

--- a/archinstall/default_profiles/desktops/cutefish.py
+++ b/archinstall/default_profiles/desktops/cutefish.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -13,7 +13,7 @@ class CutefishProfile(XorgProfile):
 		super().__init__('Cutefish', ProfileType.DesktopEnv, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"cutefish",
 			"noto-fonts"

--- a/archinstall/default_profiles/desktops/deepin.py
+++ b/archinstall/default_profiles/desktops/deepin.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class DeepinProfile(XorgProfile):
 		super().__init__('Deepin', ProfileType.DesktopEnv, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"deepin",
 			"deepin-terminal",

--- a/archinstall/default_profiles/desktops/enlightenment.py
+++ b/archinstall/default_profiles/desktops/enlightenment.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class EnlighenmentProfile(XorgProfile):
 		super().__init__('Enlightenment', ProfileType.WindowMgr, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"enlightenment",
 			"terminology"

--- a/archinstall/default_profiles/desktops/gnome.py
+++ b/archinstall/default_profiles/desktops/gnome.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class GnomeProfile(XorgProfile):
 		super().__init__('Gnome', ProfileType.DesktopEnv, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			'gnome',
 			'gnome-tweaks'

--- a/archinstall/default_profiles/desktops/i3.py
+++ b/archinstall/default_profiles/desktops/i3.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class I3wmProfile(XorgProfile):
 		super().__init__('i3-wm', ProfileType.WindowMgr, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			'i3-wm',
 			'i3lock',

--- a/archinstall/default_profiles/desktops/lxqt.py
+++ b/archinstall/default_profiles/desktops/lxqt.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -15,7 +15,7 @@ class LxqtProfile(XorgProfile):
 	# LXQt works with lightdm, but since this is not supported, we will not default to this.
 	# https://github.com/lxqt/lxqt/issues/795
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"lxqt",
 			"breeze-icons",

--- a/archinstall/default_profiles/desktops/mate.py
+++ b/archinstall/default_profiles/desktops/mate.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class MateProfile(XorgProfile):
 		super().__init__('Mate', ProfileType.DesktopEnv, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"mate",
 			"mate-extra"

--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class PlasmaProfile(XorgProfile):
 		super().__init__('KDE Plasma', ProfileType.DesktopEnv, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"plasma-meta",
 			"konsole",

--- a/archinstall/default_profiles/desktops/qtile.py
+++ b/archinstall/default_profiles/desktops/qtile.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class QtileProfile(XorgProfile):
 		super().__init__('Qtile', ProfileType.WindowMgr, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			'qtile',
 			'alacritty'

--- a/archinstall/default_profiles/desktops/xfce4.py
+++ b/archinstall/default_profiles/desktops/xfce4.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,7 +12,7 @@ class Xfce4Profile(XorgProfile):
 		super().__init__('Xfce4', ProfileType.DesktopEnv, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"xfce4",
 			"xfce4-goodies",

--- a/archinstall/default_profiles/servers/cockpit.py
+++ b/archinstall/default_profiles/servers/cockpit.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -11,9 +9,9 @@ class CockpitProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['cockpit', 'udisks2', 'packagekit']
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		return ['cockpit.socket']

--- a/archinstall/default_profiles/servers/docker.py
+++ b/archinstall/default_profiles/servers/docker.py
@@ -1,4 +1,4 @@
-from typing import List, Union, TYPE_CHECKING
+from typing import Union, TYPE_CHECKING
 
 import archinstall
 
@@ -17,15 +17,15 @@ class DockerProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['docker']
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		return ['docker']
 
 	def post_install(self, install_session: 'Installer') -> None:
-		users: Union[User, List[User]] = archinstall.arguments.get('!users', [])
+		users: Union[User, list[User]] = archinstall.arguments.get('!users', [])
 		if not isinstance(users, list):
 			users = [users]
 

--- a/archinstall/default_profiles/servers/httpd.py
+++ b/archinstall/default_profiles/servers/httpd.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -11,9 +9,9 @@ class HttpdProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['apache']
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		return ['httpd']

--- a/archinstall/default_profiles/servers/lighttpd.py
+++ b/archinstall/default_profiles/servers/lighttpd.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -11,9 +9,9 @@ class LighttpdProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['lighttpd']
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		return ['lighttpd']

--- a/archinstall/default_profiles/servers/mariadb.py
+++ b/archinstall/default_profiles/servers/mariadb.py
@@ -1,4 +1,4 @@
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from archinstall.default_profiles.profile import Profile, ProfileType
 
@@ -14,11 +14,11 @@ class MariadbProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['mariadb']
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		return ['mariadb']
 
 	def post_install(self, install_session: 'Installer') -> None:

--- a/archinstall/default_profiles/servers/nginx.py
+++ b/archinstall/default_profiles/servers/nginx.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -11,9 +9,9 @@ class NginxProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['nginx']
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		return ['nginx']

--- a/archinstall/default_profiles/servers/postgresql.py
+++ b/archinstall/default_profiles/servers/postgresql.py
@@ -1,4 +1,4 @@
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from archinstall.default_profiles.profile import Profile, ProfileType
 
@@ -15,11 +15,11 @@ class PostgresqlProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['postgresql']
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		return ['postgresql']
 
 	def post_install(self, install_session: 'Installer') -> None:

--- a/archinstall/default_profiles/servers/sshd.py
+++ b/archinstall/default_profiles/servers/sshd.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -11,9 +9,9 @@ class SshdProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['openssh']
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		return ['sshd']

--- a/archinstall/default_profiles/servers/tomcat.py
+++ b/archinstall/default_profiles/servers/tomcat.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -11,9 +9,9 @@ class TomcatProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['tomcat10']
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		return ['tomcat10']

--- a/archinstall/default_profiles/tailored.py
+++ b/archinstall/default_profiles/tailored.py
@@ -1,4 +1,4 @@
-from typing import List, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -13,7 +13,7 @@ class TailoredProfile(XorgProfile):
 		super().__init__('52-54-00-12-34-56', ProfileType.Tailored, description='')
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return ['nano', 'wget', 'git']
 
 	def install(self, install_session: 'Installer') -> None:

--- a/archinstall/default_profiles/xorg.py
+++ b/archinstall/default_profiles/xorg.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TYPE_CHECKING, List
+from typing import Any, Optional, TYPE_CHECKING
 
 from archinstall.default_profiles.profile import Profile, ProfileType
 
@@ -30,7 +30,7 @@ class XorgProfile(Profile):
 		return text
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			'xorg-server'
 		]

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -6,7 +6,7 @@ import time
 import select
 import signal
 import random
-from typing import Union, Dict, Any, List, Optional
+from typing import Union, Any, Optional
 from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import urlopen
@@ -73,7 +73,7 @@ def get_hw_addr(ifname: str) -> str:
 	return ':'.join('%02x' % b for b in ret[18:24])
 
 
-def list_interfaces(skip_loopback: bool = True) -> Dict[str, str]:
+def list_interfaces(skip_loopback: bool = True) -> dict[str, str]:
 	interfaces = {}
 
 	for index, iface in socket.if_nameindex():
@@ -98,7 +98,7 @@ def update_keyring() -> bool:
 	return False
 
 
-def enrich_iface_types(interfaces: Union[Dict[str, Any], List[str]]) -> Dict[str, str]:
+def enrich_iface_types(interfaces: Union[dict[str, Any], list[str]]) -> dict[str, str]:
 	result = {}
 
 	for iface in interfaces:
@@ -118,7 +118,7 @@ def enrich_iface_types(interfaces: Union[Dict[str, Any], List[str]]) -> Dict[str
 	return result
 
 
-def fetch_data_from_url(url: str, params: Optional[Dict] = None) -> str:
+def fetch_data_from_url(url: str, params: Optional[dict] = None) -> str:
 	ssl_context = ssl.create_default_context()
 	ssl_context.check_hostname = False
 	ssl_context.verify_mode = ssl.CERT_NONE

--- a/archinstall/lib/pacman/__init__.py
+++ b/archinstall/lib/pacman/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import time
 import re
-from typing import TYPE_CHECKING, Any, List, Callable, Union
+from typing import TYPE_CHECKING, Any, Callable, Union
 from shutil import copy2
 
 from ..general import SysCommand
@@ -67,7 +67,7 @@ class Pacman:
 		)
 		self.synced = True
 
-	def strap(self, packages: Union[str, List[str]]) -> None:
+	def strap(self, packages: Union[str, list[str]]) -> None:
 		self.sync()
 		if isinstance(packages, str):
 			packages = [packages]

--- a/archinstall/lib/translationhandler.py
+++ b/archinstall/lib/translationhandler.py
@@ -6,7 +6,7 @@ import gettext
 from dataclasses import dataclass
 
 from pathlib import Path
-from typing import List, Dict, Any, TYPE_CHECKING, Optional
+from typing import Any, TYPE_CHECKING, Optional
 
 from .output import error, debug
 
@@ -47,10 +47,10 @@ class TranslationHandler:
 		self._translated_languages = self._get_translations()
 
 	@property
-	def translated_languages(self) -> List[Language]:
+	def translated_languages(self) -> list[Language]:
 		return self._translated_languages
 
-	def _get_translations(self) -> List[Language]:
+	def _get_translations(self) -> list[Language]:
 		"""
 		Load all translated languages and return a list of such
 		"""
@@ -60,7 +60,7 @@ class TranslationHandler:
 		languages = []
 
 		for short_form in defined_languages:
-			mapping_entry: Dict[str, Any] = next(filter(lambda x: x['abbr'] == short_form, mappings))
+			mapping_entry: dict[str, Any] = next(filter(lambda x: x['abbr'] == short_form, mappings))
 			abbr = mapping_entry['abbr']
 			lang = mapping_entry['lang']
 			translated_lang = mapping_entry.get('translated_lang', None)
@@ -96,7 +96,7 @@ class TranslationHandler:
 		except Exception:
 			error(f'Unable to set font {font}')
 
-	def _load_language_mappings(self) -> List[Dict[str, Any]]:
+	def _load_language_mappings(self) -> list[dict[str, Any]]:
 		"""
 		Load the mapping table of all known languages
 		"""
@@ -159,7 +159,7 @@ class TranslationHandler:
 		locales_dir = Path.joinpath(cur_path, 'locales')
 		return locales_dir
 
-	def _provided_translations(self) -> List[str]:
+	def _provided_translations(self) -> list[str]:
 		"""
 		Get a list of all known languages
 		"""

--- a/archinstall/lib/utils/singleton.py
+++ b/archinstall/lib/utils/singleton.py
@@ -1,9 +1,9 @@
-from typing import Dict, Any
+from typing import Any
 
 
 class _Singleton(type):
 	""" A metaclass that creates a Singleton base class when called. """
-	_instances: Dict[Any, Any] = {}
+	_instances: dict[Any, Any] = {}
 
 	def __call__(cls, *args, **kwargs):
 		if cls not in cls._instances:


### PR DESCRIPTION
## PR Description:

`typing.Dict` and `typing.List` are deprecated:
- https://docs.python.org/3/library/typing.html#typing.Dict
- https://docs.python.org/3/library/typing.html#typing.List
- https://docs.astral.sh/ruff/rules/deprecated-import/

This PR doesn't touch menu-related code to avoid merge conflicts with #2663.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
