### PR TITLE
Add Teaching Mode as a CLI Flag

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -74,6 +74,8 @@ def define_arguments() -> None:
 	parser.add_argument("-v", "--version", action="version", version="%(prog)s " + __version__)
 	parser.add_argument("--config", nargs="?", help="JSON configuration file or URL")
 	parser.add_argument("--creds", nargs="?", help="JSON credentials configuration file")
+	parser.add_argument("--teach", action="store_true", default=False,
+						help="Teaching mode. Echoes all subprocess commands to the screen with a short pause after each. Useful for understanding what goes on under the hood.")
 	parser.add_argument("--silent", action="store_true",
 						help="WARNING: Disables all prompts for input and confirmation. If no configuration is provided, this is ignored")
 	parser.add_argument("--dry-run", "--dry_run", action="store_true",
@@ -323,6 +325,8 @@ def main() -> None:
 	script = arguments.get('script', None)
 
 	if script is None:
+		# `script` is typically passed in from ArgumentParser,
+		# which comes with a default value.
 		print('No script to run provided')
 
 	mod_name = f'archinstall.scripts.{script}'

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -21,7 +21,7 @@ from select import epoll, EPOLLIN, EPOLLHUP
 from shutil import which
 
 from .exceptions import RequirementError, SysCallError
-from .output import debug, error, info
+from .output import debug, error, info, Teacher
 from .storage import storage
 
 
@@ -412,6 +412,11 @@ class SysCommand:
 		"""
 		if self.session:
 			return True
+
+		if storage.get('arguments', {}).get('teach'):
+			# Call Teacher here (before worker starts), so that its stdout
+			# does not get in the way of JSON parsing the output from SysCommandWorker
+			Teacher.teach(self.cmd)
 
 		with SysCommandWorker(
 			self.cmd,

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -258,7 +258,6 @@ def _stylize_output(
 	return f'\033[{ansi}m{text}\033[0m'
 
 
-
 class Teacher:
 	"""
 	Used to support the --teach command line argument
@@ -278,7 +277,7 @@ class Teacher:
 	COUNT = 1
 
 	@classmethod
-	def initialize(cls):
+	def initialize(cls) -> None:
 		"""
 		Enable teacher mode.
 
@@ -302,11 +301,11 @@ class Teacher:
 ''')
 
 	@classmethod
-	def is_disabled(cls):
+	def is_disabled(cls) -> bool:
 		return not cls.ENABLED
 
 	@classmethod
-	def teach(cls, command: str) -> None:
+	def teach(cls, command: str | list[str]) -> None:
 		"""
 		Display command and sleep for a few seconds
 
@@ -320,7 +319,6 @@ class Teacher:
 
 		command_str = command if isinstance(command, str) else ' '.join([str(x) for x in command])
 
-
 		text = f'\nCOMMAND {cls.COUNT}:\n{cls.LEFT_PAD}{command_str}\n\n\n'
 		cls.emit(text)
 
@@ -329,7 +327,7 @@ class Teacher:
 		cls.COUNT += 1
 
 	@classmethod
-	def emit(cls, text: str ) -> None:
+	def emit(cls, text: str) -> None:
 		"""
 		Print the output to the screen with color
 		"""
@@ -456,5 +454,4 @@ def unicode_rjust(string: str, width: int, fillbyte: str = ' ') -> str:
 
 # Import at the end of the file instead of the beginning
 # to avoid a circular import
-from .menu import Menu
-
+from .menu import Menu  # noqa: E402

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -13,6 +13,7 @@ from archinstall.lib.menu import Menu
 from archinstall.lib.models import AudioConfiguration, Bootloader
 from archinstall.lib.models.network_configuration import NetworkConfiguration
 from archinstall.lib.profile.profiles_handler import profile_handler
+from archinstall.lib.output import Teacher
 
 if TYPE_CHECKING:
 	_: Any
@@ -104,6 +105,12 @@ def perform_installation(mountpoint: Path) -> None:
 	formatted and setup prior to entering this function.
 	"""
 	info('Starting installation...')
+
+	# Teacher is initialized only after we start installation to avoid
+	# lots of messages during menu startup
+	if archinstall.storage.get('arguments', {}).get('teach'):
+		Teacher.initialize()
+
 	disk_config: disk.DiskLayoutConfiguration = archinstall.arguments['disk_config']
 
 	# Retrieve list of additional repositories and set boolean values appropriately


### PR DESCRIPTION

## PR Description:

Adds a flag through ArgParser for `--teach`, which does the following:

1. Echo each subprocess command to the screen (but only after installation actually begins)
2. Wait for a few seconds before actually running the command so the user has a chance to grok what's going on


## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
