### PR TITLE
Warn user when UEFI is disabled

### DIFF
--- a/archinstall/lib/interactions/system_conf.py
+++ b/archinstall/lib/interactions/system_conf.py
@@ -55,9 +55,11 @@ def ask_for_bootloader(preset: Optional[Bootloader]) -> Optional[Bootloader]:
 	if not SysInfo.has_uefi():
 		options = [Bootloader.Grub, Bootloader.Limine]
 		default = Bootloader.Grub
+		header = str(_('UEFI is not detected and some options are disabled'))
 	else:
 		options = [b for b in Bootloader]
 		default = Bootloader.Systemd
+		header = None
 
 	items = [MenuItem(o.value, value=o) for o in options]
 	group = MenuItemGroup(items)
@@ -66,6 +68,7 @@ def ask_for_bootloader(preset: Optional[Bootloader]) -> Optional[Bootloader]:
 
 	result = SelectMenu(
 		group,
+		header=header,
 		alignment=Alignment.CENTER,
 		frame=FrameProperties.min(str(_('Bootloader'))),
 		allow_skip=True


### PR DESCRIPTION
## PR Description:

Recently I've accidentally booted in legacy mode and spent half an hour trying to figure out why there are only grub and limine boot managers available. Simple warning does fix that.

## Tests and Checks

The code is quite simple, and i've manually tested both variants.
