### PR TITLE
Include xss-set when installing i3wm

### DIFF
--- a/archinstall/default_profiles/desktops/i3.py
+++ b/archinstall/default_profiles/desktops/i3.py
@@ -18,6 +18,7 @@ class I3wmProfile(XorgProfile):
 			'i3lock',
 			'i3status',
 			'i3blocks',
+			'xss-set',
 			'xterm',
 			'lightdm-gtk-greeter',
 			'lightdm',


### PR DESCRIPTION
- This fixes issue: https://github.com/archlinux/archinstall/issues/2790



## PR Description:

xss-set is needed for the default i3 config to lock the screen before sleep
This PR adds xss-set to the list of installed packages

## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
