### PR TITLE
Wait for LVM info to appear

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -368,13 +368,11 @@ class DeviceHandler(object):
 		return None
 
 	def _lvm_info_with_retry(self, cmd: str, info_type: Literal['lv', 'vg', 'pvseg']) -> Optional[Any]:
-		attempts = 3
-
-		for attempt_nr in range(attempts):
+		while True:
 			try:
 				return self._lvm_info(cmd, info_type)
 			except ValueError:
-				time.sleep(attempt_nr + 1)
+				time.sleep(3)
 
 		raise ValueError(f'Failed to fetch {info_type} information')
 

--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -374,8 +374,6 @@ class DeviceHandler(object):
 			except ValueError:
 				time.sleep(3)
 
-		raise ValueError(f'Failed to fetch {info_type} information')
-
 	def lvm_vol_info(self, lv_name: str) -> Optional[LvmVolumeInfo]:
 		cmd = (
 			'lvs --reportformat json '


### PR DESCRIPTION
It seems that creating LVM resources will take some time depending on the system.
This PR will make the info call wait forever for the LVM info to appear, this is a hacky attempt to fix #2687 