### PR TITLE
When no options provided, mention that options are available

### DIFF
--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -1,4 +1,6 @@
+import sys
 from pathlib import Path
+from time import sleep
 from typing import Any, TYPE_CHECKING, Optional
 
 import archinstall
@@ -219,6 +221,11 @@ def perform_installation(mountpoint: Path) -> None:
 
 	debug(f"Disk states after installing: {disk.disk_layouts()}")
 
+
+if len(sys.argv) == 1:
+	# Make it obvious that there are options you can pass
+	info('Additional command-line options are available. See `archinstall --help`.')
+	sleep(4)
 
 if not archinstall.arguments.get('silent'):
 	ask_user_questions()


### PR DESCRIPTION


## PR Description:

When I first started using archinstall I hadn't thought to check to see if there were options I could pass it on the command line. It turns out these options are needed in order to load a config file from disk. So this PR points out that there are options available. (But it only points them out if no options were passed. This way when people are already using options, they don't see either the notice or get the delay.)


## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->

See the bottom of this screenshot for what you get with this PR when you call `python -m archinstall` with no options:
![2024-11-14 14 43 09](https://github.com/user-attachments/assets/bb95745f-e9b7-44bc-bb95-7ad89070c3a6)


