### PR TITLE
Do not try to update github-pages on pull_request

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,7 +31,7 @@ jobs:
           sphinx-build docs _build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
-      #  if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

When a pull request is created, the github-pages.yml workflow file builds the docs and tries to update the published docs. It fails with:

```
remote: Permission to archlinux/archinstall.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/archlinux/archinstall.git/': The requested URL returned error: 403
Error: Action failed with "The process '/usr/sbin/git' failed with exit code 128"
```

See [this](https://github.com/archlinux/archinstall/actions/runs/11129933702/job/30928163240) example.

This adds condition to not run "Deploy to GitHub Pages" step on pull requests

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
