### PR TITLE
Notify user of LOG_PATH upon completion

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -111,7 +111,7 @@ class Installer:
 			raise exc_val
 
 		if not (missing_steps := self.post_install_check()):
-			log('Installation completed without any errors. You may now reboot.', fg='green')
+			log(f'Installation completed without any errors.\nLog files temporarily available at {storage["LOG_PATH"]}.\nYou may reboot when ready.\n', fg='green')
 			self.sync_log_to_install_medium()
 			return True
 		else:


### PR DESCRIPTION
## PR Description

The first ten or twenty times or so that I used archinstall, I had no idea where to find the log files. This PR points the user to the log directory after the install completes. 

Here is a screenshot of this PR's output when the install completes:
![2024-11-14 14 06 54](https://github.com/user-attachments/assets/2637e0a3-7c39-4eca-b29a-5c3c332828b2)


## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
