### PR TITLE
Add auto-merge for dev tools

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,23 @@
   ],
   "pre-commit": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchPackageNames": [
+        "mypy",
+        "ruff",
+        "pre-commit",
+        "pre-commit/pre-commit-hooks",
+        "pre-commit/mirrors-mypy",
+        "dev/flake8",
+        "pycqa/flake8",
+        "astral-sh/ruff-pre-commit"
+      ],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
For dev tool packages, if they pass the tests they should be save to auto-merge. 
@Torxed this may require this setting to be toggled https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository#managing-auto-merge