### PR TITLE
Add helpful tips for saving config files in a directory

### DIFF
--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -152,8 +152,8 @@ def save_config(config: Dict) -> None:
 Into which DIRECTORY should the configuration(s) be saved?
 
 	TIPS
-	1. Tab completion is enabled to help you locate a full directory name.
-	2. To persist a configuration file through a reboot, mount a separate drive before running `archinstall`.
+	1. Tab completion is enabled to help you locate a full directory name
+	2. To persist a configuration file through a reboot, mount a separate drive before running `archinstall`
 	3. If you are not sure what to choose, try "." or "/"
 
 Save Directory:  '''

--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -148,7 +148,15 @@ def save_config(config: Dict) -> None:
 		while True:
 			path = input(
 				_(
-					'Into which DIRECTORY should the configuration(s) be saved?\n\n    TIPS\n    1. Tab completion is enabled to help you locate a full directory name.\n    2. To persist a configuration file through a reboot, mount a separate drive before running `archinstall`.\n    3. If you are not sure what to choose, try "." or "/"\n\nSave Directory:  '
+					'''\
+Into which DIRECTORY should the configuration(s) be saved?
+
+	TIPS
+	1. Tab completion is enabled to help you locate a full directory name.
+	2. To persist a configuration file through a reboot, mount a separate drive before running `archinstall`.
+	3. If you are not sure what to choose, try "." or "/"
+
+Save Directory:  '''
 				)
 			).strip(" ")
 			dest_path = Path(path)

--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -148,7 +148,7 @@ def save_config(config: Dict) -> None:
 		while True:
 			path = input(
 				_(
-					"Enter a directory for the configuration(s) to be saved (tab completion enabled)\nSave directory: "
+					'Into which DIRECTORY should the configuration(s) be saved?\n\n    TIPS\n    1. Tab completion is enabled to help you locate a full directory name.\n    2. To persist a configuration file through a reboot, mount a separate drive before running `archinstall`.\n    3. If you are not sure what to choose, try "." or "/"\n\nSave Directory:  '
 				)
 			).strip(" ")
 			dest_path = Path(path)


### PR DESCRIPTION
## PR Description

The first few times I used archinstall, I struggled with saving config files to a directory. It sounds easy, I know. But at the time I kept getting errors and finally gave up saving any config files at all. 

This PR makes it obvious why tab-completion is a boon in this scenario. It also gives a couple useful working locations, and it clarifies that extra steps are needed if you want your config files to persist through a boot cycle.

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

Here is a screenshot showing the updated text:
![2024-11-14 15 42 46](https://github.com/user-attachments/assets/9f3b3a8f-302a-4f5e-962e-3cdc15739343)



## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
