### PR TITLE
Enable the expression-not-assigned Pylint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ disable = [
     "cell-var-from-loop",
     "comparison-with-callable",
     "dangerous-default-value",
-    "expression-not-assigned",
     "f-string-without-interpolation",
     "fixme",
     "protected-access",


### PR DESCRIPTION
## PR Description:

Commit 88b91ae201e0 fixed the last instance that existed in the codebase:

```
archinstall/lib/interactions/general_conf.py:178:4: W0106: Expression "fwrite.write(f'ParallelDownloads = {input_number}\n') if not input_number == 0 else fwrite.write('#ParallelDownloads = 0\n')" is assigned to nothing (expression-not-assigned)
```

Docs
- https://pylint.pycqa.org/en/latest/user_guide/messages/warning/expression-not-assigned.html

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
