### PR TITLE
Package name correction 'xss-lock', i3.py

### DIFF
--- a/archinstall/default_profiles/desktops/i3.py
+++ b/archinstall/default_profiles/desktops/i3.py
@@ -18,7 +18,7 @@ class I3wmProfile(XorgProfile):
 			'i3lock',
 			'i3status',
 			'i3blocks',
-			'xss-set',
+			'xss-lock',
 			'xterm',
 			'lightdm-gtk-greeter',
 			'lightdm',


### PR DESCRIPTION
- This fix issue: https://github.com/archlinux/archinstall/issues/2790
- Pull with incorrect package name: https://github.com/archlinux/archinstall/pull/2791

## PR Description:
Package name correction 'xss-lock' needed in the base installation of the i3 desktop.
Man: https://man.archlinux.org/man/xss-lock.1
Error log: https://0x0.st/XkrA.log

## Tests and Checks
- [x] I have tested the code!<br>
