### PR TITLE
Remove lsblk default columns

### DIFF
--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -1425,7 +1425,7 @@ def _fetch_lsblk_info(
 	full_dev_path: bool = False
 ) -> List[LsblkInfo]:
 	fields = [_clean_field(f, CleanType.Lsblk) for f in LsblkInfo.fields()]
-	cmd = ['lsblk', '--json', '--bytes', '--output', '+' + ','.join(fields)]
+	cmd = ['lsblk', '--json', '--bytes', '--output', ','.join(fields)]
 
 	if reverse:
 		cmd.append('--inverse')


### PR DESCRIPTION
There is no need for the default columns because `LsblkInfo` fields are the only to be parsed and they are passed to lsblk explicitly.

Excerpt from [lsblk(8)](https://man.archlinux.org/man/lsblk.8):

> The default list of columns may be extended if _list_ is specified in the format +_list_ (e.g., **lsblk -o +UUI**D).
