### PR TITLE
Enable the self-assigning-variable Pylint warning

### DIFF
--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -107,7 +107,6 @@ class Selector:
 		if current:
 			padding += 5
 			description = unicode_ljust(str(self.description), padding, ' ')
-			current = current
 		else:
 			description = self.description
 			current = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,6 @@ disable = [
     "raise-missing-from",
     "redefined-builtin",
     "redefined-outer-name",
-    "self-assigning-variable",
     "unnecessary-lambda",
     "unreachable",
     "unspecified-encoding",


### PR DESCRIPTION
## PR Description:

This PR fixes the following warning:
```
************* Module archinstall.lib.menu.abstract_menu
archinstall/lib/menu/abstract_menu.py:110:3: W0127: Assigning the same variable 'current' to itself (self-assigning-variable)
```

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
