### PR TITLE
Add clarity to help menu

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -73,12 +73,12 @@ def define_arguments() -> None:
 	"""
 	parser.add_argument("-v", "--version", action="version", version="%(prog)s " + __version__)
 	parser.add_argument("--config", nargs="?", help="JSON configuration file or URL")
-	parser.add_argument("--creds", nargs="?", help="JSON credentials configuration file")
+	parser.add_argument("--creds", nargs="?", help="JSON credentials file or URL")
 	parser.add_argument("--silent", action="store_true",
 						help="WARNING: Disables all prompts for input and confirmation. If no configuration is provided, this is ignored")
 	parser.add_argument("--dry-run", "--dry_run", action="store_true",
 						help="Generates a configuration file and then exits instead of performing an installation")
-	parser.add_argument("--script", default="guided", nargs="?", help="Script to run for installation", type=str)
+	parser.add_argument("--script", default="guided", nargs="?", help="Script to run for installation. Default: guided", type=str)
 	parser.add_argument("--mount-point", "--mount_point", nargs="?", type=str,
 						help="Define an alternate mount point for installation")
 	parser.add_argument("--skip-ntp", action="store_true", help="Disables NTP checks during installation", default=False)


### PR DESCRIPTION


## PR Description:

The first few times I used the --config and --creds options with archinstall, I didn't even notice that the help menu said you could use a URL instead of a local file. This PR is intended to make that just a bit more obvious.



## Tests and Checks
- [ ] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->

Here is a screenshot of the menu options using this branch:
![2024-11-14 14 43 48](https://github.com/user-attachments/assets/2ae0a14b-9cdf-453c-9481-10033eb1cf0e)
