### PR TITLE
Fix 2735 - Erase luks partition explicitly

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -803,6 +803,10 @@ class DeviceHandler(object):
 		"""
 		info(f'Wiping partitions and metadata: {block_device.device_info.path}')
 		for partition in block_device.partition_infos:
+			luks = Luks2(partition.path)
+			if luks.isLuks():
+				luks.erase()
+
 			self._wipe(partition.path)
 
 		self._wipe(block_device.device_info.path)

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -30,6 +30,19 @@ class Luks2:
 			return Path(f'/dev/mapper/{self.mapper_name}')
 		return None
 
+	def isLuks(self) -> bool:
+		try:
+			SysCommand(f'cryptsetup isLuks {self.luks_dev_path}')
+			return True
+		except SysCallError:
+			return False
+
+	def erase(self) -> None:
+		debug(f'Erasing luks partition: {self.luks_dev_path}')
+		worker = SysCommandWorker(f'cryptsetup erase {self.luks_dev_path}')
+		worker.poll()
+		worker.write(b'YES\n', line_ending=False)
+
 	def __post_init__(self) -> None:
 		if self.luks_dev_path is None:
 			raise ValueError('Partition must have a path set')


### PR DESCRIPTION
This should fix #2735 . 
On wipe, first it will check if the partition is a luks partition and if so it will perform a `cryptsetup erase` which should delete the luks headers correctly. 