### PR TITLE
Update config-sample.json to comply with the requirements for version 2.8.6

### DIFF
--- a/examples/config-sample.json
+++ b/examples/config-sample.json
@@ -1,5 +1,6 @@
 {
-    "config_version": "2.5.2",
+    "__separator__": null,
+    "config_version": "2.8.6",
     "additional-repositories": [],
     "archinstall-language": "English",
     "audio_config": {"audio": "pipewire"},
@@ -82,19 +83,29 @@
     "kernels": [
         "linux"
     ],
-    "keyboard-layout": "us",
-    "mirror-region": {
-        "Australia": {
-            "http://archlinux.mirror.digitalpacific.com.au/$repo/os/$arch": true,
-        }
+    "locale_config": {
+      "kb_layout": "us",
+      "sys_enc": "UTF-8",
+      "sys_lang": "en_US"
     },
-    "nic": {
-        "dhcp": true,
-        "dns": null,
-        "gateway": null,
-        "iface": null,
-        "ip": null,
-        "type": "nm"
+    "mirror_config": {
+      "mirror-regions": {
+        "Australia": [
+          "http://archlinux.mirror.digitalpacific.com.au/$repo/os/$arch"
+        ]
+      }
+    },
+    "network_config": {
+      "type": "manual",
+      "nics": [
+        {
+          "iface": null,
+          "ip": null,
+          "dhcp": true,
+          "gateway": null,
+          "dns": null
+        }
+      ]
     },
     "no_pkg_lookups": false,
     "ntp": true,
@@ -114,8 +125,6 @@
     "script": "guided",
     "silent": false,
     "swap": true,
-    "sys-encoding": "utf-8",
-    "sys-language": "en_US",
     "timezone": "UTC",
-    "version": "2.5.2"
+    "version": "2.8.6"
 }


### PR DESCRIPTION
I did not add the 'dev_path' key to each one of the partitions, as this may not be required in the 'default_layout' section, but it was required in my configuration when I chose 'manual_partitioning'.

- This fix issue: -

## PR Description:

This is merely a documentation update. I struggled a lot to find usable config.json files on the interwebs, andI want to contribute to this project with a config.json file that resembles my working file (I did not want to change the setup to a Server install, but glad to upload another config.json to showcase other options)

## Tests and Checks
- [X] I have tested the code!<br>
