### PR TITLE
Fix PyPI name and installing from, in python.rst

### DIFF
--- a/docs/installing/python.rst
+++ b/docs/installing/python.rst
@@ -23,10 +23,10 @@ To install both the library and the archinstall script:
 
 Alternatively, you can install only the library and not the helper executable using the ``python-archinstall`` package.
 
-Installing with PyPi
+Installing from PyPI
 --------------------
 
-The basic concept of PyPi applies using `pip`.
+The basic concept of PyPI applies using `pip`.
 
 .. code-block:: console
 


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

This is a low-priority contribution to fix two things in the docs:
- PyPI is the name, not PyPi, as can be seen in https://pypi.org
- Fix section title to "Installing from PyPI" not "with PyPI". The package manager is named "pip", while PyPI is the public repository powered by PyPA's [warehouse](https://github.com/pypa/warehouse/) software.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
