### PR TITLE
Remove most deprecated typing.List usage

### DIFF
--- a/archinstall/default_profiles/desktop.py
+++ b/archinstall/default_profiles/desktop.py
@@ -1,4 +1,4 @@
-from typing import Any, TYPE_CHECKING, List, Optional, Dict
+from typing import Any, TYPE_CHECKING, Optional, Dict
 
 from archinstall.lib.output import info
 from archinstall.lib.profile.profiles_handler import profile_handler
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class DesktopProfile(Profile):
-	def __init__(self, current_selection: List[Profile] = []) -> None:
+	def __init__(self, current_selection: list[Profile] = []) -> None:
 		super().__init__(
 			'Desktop',
 			ProfileType.Desktop,
@@ -25,7 +25,7 @@ class DesktopProfile(Profile):
 		)
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			'nano',
 			'vim',

--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional, TYPE_CHECKING, Any
+from typing import Optional, TYPE_CHECKING, Any
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType, SelectResult
 from archinstall.default_profiles.xorg import XorgProfile
@@ -25,7 +25,7 @@ class HyprlandProfile(XorgProfile):
 		self.custom_settings = {'seat_access': None}
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		return [
 			"hyprland",
 			"dunst",
@@ -45,7 +45,7 @@ class HyprlandProfile(XorgProfile):
 		return GreeterType.Sddm
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		if pref := self.custom_settings.get('seat_access', None):
 			return [pref]
 		return []

--- a/archinstall/default_profiles/desktops/sway.py
+++ b/archinstall/default_profiles/desktops/sway.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional, TYPE_CHECKING, Any
+from typing import Optional, TYPE_CHECKING, Any
 
 from archinstall.default_profiles.profile import ProfileType, GreeterType, SelectResult
 from archinstall.default_profiles.xorg import XorgProfile
@@ -30,7 +30,7 @@ class SwayProfile(XorgProfile):
 		self.custom_settings = {'seat_access': None}
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		additional = []
 		if seat := self.custom_settings.get('seat_access', None):
 			additional = [seat]
@@ -55,7 +55,7 @@ class SwayProfile(XorgProfile):
 		return GreeterType.Lightdm
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		if pref := self.custom_settings.get('seat_access', None):
 			return [pref]
 		return []

--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from enum import Enum, auto
-from typing import List, Optional, Any, Dict, TYPE_CHECKING
+from typing import Optional, Any, Dict, TYPE_CHECKING
 
 from ..lib.storage import storage
 
@@ -52,9 +52,9 @@ class Profile:
 		name: str,
 		profile_type: ProfileType,
 		description: str = '',
-		current_selection: List[Profile] = [],
-		packages: List[str] = [],
-		services: List[str] = [],
+		current_selection: list[Profile] = [],
+		packages: list[str] = [],
+		services: list[str] = [],
 		support_gfx_driver: bool = False,
 		support_greeter: bool = False,
 		advanced: bool = False
@@ -78,7 +78,7 @@ class Profile:
 		self.custom_enabled = False
 
 	@property
-	def packages(self) -> List[str]:
+	def packages(self) -> list[str]:
 		"""
 		Returns a list of packages that should be installed when
 		this profile is among the chosen ones
@@ -86,7 +86,7 @@ class Profile:
 		return self._packages
 
 	@property
-	def services(self) -> List[str]:
+	def services(self) -> list[str]:
 		"""
 		Returns a list of services that should be enabled when
 		this profile is among the chosen ones
@@ -139,7 +139,7 @@ class Profile:
 		"""
 		self.custom_settings = settings
 
-	def current_selection_names(self) -> List[str]:
+	def current_selection_names(self) -> list[str]:
 		if self.current_selection:
 			return [s.name for s in self.current_selection]
 		return []

--- a/archinstall/default_profiles/server.py
+++ b/archinstall/default_profiles/server.py
@@ -1,4 +1,4 @@
-from typing import Any, TYPE_CHECKING, List, Optional
+from typing import Any, TYPE_CHECKING, Optional
 
 from archinstall.lib.output import info
 from archinstall.lib.profile.profiles_handler import profile_handler
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class ServerProfile(Profile):
-	def __init__(self, current_value: List[Profile] = []):
+	def __init__(self, current_value: list[Profile] = []):
 		super().__init__(
 			'Server',
 			ProfileType.Server,

--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any, TYPE_CHECKING, List
+from typing import Dict, Optional, Any, TYPE_CHECKING
 
 from . import DiskLayoutConfiguration, DiskLayoutType
 from .device_model import LvmConfiguration
@@ -33,7 +33,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu):
 
 		super().__init__(self._item_group, data_store=self._data_store, allow_reset=True)
 
-	def _define_menu_options(self) -> List[MenuItem]:
+	def _define_menu_options(self) -> list[MenuItem]:
 		return [
 			MenuItem(
 				text=str(_('Partitioning')),
@@ -100,7 +100,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu):
 			msg += str(_('Mountpoint')) + ': ' + str(disk_layout_conf.mountpoint)
 			return msg
 
-		device_mods: List[DeviceModification] = \
+		device_mods: list[DeviceModification] = \
 			list(filter(lambda x: len(x.partitions) > 0, disk_layout_conf.device_modifications))
 
 		if device_mods:

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Optional, Any, TYPE_CHECKING, List
+from typing import Dict, Optional, Any, TYPE_CHECKING
 
 from . import LvmConfiguration, LvmVolume
 from ..disk import (
@@ -44,7 +44,7 @@ class DiskEncryptionMenu(AbstractSubMenu):
 
 		super().__init__(self._item_group, data_store=self._data_store, allow_reset=True)
 
-	def _define_menu_options(self) -> List[MenuItem]:
+	def _define_menu_options(self) -> list[MenuItem]:
 		return [
 			MenuItem(
 				text=str(_('Encryption type')),
@@ -87,7 +87,7 @@ class DiskEncryptionMenu(AbstractSubMenu):
 			),
 		]
 
-	def _select_lvm_vols(self, preset: List[LvmVolume]) -> List[LvmVolume]:
+	def _select_lvm_vols(self, preset: list[LvmVolume]) -> list[LvmVolume]:
 		if self._disk_config.lvm_config:
 			return select_lvm_vols_to_encrypt(self._disk_config.lvm_config, preset=preset)
 		return []
@@ -181,7 +181,7 @@ class DiskEncryptionMenu(AbstractSubMenu):
 		return None
 
 	def _prev_partitions(self) -> Optional[str]:
-		partitions: Optional[List[PartitionModification]] = self._item_group.find_by_key('partitions').value
+		partitions: Optional[list[PartitionModification]] = self._item_group.find_by_key('partitions').value
 
 		if partitions:
 			output = str(_('Partitions to be encrypted')) + '\n'
@@ -191,7 +191,7 @@ class DiskEncryptionMenu(AbstractSubMenu):
 		return None
 
 	def _prev_lvm_vols(self) -> Optional[str]:
-		volumes: Optional[List[PartitionModification]] = self._item_group.find_by_key('lvm_vols').value
+		volumes: Optional[list[PartitionModification]] = self._item_group.find_by_key('lvm_vols').value
 
 		if volumes:
 			output = str(_('LVM volumes to be encrypted')) + '\n'
@@ -212,7 +212,7 @@ class DiskEncryptionMenu(AbstractSubMenu):
 
 
 def select_encryption_type(disk_config: DiskLayoutConfiguration, preset: EncryptionType) -> Optional[EncryptionType]:
-	options: List[EncryptionType] = []
+	options: list[EncryptionType] = []
 	preset_value = EncryptionType.type_to_text(preset)
 
 	if disk_config.lvm_config:
@@ -278,10 +278,10 @@ def select_hsm(preset: Optional[Fido2Device] = None) -> Optional[Fido2Device]:
 
 
 def select_partitions_to_encrypt(
-	modification: List[DeviceModification],
-	preset: List[PartitionModification]
-) -> List[PartitionModification]:
-	partitions: List[PartitionModification] = []
+	modification: list[DeviceModification],
+	preset: list[PartitionModification]
+) -> list[PartitionModification]:
+	partitions: list[PartitionModification] = []
 
 	# do not allow encrypting the boot partition
 	for mod in modification:
@@ -312,9 +312,9 @@ def select_partitions_to_encrypt(
 
 def select_lvm_vols_to_encrypt(
 	lvm_config: LvmConfiguration,
-	preset: List[LvmVolume]
-) -> List[LvmVolume]:
-	volumes: List[LvmVolume] = lvm_config.get_all_volumes()
+	preset: list[LvmVolume]
+) -> list[LvmVolume]:
+	volumes: list[LvmVolume] = lvm_config.get_all_volumes()
 
 	if volumes:
 		group, header = MenuHelper.create_table(data=volumes)

--- a/archinstall/lib/disk/fido.py
+++ b/archinstall/lib/disk/fido.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import getpass
 from pathlib import Path
-from typing import List
 
 from .device_model import Fido2Device
 from ..general import SysCommand, SysCommandWorker, clear_vt100_escape_codes
@@ -12,10 +11,10 @@ from ..exceptions import SysCallError
 
 class Fido2:
 	_loaded: bool = False
-	_fido2_devices: List[Fido2Device] = []
+	_fido2_devices: list[Fido2Device] = []
 
 	@classmethod
-	def get_fido2_devices(cls, reload: bool = False) -> List[Fido2Device]:
+	def get_fido2_devices(cls, reload: bool = False) -> list[Fido2Device]:
 		"""
 		Uses systemd-cryptenroll to list the FIDO2 devices
 		connected that supports FIDO2.

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Any, Optional, TYPE_CHECKING, List, Dict, Set
+from typing import Any, Optional, TYPE_CHECKING, Dict, Set
 
 from ..interactions.general_conf import ask_abort
 from .device_handler import device_handler
@@ -85,7 +85,7 @@ class FilesystemHandler:
 
 	def _format_partitions(
 		self,
-		partitions: List[PartitionModification],
+		partitions: list[PartitionModification],
 		device_path: Path
 	) -> None:
 		"""
@@ -119,7 +119,7 @@ class FilesystemHandler:
 			part_mod.partuuid = lsblk_info.partuuid
 			part_mod.uuid = lsblk_info.uuid
 
-	def _validate_partitions(self, partitions: List[PartitionModification]) -> None:
+	def _validate_partitions(self, partitions: list[PartitionModification]) -> None:
 		checks = {
 			# verify that all partitions have a path set (which implies that they have been created)
 			lambda x: x.dev_path is None: ValueError('When formatting, all partitions must have a path set'),
@@ -260,7 +260,7 @@ class FilesystemHandler:
 
 	def _get_all_pv_dev_paths(
 		self,
-		pvs: List[PartitionModification],
+		pvs: list[PartitionModification],
 		enc_mods: Dict[PartitionModification, Luks2] = {}
 	) -> Set[Path]:
 		pv_paths: Set[Path] = set()

--- a/archinstall/lib/disk/partitioning_menu.py
+++ b/archinstall/lib/disk/partitioning_menu.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, TYPE_CHECKING, List, Optional, Tuple
+from typing import Any, TYPE_CHECKING, Optional, Tuple
 from dataclasses import dataclass
 
 from ..utils.util import prompt_dir
@@ -33,7 +33,7 @@ class DefaultFreeSector:
 
 
 class PartitioningList(ListManager):
-	def __init__(self, prompt: str, device: BDevice, device_partitions: List[PartitionModification]):
+	def __init__(self, prompt: str, device: BDevice, device_partitions: list[PartitionModification]):
 		self._device = device
 		self._actions = {
 			'create_new_partition': str(_('Create a new partition')),
@@ -58,7 +58,7 @@ class PartitioningList(ListManager):
 		else:
 			return str(partition.dev_path)
 
-	def filter_options(self, selection: PartitionModification, options: List[str]) -> List[str]:
+	def filter_options(self, selection: PartitionModification, options: list[str]) -> list[str]:
 		not_filter = []
 
 		# only display formatting if the partition exists already
@@ -94,8 +94,8 @@ class PartitioningList(ListManager):
 		self,
 		action: str,
 		entry: Optional[PartitionModification],
-		data: List[PartitionModification]
-	) -> List[PartitionModification]:
+		data: list[PartitionModification]
+	) -> list[PartitionModification]:
 		action_key = [k for k, v in self._actions.items() if v == action][0]
 
 		match action_key:
@@ -142,8 +142,8 @@ class PartitioningList(ListManager):
 	def _delete_partition(
 		self,
 		entry: PartitionModification,
-		data: List[PartitionModification]
-	) -> List[PartitionModification]:
+		data: list[PartitionModification]
+	) -> list[PartitionModification]:
 		if entry.is_exists_or_modify():
 			entry.status = ModificationStatus.Delete
 			return data
@@ -421,7 +421,7 @@ class PartitioningList(ListManager):
 
 		return result.item() == MenuItem.yes()
 
-	def _suggest_partition_layout(self, data: List[PartitionModification]) -> List[PartitionModification]:
+	def _suggest_partition_layout(self, data: list[PartitionModification]) -> list[PartitionModification]:
 		# if modifications have been done already, inform the user
 		# that this operation will erase those modifications
 		if any([not entry.exists() for entry in data]):
@@ -437,8 +437,8 @@ class PartitioningList(ListManager):
 def manual_partitioning(
 	device: BDevice,
 	prompt: str = '',
-	preset: List[PartitionModification] = []
-) -> List[PartitionModification]:
+	preset: list[PartitionModification] = []
+) -> list[PartitionModification]:
 	if not prompt:
 		prompt = str(_('Partition management: {}')).format(device.device_info.path) + '\n'
 		prompt += str(_('Total length: {}')).format(device.device_info.total_size.format_size(Unit.MiB))
@@ -455,7 +455,7 @@ def manual_partitioning(
 		manual_preset = preset
 
 	menu_list = PartitioningList(prompt, device, manual_preset)
-	partitions: List[PartitionModification] = menu_list.run()
+	partitions: list[PartitionModification] = menu_list.run()
 
 	if menu_list.is_last_choice_cancel():
 		return preset

--- a/archinstall/lib/disk/subvolume_menu.py
+++ b/archinstall/lib/disk/subvolume_menu.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from .device_model import SubvolumeModification
 from ..menu import ListManager
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class SubvolumeMenu(ListManager):
-	def __init__(self, prompt: str, btrfs_subvols: List[SubvolumeModification]):
+	def __init__(self, prompt: str, btrfs_subvols: list[SubvolumeModification]):
 		self._actions = [
 			str(_('Add subvolume')),
 			str(_('Edit subvolume')),
@@ -58,8 +58,8 @@ class SubvolumeMenu(ListManager):
 		self,
 		action: str,
 		entry: Optional[SubvolumeModification],
-		data: List[SubvolumeModification]
-	) -> List[SubvolumeModification]:
+		data: list[SubvolumeModification]
+	) -> list[SubvolumeModification]:
 		if action == self._actions[0]:  # add
 			new_subvolume = self._add_subvolume()
 

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -16,7 +16,7 @@ import urllib.error
 import pathlib
 from datetime import datetime, date
 from enum import Enum
-from typing import Callable, Optional, Dict, Any, List, Union, Iterator, TYPE_CHECKING
+from typing import Callable, Optional, Dict, Any, Union, Iterator, TYPE_CHECKING
 from select import epoll, EPOLLIN, EPOLLHUP
 from shutil import which
 
@@ -102,7 +102,7 @@ class UNSAFE_JSON(json.JSONEncoder, json.JSONDecoder):
 class SysCommandWorker:
 	def __init__(
 		self,
-		cmd: Union[str, List[str]],
+		cmd: Union[str, list[str]],
 		callbacks: Optional[Dict[str, Any]] = None,
 		peek_output: Optional[bool] = False,
 		environment_vars: Optional[Dict[str, Any]] = None,
@@ -345,7 +345,7 @@ class SysCommandWorker:
 
 class SysCommand:
 	def __init__(self,
-		cmd: Union[str, List[str]],
+		cmd: Union[str, list[str]],
 		callbacks: Dict[str, Callable[[Any], Any]] = {},
 		start_callback: Optional[Callable[[Any], Any]] = None,
 		peek_output: Optional[bool] = False,
@@ -376,7 +376,7 @@ class SysCommand:
 		if len(args) >= 2 and args[1]:
 			error(args[1])
 
-	def __iter__(self, *args: List[Any], **kwargs: Dict[str, Any]) -> Iterator[bytes]:
+	def __iter__(self, *args: list[Any], **kwargs: Dict[str, Any]) -> Iterator[bytes]:
 		if self.session:
 			for line in self.session:
 				yield line
@@ -392,10 +392,10 @@ class SysCommand:
 		else:
 			raise ValueError("SysCommand() doesn't have key & value pairs, only slices, SysCommand('ls')[:10] as an example.")
 
-	def __repr__(self, *args: List[Any], **kwargs: Dict[str, Any]) -> str:
+	def __repr__(self, *args: list[Any], **kwargs: Dict[str, Any]) -> str:
 		return self.decode('UTF-8', errors='backslashreplace') or ''
 
-	def __json__(self) -> Dict[str, Union[str, bool, List[str], Dict[str, Any], Optional[bool], Optional[Dict[str, Any]]]]:
+	def __json__(self) -> Dict[str, Union[str, bool, list[str], Dict[str, Any], Optional[bool], Optional[Dict[str, Any]]]]:
 		return {
 			'cmd': self.cmd,
 			'callbacks': self._callbacks,
@@ -472,7 +472,7 @@ def _pid_exists(pid: int) -> bool:
 		return False
 
 
-def run_custom_user_commands(commands: List[str], installation: Installer) -> None:
+def run_custom_user_commands(commands: list[str], installation: Installer) -> None:
 	for index, command in enumerate(commands):
 		script_path = f"/var/tmp/user-command.{index}.sh"
 		chroot_path = f"{installation.target}/{script_path}"

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, List, Optional, Dict, TYPE_CHECKING
+from typing import Any, Optional, Dict, TYPE_CHECKING
 
 from . import disk
 from .general import secret
@@ -54,7 +54,7 @@ class GlobalMenu(AbstractMenu):
 
 		super().__init__(self._item_group, data_store)
 
-	def _get_menu_options(self, data_store: Dict[str, Any]) -> List[MenuItem]:
+	def _get_menu_options(self, data_store: Dict[str, Any]) -> list[MenuItem]:
 		return [
 			MenuItem(
 				text=str(_('Archinstall language')),
@@ -219,7 +219,7 @@ class GlobalMenu(AbstractMenu):
 
 		save_config(data)
 
-	def _missing_configs(self) -> List[str]:
+	def _missing_configs(self) -> list[str]:
 		def check(s) -> bool:
 			item = self._item_group.find_by_key(s)
 			return item.has_value()
@@ -462,7 +462,7 @@ class GlobalMenu(AbstractMenu):
 		return None
 
 	def _prev_users(self, item: MenuItem) -> Optional[str]:
-		users: Optional[List[User]] = item.value
+		users: Optional[list[User]] = item.value
 
 		if users:
 			return FormattedOutput.as_table(users)
@@ -521,7 +521,7 @@ class GlobalMenu(AbstractMenu):
 		profile_config = ProfileMenu(preset=current_profile).run()
 		return profile_config
 
-	def _create_user_account(self, preset: Optional[List[User]] = None) -> List[User]:
+	def _create_user_account(self, preset: Optional[list[User]] = None) -> list[User]:
 		preset = [] if preset is None else preset
 		users = ask_for_additional_users(defined_users=preset)
 		return users

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -2,7 +2,7 @@ import os
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Dict, List, TYPE_CHECKING, Any
+from typing import Optional, Dict, TYPE_CHECKING, Any
 
 from .exceptions import SysCallError
 from .general import SysCommand
@@ -85,7 +85,7 @@ class GfxDriver(Enum):
 
 		return text
 
-	def gfx_packages(self) -> List[GfxPackage]:
+	def gfx_packages(self) -> list[GfxPackage]:
 		packages = [GfxPackage.XorgServer, GfxPackage.XorgXinit]
 
 		match self:
@@ -183,12 +183,12 @@ class _SysInfo:
 		return self.mem_info[key]
 
 	@cached_property
-	def loaded_modules(self) -> List[str]:
+	def loaded_modules(self) -> list[str]:
 		"""
 		Returns loaded kernel modules
 		"""
 		modules_path = Path('/proc/modules')
-		modules: List[str] = []
+		modules: list[str] = []
 
 		with modules_path.open() as file:
 			for line in file:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from typing import Any, List, Optional, TYPE_CHECKING, Union, Dict, Callable
+from typing import Any, Optional, TYPE_CHECKING, Union, Dict, Callable
 
 from . import disk
 from .exceptions import DiskError, ServiceException, RequirementError, HardwareIncompatibilityError, SysCallError
@@ -46,8 +46,8 @@ class Installer:
 		target: Path,
 		disk_config: disk.DiskLayoutConfiguration,
 		disk_encryption: Optional[disk.DiskEncryption] = None,
-		base_packages: List[str] = [],
-		kernels: Optional[List[str]] = None
+		base_packages: list[str] = [],
+		kernels: Optional[list[str]] = None
 	):
 		"""
 		`Installer()` is the wrapper for most basic installation steps.
@@ -71,24 +71,24 @@ class Installer:
 		if accessibility_tools_in_use():
 			self._base_packages.extend(__accessibility_packages__)
 
-		self.post_base_install: List[Callable] = []
+		self.post_base_install: list[Callable] = []
 
 		# TODO: Figure out which one of these two we'll use.. But currently we're mixing them..
 		storage['session'] = self
 		storage['installation_session'] = self
 
-		self._modules: List[str] = []
-		self._binaries: List[str] = []
-		self._files: List[str] = []
+		self._modules: list[str] = []
+		self._binaries: list[str] = []
+		self._files: list[str] = []
 
 		# systemd, sd-vconsole and sd-encrypt will be replaced by udev, keymap and encrypt
 		# if HSM is not used to encrypt the root volume. Check mkinitcpio() function for that override.
-		self._hooks: List[str] = [
+		self._hooks: list[str] = [
 			"base", "systemd", "autodetect", "microcode", "modconf", "kms", "keyboard",
 			"sd-vconsole", "block", "filesystems", "fsck"
 		]
-		self._kernel_params: List[str] = []
-		self._fstab_entries: List[str] = []
+		self._kernel_params: list[str] = []
+		self._fstab_entries: list[str] = []
 
 		self._zram_enabled = False
 		self._disable_fstrim = False
@@ -273,7 +273,7 @@ class Installer:
 
 	def _prepare_luks_partitions(
 		self,
-		partitions: List[disk.PartitionModification]
+		partitions: list[disk.PartitionModification]
 	) -> Dict[disk.PartitionModification, Luks2]:
 		return {
 			part_mod: disk.device_handler.unlock_luks2_dev(
@@ -300,7 +300,7 @@ class Installer:
 
 	def _prepare_luks_lvm(
 		self,
-		lvm_volumes: List[disk.LvmVolume]
+		lvm_volumes: list[disk.LvmVolume]
 	) -> Dict[disk.LvmVolume, Luks2]:
 		return {
 			vol: disk.device_handler.unlock_luks2_dev(
@@ -355,8 +355,8 @@ class Installer:
 	def _mount_btrfs_subvol(
 		self,
 		dev_path: Path,
-		subvolumes: List[disk.SubvolumeModification],
-		mount_options: List[str] = []
+		subvolumes: list[disk.SubvolumeModification],
+		mount_options: list[str] = []
 	) -> None:
 		for subvol in subvolumes:
 			mountpoint = self.target / subvol.relative_mountpoint
@@ -455,7 +455,7 @@ class Installer:
 			self._kernel_params.append(f'resume=UUID={resume_uuid}')
 			self._kernel_params.append(f'resume_offset={resume_offset}')
 
-	def post_install_check(self, *args: str, **kwargs: str) -> List[str]:
+	def post_install_check(self, *args: str, **kwargs: str) -> list[str]:
 		return [step for step, flag in self.helper_flags.items() if flag is False]
 
 	def set_mirrors(self, mirror_config: MirrorConfiguration, on_target: bool = False) -> None:
@@ -607,7 +607,7 @@ class Installer:
 		# fstrim is owned by util-linux, a dependency of both base and systemd.
 		self.enable_service("fstrim.timer")
 
-	def enable_service(self, services: Union[str, List[str]]) -> None:
+	def enable_service(self, services: Union[str, list[str]]) -> None:
 		if isinstance(services, str):
 			services = [services]
 
@@ -701,7 +701,7 @@ class Installer:
 
 		return True
 
-	def mkinitcpio(self, flags: List[str]) -> bool:
+	def mkinitcpio(self, flags: list[str]) -> bool:
 		for plugin in plugins.values():
 			if hasattr(plugin, 'on_mkinitcpio'):
 				# Allow plugins to override the usage of mkinitcpio altogether.
@@ -943,7 +943,7 @@ class Installer:
 		root_partition: disk.PartitionModification,
 		id_root: bool = True,
 		partuuid: bool = True
-	) -> List[str]:
+	) -> list[str]:
 		kernel_parameters = []
 
 		if root_partition in self._disk_encryption.partitions:
@@ -979,7 +979,7 @@ class Installer:
 	def _get_kernel_params_lvm(
 		self,
 		lvm: disk.LvmVolume
-	) -> List[str]:
+	) -> list[str]:
 		kernel_parameters = []
 
 		match self._disk_encryption.encryption_type:
@@ -1020,7 +1020,7 @@ class Installer:
 		root: disk.PartitionModification | disk.LvmVolume,
 		id_root: bool = True,
 		partuuid: bool = True
-	) -> List[str]:
+	) -> list[str]:
 		kernel_parameters = []
 
 		if isinstance(root, disk.LvmVolume):
@@ -1466,7 +1466,7 @@ Exec = /bin/sh -c "{hook_command}"
 			case Bootloader.Limine:
 				self._add_limine_bootloader(boot_partition, efi_partition, root)
 
-	def add_additional_packages(self, packages: Union[str, List[str]]) -> None:
+	def add_additional_packages(self, packages: Union[str, list[str]]) -> None:
 		return self.pacman.strap(packages)
 
 	def enable_sudo(self, entity: str, group: bool = False):
@@ -1499,14 +1499,14 @@ Exec = /bin/sh -c "{hook_command}"
 		# Guarantees sudoer conf file recommended perms
 		os.chmod(Path(rule_file_name), 0o440)
 
-	def create_users(self, users: Union[User, List[User]]) -> None:
+	def create_users(self, users: Union[User, list[User]]) -> None:
 		if not isinstance(users, list):
 			users = [users]
 
 		for user in users:
 			self.user_create(user.username, user.password, user.groups, user.sudo)
 
-	def user_create(self, user: str, password: Optional[str] = None, groups: Optional[List[str]] = None,
+	def user_create(self, user: str, password: Optional[str] = None, groups: Optional[list[str]] = None,
 					sudo: bool = False) -> None:
 		if groups is None:
 			groups = []
@@ -1567,7 +1567,7 @@ Exec = /bin/sh -c "{hook_command}"
 		except SysCallError:
 			return False
 
-	def chown(self, owner: str, path: str, options: List[str] = []) -> bool:
+	def chown(self, owner: str, path: str, options: list[str] = []) -> bool:
 		cleaned_path = path.replace('\'', '\\\'')
 		try:
 			SysCommand(f"/usr/bin/arch-chroot {self.target} sh -c 'chown {' '.join(options)} {owner} {cleaned_path}'")

--- a/archinstall/lib/interactions/disk_conf.py
+++ b/archinstall/lib/interactions/disk_conf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
-from typing import Optional, List, Tuple
+from typing import Optional, Tuple
 
 from .. import disk
 from ..disk.device_model import BtrfsMountOption
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 	_: Any
 
 
-def select_devices(preset: Optional[List[disk.BDevice]] = []) -> List[disk.BDevice]:
+def select_devices(preset: Optional[list[disk.BDevice]] = []) -> list[disk.BDevice]:
 	def _preview_device_selection(selection: disk._DeviceInfo) -> Optional[str]:
 		dev = disk.device_handler.get_device(selection.path)
 		if dev and dev.partition_infos:
@@ -50,7 +50,7 @@ def select_devices(preset: Optional[List[disk.BDevice]] = []) -> List[disk.BDevi
 		case ResultType.Reset: return []
 		case ResultType.Skip: return preset
 		case ResultType.Selection:
-			selected_device_info: List[disk._DeviceInfo] = result.get_values()
+			selected_device_info: list[disk._DeviceInfo] = result.get_values()
 			selected_devices = []
 
 			for device in devices:
@@ -61,10 +61,10 @@ def select_devices(preset: Optional[List[disk.BDevice]] = []) -> List[disk.BDevi
 
 
 def get_default_partition_layout(
-	devices: List[disk.BDevice],
+	devices: list[disk.BDevice],
 	filesystem_type: Optional[disk.FilesystemType] = None,
 	advanced_option: bool = False
-) -> List[disk.DeviceModification]:
+) -> list[disk.DeviceModification]:
 	if len(devices) == 1:
 		device_modification = suggest_single_disk_layout(
 			devices[0],
@@ -81,9 +81,9 @@ def get_default_partition_layout(
 
 
 def _manual_partitioning(
-	preset: List[disk.DeviceModification],
-	devices: List[disk.BDevice]
-) -> List[disk.DeviceModification]:
+	preset: list[disk.DeviceModification],
+	devices: list[disk.BDevice]
+) -> list[disk.DeviceModification]:
 	modifications = []
 	for device in devices:
 		mod = next(filter(lambda x: x.device == device, preset), None)
@@ -248,7 +248,7 @@ def select_main_filesystem_format(advanced_options: bool = False) -> disk.Filesy
 			raise ValueError('Unhandled result type')
 
 
-def select_mount_options() -> List[str]:
+def select_mount_options() -> list[str]:
 	prompt = str(_('Would you like to use compression or disable CoW?')) + '\n'
 	compression = str(_('Use compression'))
 	disable_cow = str(_('Disable Copy-on-Write'))
@@ -423,10 +423,10 @@ def suggest_single_disk_layout(
 
 
 def suggest_multi_disk_layout(
-	devices: List[disk.BDevice],
+	devices: list[disk.BDevice],
 	filesystem_type: Optional[disk.FilesystemType] = None,
 	advanced_options: bool = False
-) -> List[disk.DeviceModification]:
+) -> list[disk.DeviceModification]:
 	if not devices:
 		return []
 
@@ -452,7 +452,7 @@ def suggest_multi_disk_layout(
 			delta = device.device_info.total_size - desired_root_partition_size
 			devices_delta[device] = delta
 
-	sorted_delta: List[Tuple[disk.BDevice, Any]] = sorted(devices_delta.items(), key=lambda x: x[1])
+	sorted_delta: list[Tuple[disk.BDevice, Any]] = sorted(devices_delta.items(), key=lambda x: x[1])
 	root_device: Optional[disk.BDevice] = sorted_delta[0][0]
 
 	if home_device is None or root_device is None:
@@ -575,7 +575,7 @@ def suggest_lvm_layout(
 		home_volume = False
 
 	boot_part: Optional[disk.PartitionModification] = None
-	other_part: List[disk.PartitionModification] = []
+	other_part: list[disk.PartitionModification] = []
 
 	for mod in disk_config.device_modifications:
 		for part in mod.partitions:

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pathlib
-from typing import List, Any, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 from ..locale import list_timezones
 from ..models.audio_configuration import Audio, AudioConfiguration
@@ -128,7 +128,7 @@ def select_language(preset: Optional[str] = None) -> Optional[str]:
 	return select_kb_layout(preset)
 
 
-def select_archinstall_language(languages: List[Language], preset: Language) -> Language:
+def select_archinstall_language(languages: list[Language], preset: Language) -> Language:
 	# these are the displayed language names which can either be
 	# the english name of a language or, if present, the
 	# name of the language in its own language
@@ -159,7 +159,7 @@ def select_archinstall_language(languages: List[Language], preset: Language) -> 
 			raise ValueError('Language selection not handled')
 
 
-def ask_additional_packages_to_install(preset: List[str] = []) -> List[str]:
+def ask_additional_packages_to_install(preset: list[str] = []) -> list[str]:
 	# Additional packages (with some light weight error handling for invalid package names)
 	header = str(_('Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed.')) + '\n'
 	header += str(_('If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt.')) + '\n'
@@ -253,7 +253,7 @@ def add_number_of_parallel_downloads(preset: Optional[int] = None) -> Optional[i
 	return downloads
 
 
-def select_additional_repositories(preset: List[str]) -> List[str]:
+def select_additional_repositories(preset: list[str]) -> list[str]:
 	"""
 	Allows the user to select additional repositories (multilib, and testing) if desired.
 

--- a/archinstall/lib/interactions/manage_users_conf.py
+++ b/archinstall/lib/interactions/manage_users_conf.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, TYPE_CHECKING, List, Optional
+from typing import Any, TYPE_CHECKING, Optional
 
 from ..utils.util import get_password
 from ..menu import ListManager
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class UserList(ListManager):
-	def __init__(self, prompt: str, lusers: List[User]):
+	def __init__(self, prompt: str, lusers: list[User]):
 		self._actions = [
 			str(_('Add a user')),
 			str(_('Change password')),
@@ -31,7 +31,7 @@ class UserList(ListManager):
 	def selected_action_display(self, user: User) -> str:
 		return user.username
 
-	def handle_action(self, action: str, entry: Optional[User], data: List[User]) -> List[User]:
+	def handle_action(self, action: str, entry: Optional[User], data: list[User]) -> list[User]:
 		if action == self._actions[0]:  # add
 			new_user = self._add_user()
 			if new_user is not None:
@@ -106,6 +106,6 @@ class UserList(ListManager):
 		return User(username, password, sudo)
 
 
-def ask_for_additional_users(prompt: str = '', defined_users: List[User] = []) -> List[User]:
+def ask_for_additional_users(prompt: str = '', defined_users: list[User] = []) -> list[User]:
 	users = UserList(prompt, defined_users).run()
 	return users

--- a/archinstall/lib/interactions/network_menu.py
+++ b/archinstall/lib/interactions/network_menu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import Any, Optional, TYPE_CHECKING, List
+from typing import Any, Optional, TYPE_CHECKING
 
 from ..models.network_configuration import NetworkConfiguration, NicType, Nic
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 class ManualNetworkConfig(ListManager):
-	def __init__(self, prompt: str, preset: List[Nic]):
+	def __init__(self, prompt: str, preset: list[Nic]):
 		self._actions = [
 			str(_('Add interface')),
 			str(_('Edit interface')),
@@ -29,7 +29,7 @@ class ManualNetworkConfig(ListManager):
 	def selected_action_display(self, nic: Nic) -> str:
 		return nic.iface if nic.iface else ''
 
-	def handle_action(self, action: str, entry: Optional[Nic], data: List[Nic]) -> list[Nic]:
+	def handle_action(self, action: str, entry: Optional[Nic], data: list[Nic]) -> list[Nic]:
 		if action == self._actions[0]:  # add
 			iface = self._select_iface(data)
 			if iface:
@@ -45,7 +45,7 @@ class ManualNetworkConfig(ListManager):
 
 		return data
 
-	def _select_iface(self, data: List[Nic]) -> Optional[str]:
+	def _select_iface(self, data: list[Nic]) -> Optional[str]:
 		all_ifaces = list_interfaces().values()
 		existing_ifaces = [d.iface for d in data]
 		available = set(all_ifaces) - set(existing_ifaces)

--- a/archinstall/lib/interactions/system_conf.py
+++ b/archinstall/lib/interactions/system_conf.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Any, TYPE_CHECKING, Optional
+from typing import Any, TYPE_CHECKING, Optional
 
 from ..hardware import SysInfo, GfxDriver
 from ..models.bootloader import Bootloader
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 	_: Any
 
 
-def select_kernel(preset: List[str] = []) -> List[str]:
+def select_kernel(preset: list[str] = []) -> list[str]:
 	"""
 	Asks the user to select a kernel for system.
 
@@ -103,7 +103,7 @@ def ask_for_uki(preset: bool = True) -> bool:
 			raise ValueError('Unhandled result type')
 
 
-def select_driver(options: List[GfxDriver] = [], preset: Optional[GfxDriver] = None) -> Optional[GfxDriver]:
+def select_driver(options: list[GfxDriver] = [], preset: Optional[GfxDriver] = None) -> Optional[GfxDriver]:
 	"""
 	Some what convoluted function, whose job is simple.
 	Select a graphics driver from a pre-defined set of popular options.

--- a/archinstall/lib/locale/locale_menu.py
+++ b/archinstall/lib/locale/locale_menu.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Any, TYPE_CHECKING, Optional, List
+from typing import Dict, Any, TYPE_CHECKING, Optional
 
 from .utils import list_keyboard_languages, list_locales, set_kb_layout, get_kb_layout
 from ..menu import AbstractSubMenu
@@ -74,7 +74,7 @@ class LocaleMenu(AbstractSubMenu):
 		self._item_group = MenuItemGroup(menu_optioons, sort_items=False, checkmarks=True)
 		super().__init__(self._item_group, data_store=self._data_store, allow_reset=True)
 
-	def _define_menu_options(self) -> List[MenuItem]:
+	def _define_menu_options(self) -> list[MenuItem]:
 		return [
 			MenuItem(
 				text=str(_('Keyboard layout')),

--- a/archinstall/lib/locale/utils.py
+++ b/archinstall/lib/locale/utils.py
@@ -1,18 +1,16 @@
-from typing import List
-
 from ..exceptions import ServiceException, SysCallError
 from ..general import SysCommand
 from ..output import error
 
 
-def list_keyboard_languages() -> List[str]:
+def list_keyboard_languages() -> list[str]:
 	return SysCommand(
 		"localectl --no-pager list-keymaps",
 		environment_vars={'SYSTEMD_COLORS': '0'}
 	).decode().splitlines()
 
 
-def list_locales() -> List[str]:
+def list_locales() -> list[str]:
 	locales = []
 
 	with open('/usr/share/i18n/SUPPORTED') as file:
@@ -23,7 +21,7 @@ def list_locales() -> List[str]:
 	return locales
 
 
-def list_x11_keyboard_languages() -> List[str]:
+def list_x11_keyboard_languages() -> list[str]:
 	return SysCommand(
 		"localectl --no-pager list-x11-keymap-layouts",
 		environment_vars={'SYSTEMD_COLORS': '0'}
@@ -84,7 +82,7 @@ def set_kb_layout(locale: str) -> bool:
 	return False
 
 
-def list_timezones() -> List[str]:
+def list_timezones() -> list[str]:
 	return SysCommand(
 		"timedatectl --no-pager list-timezones",
 		environment_vars={'SYSTEMD_COLORS': '0'}

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -4,7 +4,7 @@ import shlex
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, List
+from typing import Optional
 
 from . import disk
 from .general import SysCommand, generate_password, SysCommandWorker
@@ -253,7 +253,7 @@ class Luks2:
 		self,
 		crypttab_path: Path,
 		key_file: Path,
-		options: List[str]
+		options: list[str]
 	) -> None:
 		debug(f'Adding crypttab entry for key {key_file}')
 

--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Any, List, Optional, Dict, TYPE_CHECKING
+from typing import Callable, Any, Optional, Dict, TYPE_CHECKING
 
 from ..output import error
 from ..output import unicode_ljust
@@ -22,8 +22,8 @@ class Selector:
 		display_func: Optional[Callable] = None,
 		default: Optional[Any] = None,
 		enabled: bool = False,
-		dependencies: List = [],
-		dependencies_not: List = [],
+		dependencies: list = [],
+		dependencies_not: list = [],
 		exec_func: Optional[Callable] = None,
 		preview_func: Optional[Callable] = None,
 		mandatory: bool = False,

--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, TYPE_CHECKING, Dict, Optional, Tuple, List
+from typing import Any, TYPE_CHECKING, Dict, Optional, Tuple
 from ..output import FormattedOutput
 
 from archinstall.tui import (
@@ -15,9 +15,9 @@ class ListManager:
 	def __init__(
 		self,
 		prompt: str,
-		entries: List[Any],
-		base_actions: List[str],
-		sub_menu_actions: List[str]
+		entries: list[Any],
+		base_actions: list[str],
+		sub_menu_actions: list[str]
 	):
 		"""
 		:param prompt:  Text which will appear at the header
@@ -58,7 +58,7 @@ class ListManager:
 			return self._last_choice == self._cancel_action
 		return False
 
-	def run(self) -> List[Any]:
+	def run(self) -> list[Any]:
 		while True:
 			# this will return a dictionary with the key as the menu entry to be displayed
 			# and the value is the original value from the self._data container
@@ -97,10 +97,10 @@ class ListManager:
 		else:
 			return self._data
 
-	def _prepare_selection(self, data_formatted: Dict[str, Any]) -> Tuple[List[str], str]:
+	def _prepare_selection(self, data_formatted: Dict[str, Any]) -> Tuple[list[str], str]:
 		# header rows are mapped to None so make sure
 		# to exclude those from the selectable data
-		options: List[str] = [key for key, val in data_formatted.items() if val is not None]
+		options: list[str] = [key for key, val in data_formatted.items() if val is not None]
 		header = ''
 
 		if len(options) > 0:
@@ -140,7 +140,7 @@ class ListManager:
 		if value != self._cancel_action:
 			self._data = self.handle_action(value, entry, self._data)
 
-	def reformat(self, data: List[Any]) -> Dict[str, Optional[Any]]:
+	def reformat(self, data: list[Any]) -> Dict[str, Optional[Any]]:
 		"""
 		Default implementation of the table to be displayed.
 		Override if any custom formatting is needed
@@ -165,14 +165,14 @@ class ListManager:
 		"""
 		raise NotImplementedError('Please implement me in the child class')
 
-	def handle_action(self, action: Any, entry: Optional[Any], data: List[Any]) -> List[Any]:
+	def handle_action(self, action: Any, entry: Optional[Any], data: list[Any]) -> list[Any]:
 		"""
 		this function is called when a base action or
 		a specific action for an entry is triggered
 		"""
 		raise NotImplementedError('Please implement me in the child class')
 
-	def filter_options(self, selection: Any, options: List[str]) -> List[str]:
+	def filter_options(self, selection: Any, options: list[str]) -> list[str]:
 		"""
 		filter which actions to show for an specific selection
 		"""

--- a/archinstall/lib/menu/menu_helper.py
+++ b/archinstall/lib/menu/menu_helper.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple, List, Dict, Optional
+from typing import Any, Tuple, Dict, Optional
 
 from archinstall.lib.output import FormattedOutput
 
@@ -10,8 +10,8 @@ from archinstall.tui import (
 class MenuHelper:
 	@staticmethod
 	def create_table(
-		data: Optional[List[Any]] = None,
-		table_data: Optional[Tuple[List[Any], str]] = None,
+		data: Optional[list[Any]] = None,
+		table_data: Optional[Tuple[list[Any], str]] = None,
 	) -> Tuple[MenuItemGroup, str]:
 		if data is not None:
 			table_text = FormattedOutput.as_table(data)
@@ -39,7 +39,7 @@ class MenuHelper:
 		return group, header
 
 	@staticmethod
-	def _create_table(data: List[Any], rows: List[str], header_padding: int = 2) -> Dict[str, Any]:
+	def _create_table(data: list[Any], rows: list[str], header_padding: int = 2) -> Dict[str, Any]:
 		# these are the header rows of the table and do not map to any data obviously
 		# we're adding 2 spaces as prefix because the menu selector '> ' will be put before
 		# the selectable rows so the header has to be aligned

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -4,7 +4,7 @@ import urllib.parse
 from pathlib import Path
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, Any, List, Optional, TYPE_CHECKING, Tuple
+from typing import Dict, Any, Optional, TYPE_CHECKING, Tuple
 
 from .menu import AbstractSubMenu, ListManager
 from .networking import fetch_data_from_url
@@ -58,7 +58,7 @@ class CustomMirror:
 		}
 
 	@classmethod
-	def parse_args(cls, args: List[Dict[str, str]]) -> List['CustomMirror']:
+	def parse_args(cls, args: list[Dict[str, str]]) -> list['CustomMirror']:
 		configs = []
 		for arg in args:
 			configs.append(
@@ -75,8 +75,8 @@ class CustomMirror:
 
 @dataclass
 class MirrorConfiguration:
-	mirror_regions: Dict[str, List[MirrorStatusEntryV3]] = field(default_factory=dict)
-	custom_mirrors: List[CustomMirror] = field(default_factory=list)
+	mirror_regions: Dict[str, list[MirrorStatusEntryV3]] = field(default_factory=dict)
+	custom_mirrors: list[CustomMirror] = field(default_factory=list)
 
 	@property
 	def regions(self) -> str:
@@ -124,7 +124,7 @@ class MirrorConfiguration:
 
 
 class CustomMirrorList(ListManager):
-	def __init__(self, custom_mirrors: List[CustomMirror]):
+	def __init__(self, custom_mirrors: list[CustomMirror]):
 		self._actions = [
 			str(_('Add a custom mirror')),
 			str(_('Change custom mirror')),
@@ -144,8 +144,8 @@ class CustomMirrorList(ListManager):
 		self,
 		action: str,
 		entry: Optional[CustomMirror],
-		data: List[CustomMirror]
-	) -> List[CustomMirror]:
+		data: list[CustomMirror]
+	) -> list[CustomMirror]:
 		if action == self._actions[0]:  # add
 			new_mirror = self._add_custom_mirror()
 			if new_mirror is not None:
@@ -259,7 +259,7 @@ class MirrorMenu(AbstractSubMenu):
 
 		super().__init__(self._item_group, data_store=self._data_store, allow_reset=True)
 
-	def _define_menu_options(self) -> List[MenuItem]:
+	def _define_menu_options(self) -> list[MenuItem]:
 		return [
 			MenuItem(
 				text=str(_('Mirror region')),
@@ -278,7 +278,7 @@ class MirrorMenu(AbstractSubMenu):
 		]
 
 	def _prev_regions(self, item: MenuItem) -> Optional[str]:
-		mirrors: Dict[str, List[MirrorStatusEntryV3]] = item.get_value()
+		mirrors: Dict[str, list[MirrorStatusEntryV3]] = item.get_value()
 
 		output = ''
 		for name, status_list in mirrors.items():
@@ -296,7 +296,7 @@ class MirrorMenu(AbstractSubMenu):
 		if not item.value:
 			return None
 
-		custom_mirrors: List[CustomMirror] = item.value
+		custom_mirrors: list[CustomMirror] = item.value
 		output = FormattedOutput.as_table(custom_mirrors)
 		return output.strip()
 
@@ -312,8 +312,8 @@ class MirrorMenu(AbstractSubMenu):
 		)
 
 
-def select_mirror_regions(preset: Dict[str, List[MirrorStatusEntryV3]]) -> Dict[str, List[MirrorStatusEntryV3]]:
-	mirrors: Dict[str, List[MirrorStatusEntryV3]] | None = list_mirrors_from_remote()
+def select_mirror_regions(preset: Dict[str, list[MirrorStatusEntryV3]]) -> Dict[str, list[MirrorStatusEntryV3]]:
+	mirrors: Dict[str, list[MirrorStatusEntryV3]] | None = list_mirrors_from_remote()
 
 	if not mirrors:
 		mirrors = list_mirrors_from_local()
@@ -339,16 +339,16 @@ def select_mirror_regions(preset: Dict[str, List[MirrorStatusEntryV3]]) -> Dict[
 		case ResultType.Reset:
 			return {}
 		case ResultType.Selection:
-			selected_mirrors: List[Tuple[str, List[MirrorStatusEntryV3]]] = result.get_values()
+			selected_mirrors: list[Tuple[str, list[MirrorStatusEntryV3]]] = result.get_values()
 			return {name: mirror for name, mirror in selected_mirrors}
 
 
-def select_custom_mirror(preset: List[CustomMirror] = []):
+def select_custom_mirror(preset: list[CustomMirror] = []):
 	custom_mirrors = CustomMirrorList(preset).run()
 	return custom_mirrors
 
 
-def list_mirrors_from_remote() -> Optional[Dict[str, List[MirrorStatusEntryV3]]]:
+def list_mirrors_from_remote() -> Optional[Dict[str, list[MirrorStatusEntryV3]]]:
 	if not storage['arguments']['offline']:
 		url = "https://archlinux.org/mirrors/status/json/"
 		attempts = 3
@@ -366,20 +366,20 @@ def list_mirrors_from_remote() -> Optional[Dict[str, List[MirrorStatusEntryV3]]]
 	return None
 
 
-def list_mirrors_from_local() -> Dict[str, List[MirrorStatusEntryV3]]:
+def list_mirrors_from_local() -> Dict[str, list[MirrorStatusEntryV3]]:
 	with Path('/etc/pacman.d/mirrorlist').open('r') as fp:
 		mirrorlist = fp.read()
 		return _parse_locale_mirrors(mirrorlist)
 
 
-def _sort_mirrors_by_performance(mirror_list: List[MirrorStatusEntryV3]) -> List[MirrorStatusEntryV3]:
+def _sort_mirrors_by_performance(mirror_list: list[MirrorStatusEntryV3]) -> list[MirrorStatusEntryV3]:
 	return sorted(mirror_list, key=lambda mirror: (mirror.score, mirror.speed))
 
 
-def _parse_remote_mirror_list(mirrorlist: str) -> Dict[str, List[MirrorStatusEntryV3]]:
+def _parse_remote_mirror_list(mirrorlist: str) -> Dict[str, list[MirrorStatusEntryV3]]:
 	mirror_status = MirrorStatusListV3(**json.loads(mirrorlist))
 
-	sorting_placeholder: Dict[str, List[MirrorStatusEntryV3]] = {}
+	sorting_placeholder: Dict[str, list[MirrorStatusEntryV3]] = {}
 
 	for mirror in mirror_status.urls:
 		# We filter out mirrors that have bad criteria values
@@ -401,7 +401,7 @@ def _parse_remote_mirror_list(mirrorlist: str) -> Dict[str, List[MirrorStatusEnt
 		if mirror.url.startswith('http'):
 			sorting_placeholder.setdefault(mirror.country, []).append(mirror)
 
-	sorted_by_regions: Dict[str, List[MirrorStatusEntryV3]] = dict({
+	sorted_by_regions: Dict[str, list[MirrorStatusEntryV3]] = dict({
 		region: unsorted_mirrors
 		for region, unsorted_mirrors in sorted(sorting_placeholder.items(), key=lambda item: item[0])
 	})
@@ -409,13 +409,13 @@ def _parse_remote_mirror_list(mirrorlist: str) -> Dict[str, List[MirrorStatusEnt
 	return sorted_by_regions
 
 
-def _parse_locale_mirrors(mirrorlist: str) -> Dict[str, List[MirrorStatusEntryV3]]:
+def _parse_locale_mirrors(mirrorlist: str) -> Dict[str, list[MirrorStatusEntryV3]]:
 	lines = mirrorlist.splitlines()
 
 	# remove empty lines
 	lines = [line for line in lines if line]
 
-	mirror_list: Dict[str, List[MirrorStatusEntryV3]] = {}
+	mirror_list: Dict[str, list[MirrorStatusEntryV3]] = {}
 
 	current_region = ''
 	for idx, line in enumerate(lines):

--- a/archinstall/lib/models/bootloader.py
+++ b/archinstall/lib/models/bootloader.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 from enum import Enum
-from typing import List
 
 from ..hardware import SysInfo
 from ..output import warn
@@ -25,7 +24,7 @@ class Bootloader(Enum):
 		return self.value
 
 	@staticmethod
-	def values() -> List[str]:
+	def values() -> list[str]:
 		return [e.value for e in Bootloader]
 
 	@classmethod

--- a/archinstall/lib/models/gen.py
+++ b/archinstall/lib/models/gen.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any
+from typing import Optional, Dict, Any
 
 
 @dataclass
@@ -7,7 +7,7 @@ class VersionDef:
 	version_string: str
 
 	@classmethod
-	def parse_version(cls) -> List[str]:
+	def parse_version(cls) -> list[str]:
 		if '.' in cls.version_string:
 			versions = cls.version_string.split('.')
 		else:
@@ -75,17 +75,17 @@ class PackageSearchResult:
 	build_date: str
 	last_update: str
 	flag_date: Optional[str]
-	maintainers: List[str]
+	maintainers: list[str]
 	packager: str
-	groups: List[str]
-	licenses: List[str]
-	conflicts: List[str]
-	provides: List[str]
-	replaces: List[str]
-	depends: List[str]
-	optdepends: List[str]
-	makedepends: List[str]
-	checkdepends: List[str]
+	groups: list[str]
+	licenses: list[str]
+	conflicts: list[str]
+	provides: list[str]
+	replaces: list[str]
+	depends: list[str]
+	optdepends: list[str]
+	makedepends: list[str]
+	checkdepends: list[str]
 
 	@staticmethod
 	def from_json(data: Dict[str, Any]) -> 'PackageSearchResult':
@@ -109,7 +109,7 @@ class PackageSearch:
 	valid: bool
 	num_pages: int
 	page: int
-	results: List[PackageSearchResult]
+	results: list[PackageSearchResult]
 
 	@staticmethod
 	def from_json(data: Dict[str, Any]) -> 'PackageSearch':

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -6,7 +6,6 @@ import urllib.parse
 import urllib.request
 from typing import (
 	Dict,
-	List,
 	Optional
 )
 
@@ -113,15 +112,15 @@ class MirrorStatusListV3(BaseModel):
 	cutoff: int
 	last_check: datetime.datetime
 	num_checks: int
-	urls: List[MirrorStatusEntryV3]
+	urls: list[MirrorStatusEntryV3]
 	version: int
 
 	@model_validator(mode='before')
 	@classmethod
 	def check_model(
 		cls,
-		data: Dict[str, int | datetime.datetime | List[MirrorStatusEntryV3]]
-	) -> Dict[str, int | datetime.datetime | List[MirrorStatusEntryV3]]:
+		data: Dict[str, int | datetime.datetime | list[MirrorStatusEntryV3]]
+	) -> Dict[str, int | datetime.datetime | list[MirrorStatusEntryV3]]:
 		if data.get('version') == 3:
 			return data
 

--- a/archinstall/lib/models/network_configuration.py
+++ b/archinstall/lib/models/network_configuration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional, Dict, Any, TYPE_CHECKING, Tuple
+from typing import Optional, Dict, Any, TYPE_CHECKING, Tuple
 
 from ..profile import ProfileConfiguration
 
@@ -31,7 +31,7 @@ class Nic:
 	ip: Optional[str] = None
 	dhcp: bool = True
 	gateway: Optional[str] = None
-	dns: List[str] = field(default_factory=list)
+	dns: list[str] = field(default_factory=list)
 
 	def table_data(self) -> Dict[str, Any]:
 		return {
@@ -62,8 +62,8 @@ class Nic:
 		)
 
 	def as_systemd_config(self) -> str:
-		match: List[Tuple[str, str]] = []
-		network: List[Tuple[str, str]] = []
+		match: list[Tuple[str, str]] = []
+		network: list[Tuple[str, str]] = []
 
 		if self.iface:
 			match.append(('Name', self.iface))
@@ -92,7 +92,7 @@ class Nic:
 @dataclass
 class NetworkConfiguration:
 	type: NicType
-	nics: List[Nic] = field(default_factory=list)
+	nics: list[Nic] = field(default_factory=list)
 
 	def json(self) -> Dict[str, Any]:
 		config: Dict[str, Any] = {'type': self.type.value}

--- a/archinstall/lib/models/users.py
+++ b/archinstall/lib/models/users.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Union, Any, TYPE_CHECKING
+from typing import Dict, Union, Any, TYPE_CHECKING
 from enum import Enum
 
 if TYPE_CHECKING:
@@ -97,7 +97,7 @@ class User:
 	sudo: bool
 
 	@property
-	def groups(self) -> List[str]:
+	def groups(self) -> list[str]:
 		# this property should be transferred into a class attr instead
 		# if it's every going to be used
 		return []
@@ -110,7 +110,7 @@ class User:
 		}
 
 	@classmethod
-	def _parse(cls, config_users: List[Dict[str, Any]]) -> List['User']:
+	def _parse(cls, config_users: list[Dict[str, Any]]) -> list['User']:
 		users = []
 
 		for entry in config_users:
@@ -127,7 +127,7 @@ class User:
 		return users
 
 	@classmethod
-	def _parse_backwards_compatible(cls, config_users: Dict, sudo: bool) -> List['User']:
+	def _parse_backwards_compatible(cls, config_users: Dict, sudo: bool) -> list['User']:
 		if len(config_users.keys()) > 0:
 			username = list(config_users.keys())[0]
 			password = config_users[username]['!password']
@@ -140,9 +140,9 @@ class User:
 	@classmethod
 	def parse_arguments(
 		cls,
-		config_users: Union[List[Dict[str, str]], Dict[str, str]],
-		config_superusers: Union[List[Dict[str, str]], Dict[str, str]]
-	) -> List['User']:
+		config_users: Union[list[Dict[str, str]], Dict[str, str]],
+		config_superusers: Union[list[Dict[str, str]], Dict[str, str]]
+	) -> list['User']:
 		users = []
 
 		# backwards compatibility

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -5,7 +5,7 @@ import unicodedata
 from enum import Enum
 
 from pathlib import Path
-from typing import Dict, Union, List, Any, Callable, Optional, TYPE_CHECKING
+from typing import Dict, Union, Any, Callable, Optional, TYPE_CHECKING
 from dataclasses import asdict, is_dataclass
 
 from .storage import storage
@@ -21,7 +21,7 @@ class FormattedOutput:
 		cls,
 		o: 'DataclassInstance',
 		class_formatter: Optional[Union[str, Callable]] = None,
-		filter_list: List[str] = []
+		filter_list: list[str] = []
 	) -> Dict[str, Any]:
 		"""
 		the original values returned a dataclass as dict thru the call to some specific methods
@@ -51,9 +51,9 @@ class FormattedOutput:
 	@classmethod
 	def as_table(
 		cls,
-		obj: List[Any],
+		obj: list[Any],
 		class_formatter: Optional[Union[str, Callable]] = None,
-		filter_list: List[str] = [],
+		filter_list: list[str] = [],
 		capitalize: bool = False
 	) -> str:
 		""" variant of as_table (subtly different code) which has two additional parameters
@@ -112,7 +112,7 @@ class FormattedOutput:
 		return output
 
 	@classmethod
-	def as_columns(cls, entries: List[str], cols: int) -> str:
+	def as_columns(cls, entries: list[str], cols: int) -> str:
 		"""
 		Will format a list into a given number of columns
 		"""
@@ -204,7 +204,7 @@ def _stylize_output(
 	fg: str,
 	bg: Optional[str],
 	reset: bool,
-	font: List[Font] = [],
+	font: list[Font] = [],
 ) -> str:
 	"""
 	Heavily influenced by:
@@ -258,7 +258,7 @@ def info(
 	fg: str = 'white',
 	bg: Optional[str] = None,
 	reset: bool = False,
-	font: List[Font] = []
+	font: list[Font] = []
 ) -> None:
 	log(*msgs, level=level, fg=fg, bg=bg, reset=reset, font=font)
 
@@ -269,7 +269,7 @@ def debug(
 	fg: str = 'white',
 	bg: Optional[str] = None,
 	reset: bool = False,
-	font: List[Font] = []
+	font: list[Font] = []
 ) -> None:
 	log(*msgs, level=level, fg=fg, bg=bg, reset=reset, font=font)
 
@@ -280,7 +280,7 @@ def error(
 	fg: str = 'red',
 	bg: Optional[str] = None,
 	reset: bool = False,
-	font: List[Font] = []
+	font: list[Font] = []
 ) -> None:
 	log(*msgs, level=level, fg=fg, bg=bg, reset=reset, font=font)
 
@@ -291,7 +291,7 @@ def warn(
 	fg: str = 'yellow',
 	bg: Optional[str] = None,
 	reset: bool = False,
-	font: List[Font] = []
+	font: list[Font] = []
 ) -> None:
 	log(*msgs, level=level, fg=fg, bg=bg, reset=reset, font=font)
 
@@ -302,7 +302,7 @@ def log(
 	fg: str = 'white',
 	bg: Optional[str] = None,
 	reset: bool = False,
-	font: List[Font] = []
+	font: list[Font] = []
 ) -> None:
 	# leave this check here as we need to setup the logging
 	# right from the beginning when the modules are loaded

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -1,7 +1,7 @@
 import dataclasses
 import json
 import ssl
-from typing import Dict, Any, Tuple, List
+from typing import Dict, Any, Tuple
 from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import urlopen
@@ -26,7 +26,7 @@ def _make_request(url: str, params: Dict) -> Any:
 	return urlopen(full_url, context=ssl_context)
 
 
-def group_search(name: str) -> List[PackageSearchResult]:
+def group_search(name: str) -> list[PackageSearchResult]:
 	# TODO UPSTREAM: Implement /json/ for the groups search
 	try:
 		response = _make_request(BASE_GROUP_URL, {'name': name})
@@ -59,7 +59,7 @@ def package_search(package: str) -> PackageSearch:
 	return PackageSearch.from_json(json_data)
 
 
-def find_package(package: str) -> List[PackageSearchResult]:
+def find_package(package: str) -> list[PackageSearchResult]:
 	data = package_search(package)
 	results = []
 

--- a/archinstall/lib/pacman/config.py
+++ b/archinstall/lib/pacman/config.py
@@ -1,7 +1,6 @@
 import re
 from pathlib import Path
 from shutil import copy2
-from typing import List
 
 from .repo import Repo
 
@@ -10,7 +9,7 @@ class Config:
 	def __init__(self, target: Path):
 		self.path = Path("/etc") / "pacman.conf"
 		self.chroot_path = target / "etc" / "pacman.conf"
-		self.repos: List[Repo] = []
+		self.repos: list[Repo] = []
 
 	def enable(self, repo: Repo) -> None:
 		self.repos.append(repo)

--- a/archinstall/lib/plugins.py
+++ b/archinstall/lib/plugins.py
@@ -6,7 +6,7 @@ import urllib.parse
 import urllib.request
 from importlib import metadata
 from pathlib import Path
-from typing import Optional, List
+from typing import Optional
 
 from .output import error, info, warn
 from .storage import storage
@@ -75,7 +75,7 @@ def _import_via_path(path: Path, namespace: Optional[str] = None) -> Optional[st
 	return namespace
 
 
-def _find_nth(haystack: List[str], needle: str, n: int) -> Optional[int]:
+def _find_nth(haystack: list[str], needle: str, n: int) -> Optional[int]:
 	indices = [idx for idx, elem in enumerate(haystack) if elem == needle]
 	if n <= len(indices):
 		return indices[n - 1]

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Dict, List
+from typing import TYPE_CHECKING, Any, Optional, Dict
 
 from archinstall.default_profiles.profile import Profile, GreeterType
 from .profile_model import ProfileConfiguration
@@ -35,7 +35,7 @@ class ProfileMenu(AbstractSubMenu):
 
 		super().__init__(self._item_group, data_store=self._data_store, allow_reset=True)
 
-	def _define_menu_options(self) -> List[MenuItem]:
+	def _define_menu_options(self) -> list[MenuItem]:
 		return [
 			MenuItem(
 				text=str(_('Type')),

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from types import ModuleType
-from typing import List, TYPE_CHECKING, Any, Optional, Dict, Union
+from typing import TYPE_CHECKING, Any, Optional, Dict, Union
 
 from ...default_profiles.profile import Profile, GreeterType
 from .profile_model import ProfileConfiguration
@@ -101,9 +101,9 @@ class ProfileHandler:
 		if not profile:
 			return None
 
-		valid_sub_profiles: List[Profile] = []
-		invalid_sub_profiles: List[str] = []
-		details: List[str] = profile_config.get('details', [])
+		valid_sub_profiles: list[Profile] = []
+		invalid_sub_profiles: list[str] = []
+		details: list[str] = profile_config.get('details', [])
 
 		if details:
 			for detail in filter(None, details):
@@ -127,7 +127,7 @@ class ProfileHandler:
 		return profile
 
 	@property
-	def profiles(self) -> List[Profile]:
+	def profiles(self) -> list[Profile]:
 		"""
 		List of all available default_profiles
 		"""
@@ -135,10 +135,10 @@ class ProfileHandler:
 		return self._profiles
 
 	@cached_property
-	def _local_mac_addresses(self) -> List[str]:
+	def _local_mac_addresses(self) -> list[str]:
 		return list(list_interfaces())
 
-	def add_custom_profiles(self, profiles: Union[Profile, List[Profile]]) -> None:
+	def add_custom_profiles(self, profiles: Union[Profile, list[Profile]]) -> None:
 		if not isinstance(profiles, list):
 			profiles = [profiles]
 
@@ -147,7 +147,7 @@ class ProfileHandler:
 
 		self._verify_unique_profile_names(self.profiles)
 
-	def remove_custom_profiles(self, profiles: Union[Profile, List[Profile]]) -> None:
+	def remove_custom_profiles(self, profiles: Union[Profile, list[Profile]]) -> None:
 		if not isinstance(profiles, list):
 			profiles = [profiles]
 
@@ -157,19 +157,19 @@ class ProfileHandler:
 	def get_profile_by_name(self, name: str) -> Optional[Profile]:
 		return next(filter(lambda x: x.name == name, self.profiles), None)  # type: ignore
 
-	def get_top_level_profiles(self) -> List[Profile]:
+	def get_top_level_profiles(self) -> list[Profile]:
 		return list(filter(lambda x: x.is_top_level_profile(), self.profiles))
 
-	def get_server_profiles(self) -> List[Profile]:
+	def get_server_profiles(self) -> list[Profile]:
 		return list(filter(lambda x: x.is_server_type_profile(), self.profiles))
 
-	def get_desktop_profiles(self) -> List[Profile]:
+	def get_desktop_profiles(self) -> list[Profile]:
 		return list(filter(lambda x: x.is_desktop_type_profile(), self.profiles))
 
-	def get_custom_profiles(self) -> List[Profile]:
+	def get_custom_profiles(self) -> list[Profile]:
 		return list(filter(lambda x: x.is_custom_type_profile(), self.profiles))
 
-	def get_mac_addr_profiles(self) -> List[Profile]:
+	def get_mac_addr_profiles(self) -> list[Profile]:
 		tailored = list(filter(lambda x: x.is_tailored(), self.profiles))
 		match_mac_addr_profiles = list(filter(lambda x: x.name in self._local_mac_addresses, tailored))
 		return match_mac_addr_profiles
@@ -265,7 +265,7 @@ class ProfileHandler:
 			err = str(_('Unable to fetch profile from specified url: {}')).format(url)
 			error(err)
 
-	def _load_profile_class(self, module: ModuleType) -> List[Profile]:
+	def _load_profile_class(self, module: ModuleType) -> list[Profile]:
 		"""
 		Load all default_profiles defined in a module
 		"""
@@ -284,7 +284,7 @@ class ProfileHandler:
 
 		return profiles
 
-	def _verify_unique_profile_names(self, profiles: List[Profile]):
+	def _verify_unique_profile_names(self, profiles: list[Profile]):
 		"""
 		All profile names have to be unique, this function will verify
 		that the provided list contains only default_profiles with unique names
@@ -308,7 +308,7 @@ class ProfileHandler:
 					return True
 		return False
 
-	def _process_profile_file(self, file: Path) -> List[Profile]:
+	def _process_profile_file(self, file: Path) -> list[Profile]:
 		"""
 		Process a file for profile definitions
 		"""
@@ -334,7 +334,7 @@ class ProfileHandler:
 
 		return []
 
-	def _find_available_profiles(self) -> List[Profile]:
+	def _find_available_profiles(self) -> list[Profile]:
 		"""
 		Search the profile path for profile definitions
 		"""
@@ -348,7 +348,7 @@ class ProfileHandler:
 		self._verify_unique_profile_names(profiles)
 		return profiles
 
-	def reset_top_level_profiles(self, exclude: List[Profile] = []):
+	def reset_top_level_profiles(self, exclude: list[Profile] = []):
 		"""
 		Reset all top level profile configurations, this is usually necessary
 		when a new top level profile is selected

--- a/archinstall/lib/utils/util.py
+++ b/archinstall/lib/utils/util.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, TYPE_CHECKING, Optional, List
+from typing import Any, TYPE_CHECKING, Optional
 
 from ..output import FormattedOutput
 from ..general import secret
@@ -107,7 +107,7 @@ def is_subpath(first: Path, second: Path) -> bool:
 		return False
 
 
-def format_cols(items: List[str], header: Optional[str] = None) -> str:
+def format_cols(items: list[str], header: Optional[str] = None) -> str:
 	if header:
 		text = f'{header}:\n'
 	else:

--- a/archinstall/scripts/minimal.py
+++ b/archinstall/scripts/minimal.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any
 
 import archinstall
 from archinstall import info, debug
@@ -75,8 +75,8 @@ def prompt_disk_layout() -> None:
 
 def parse_disk_encryption() -> None:
 	if enc_password := archinstall.arguments.get('!encryption-password', None):
-		modification: List[disk.DeviceModification] = archinstall.arguments['disk_config']
-		partitions: List[disk.PartitionModification] = []
+		modification: list[disk.DeviceModification] = archinstall.arguments['disk_config']
+		partitions: list[disk.PartitionModification] = []
 
 		# encrypt all partitions except the /boot
 		for mod in modification:

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -7,7 +7,7 @@ import signal
 from abc import ABCMeta, abstractmethod
 from curses.textpad import Textbox
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple, List, TYPE_CHECKING, Literal
+from typing import Any, Optional, Tuple, TYPE_CHECKING, Literal
 from typing import Callable
 
 from .help import Help
@@ -94,7 +94,7 @@ class AbstractCurses(metaclass=ABCMeta):
 		self,
 		header: Optional[str],
 		offset: int = 0
-	) -> List[ViewportEntry]:
+	) -> list[ViewportEntry]:
 		cur_row = 0
 		full_header = []
 
@@ -120,12 +120,12 @@ class AbstractViewport:
 
 	def add_frame(
 		self,
-		entries: List[ViewportEntry],
+		entries: list[ViewportEntry],
 		max_width: int,
 		max_height: int,
 		frame: FrameProperties,
 		scroll_pct: Optional[int] = None
-	) -> List[ViewportEntry]:
+	) -> list[ViewportEntry]:
 		if not entries:
 			return []
 
@@ -155,7 +155,7 @@ class AbstractViewport:
 
 		return framed_entries
 
-	def align_center(self, lines: List[ViewportEntry], width: int) -> int:
+	def align_center(self, lines: list[ViewportEntry], width: int) -> int:
 		max_col = self._max_col(lines)
 		x_offset = int((width / 2) - (max_col / 2))
 		return x_offset
@@ -164,7 +164,7 @@ class AbstractViewport:
 		self,
 		dim: _FrameDim,
 		scroll_percentage: Optional[int] = None
-	) -> List[ViewportEntry]:
+	) -> list[ViewportEntry]:
 		right_frame = {}
 		scroll_height = int(dim.height * scroll_percentage // 100) if scroll_percentage else 0
 
@@ -214,7 +214,7 @@ class AbstractViewport:
 
 	def _get_frame_dim(
 		self,
-		entries: List[ViewportEntry],
+		entries: list[ViewportEntry],
 		max_width: int,
 		max_height: int,
 		frame: FrameProperties
@@ -245,9 +245,9 @@ class AbstractViewport:
 
 	def _adjust_entries(
 		self,
-		entries: List[ViewportEntry],
+		entries: list[ViewportEntry],
 		frame_dim: _FrameDim
-	) -> List[ViewportEntry]:
+	) -> list[ViewportEntry]:
 		for entry in entries:
 			# top row frame offset
 			entry.row += 1
@@ -256,10 +256,10 @@ class AbstractViewport:
 
 		return entries
 
-	def _num_unique_rows(self, entries: List[ViewportEntry]) -> int:
+	def _num_unique_rows(self, entries: list[ViewportEntry]) -> int:
 		return len(set([e.row for e in entries]))
 
-	def _max_col(self, entries: List[ViewportEntry]) -> int:
+	def _max_col(self, entries: list[ViewportEntry]) -> int:
 		values = [len(e.text) + e.col for e in entries]
 		if not values:
 			return 0
@@ -269,7 +269,7 @@ class AbstractViewport:
 		len_replace = len(replacement)
 		return f'{text[:index]}{replacement}{text[index + len_replace:]}'
 
-	def _assemble_entries(self, entries: List[ViewportEntry]) -> str:
+	def _assemble_entries(self, entries: list[ViewportEntry]) -> str:
 		if not entries:
 			return ''
 
@@ -385,7 +385,7 @@ class EditViewport(AbstractViewport):
 @dataclass
 class ViewportState:
 	cur_pos: int
-	displayed_entries: List[ViewportEntry]
+	displayed_entries: list[ViewportEntry]
 	scroll_pct: Optional[int]
 	scroll_pos: Optional[int] = 0
 
@@ -436,7 +436,7 @@ class Viewport(AbstractViewport):
 
 	def update(
 		self,
-		lines: List[ViewportEntry],
+		lines: list[ViewportEntry],
 		cur_pos: int = 0,
 		scroll_pos: Optional[int] = None
 	):
@@ -490,7 +490,7 @@ class Viewport(AbstractViewport):
 
 	def _get_viewport_state(
 		self,
-		entries: List[ViewportEntry],
+		entries: list[ViewportEntry],
 		cur_pos: int,
 		scroll_pos: Optional[int] = 0
 	) -> ViewportState:
@@ -535,7 +535,7 @@ class Viewport(AbstractViewport):
 
 	def _get_visible_entries(
 		self,
-		entries: List[ViewportEntry],
+		entries: list[ViewportEntry],
 		cur_pos: int,
 		screen_rows: int,
 		scroll_pos: Optional[int],
@@ -570,7 +570,7 @@ class Viewport(AbstractViewport):
 
 		return [entry for entry in entries if start <= entry.row < end]
 
-	def _adjust_entries_row(self, entries: List[ViewportEntry]) -> List[ViewportEntry]:
+	def _adjust_entries_row(self, entries: list[ViewportEntry]) -> list[ViewportEntry]:
 		assert self._state is not None
 		modified = []
 
@@ -585,7 +585,7 @@ class Viewport(AbstractViewport):
 		len_replace = len(replacement)
 		return f'{text[:index]}{replacement}{text[index + len_replace:]}'
 
-	def _unique_rows(self, entries: List[ViewportEntry]) -> int:
+	def _unique_rows(self, entries: list[ViewportEntry]) -> int:
 		return len(set([e.row for e in entries]))
 
 
@@ -847,11 +847,11 @@ class SelectMenu(AbstractCurses):
 		else:
 			self._horizontal_cols = 1
 
-		self._row_entries: List[List[MenuCell]] = []
+		self._row_entries: list[list[MenuCell]] = []
 		self._prev_scroll_pos: int = 0
 		self._cur_pos: Optional[int] = None
 
-		self._visible_entries: List[ViewportEntry] = []
+		self._visible_entries: list[ViewportEntry] = []
 		self._max_height, self._max_width = Tui.t().max_yx
 
 		self._help_vp: Optional[Viewport] = None
@@ -911,7 +911,7 @@ class SelectMenu(AbstractCurses):
 		if self._help_vp:
 			self._help_vp.erase()
 
-	def _footer_entries(self) -> List[ViewportEntry]:
+	def _footer_entries(self) -> list[ViewportEntry]:
 		if self._active_search:
 			filter_pattern = self._item_group.filter_pattern
 			return [ViewportEntry(f'/{filter_pattern}', 0, 0, STYLE.NORMAL)]
@@ -1078,7 +1078,7 @@ class SelectMenu(AbstractCurses):
 	def _update_viewport(
 		self,
 		viewport: Viewport,
-		entries: List[ViewportEntry],
+		entries: list[ViewportEntry],
 		cur_pos: int = 0
 	) -> None:
 		if entries:
@@ -1093,13 +1093,13 @@ class SelectMenu(AbstractCurses):
 					return idx
 		return 0
 
-	def _get_visible_items(self) -> List[MenuItem]:
+	def _get_visible_items(self) -> list[MenuItem]:
 		return [it for it in self._item_group.items if self._item_group.should_enable_item(it)]
 
-	def _list_to_cols(self, items: List[MenuItem], cols: int) -> List[List[MenuItem]]:
+	def _list_to_cols(self, items: list[MenuItem], cols: int) -> list[list[MenuItem]]:
 		return [items[i:i + cols] for i in range(0, len(items), cols)]
 
-	def _get_col_widths(self) -> List[int]:
+	def _get_col_widths(self) -> list[int]:
 		cols_widths = self._calc_col_widths(self._row_entries, self._horizontal_cols)
 		return [col_width + len(self._cursor_char) + self._item_distance() for col_width in cols_widths]
 
@@ -1109,7 +1109,7 @@ class SelectMenu(AbstractCurses):
 		else:
 			return self._column_spacing
 
-	def _get_row_entries(self) -> List[ViewportEntry]:
+	def _get_row_entries(self) -> list[ViewportEntry]:
 		cells = self._assemble_menu_cells()
 		entries = []
 
@@ -1141,9 +1141,9 @@ class SelectMenu(AbstractCurses):
 
 	def _calc_col_widths(
 		self,
-		row_chunks: List[List[MenuCell]],
+		row_chunks: list[list[MenuCell]],
 		cols: int
-	) -> List[int]:
+	) -> list[int]:
 		col_widths = []
 		for col in range(cols):
 			col_entries = []
@@ -1156,7 +1156,7 @@ class SelectMenu(AbstractCurses):
 
 		return col_widths
 
-	def _assemble_menu_cells(self) -> List[MenuCell]:
+	def _assemble_menu_cells(self) -> list[MenuCell]:
 		items = self._get_visible_items()
 		entries = []
 
@@ -1195,7 +1195,7 @@ class SelectMenu(AbstractCurses):
 
 		self._preview_vp.update(entries, scroll_pos=self._prev_scroll_pos)
 
-	def _calc_prev_scroll_pos(self, entries: List[ViewportEntry]):
+	def _calc_prev_scroll_pos(self, entries: list[ViewportEntry]):
 		total_rows = max([e.row for e in entries]) + 1  # rows start with 0 and we need the count
 
 		if self._prev_scroll_pos >= total_rows:

--- a/archinstall/tui/help.py
+++ b/archinstall/tui/help.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List
 
 
 class HelpTextGroupId(Enum):
@@ -13,13 +12,13 @@ class HelpTextGroupId(Enum):
 @dataclass
 class HelpText:
 	description: str
-	keys: List[str] = field(default_factory=list)
+	keys: list[str] = field(default_factory=list)
 
 
 @dataclass
 class HelpGroup:
 	group_id: HelpTextGroupId
-	group_entries: List[HelpText]
+	group_entries: list[HelpText]
 
 	def get_desc_width(self) -> int:
 		return max([len(e.description) for e in self.group_entries])

--- a/archinstall/tui/menu_item.py
+++ b/archinstall/tui/menu_item.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Optional, List, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from typing import Callable, ClassVar
 
 from ..lib.output import unicode_ljust
@@ -15,8 +15,8 @@ class MenuItem:
 	action: Optional[Callable[[Any], Any]] = None
 	enabled: bool = True
 	mandatory: bool = False
-	dependencies: List[str | Callable[[], bool]] = field(default_factory=list)
-	dependencies_not: List[str] = field(default_factory=list)
+	dependencies: list[str | Callable[[], bool]] = field(default_factory=list)
+	dependencies_not: list[str] = field(default_factory=list)
 	display_action: Optional[Callable[[Any], str]] = None
 	preview_action: Optional[Callable[[Any], Optional[str]]] = None
 	key: Optional[str] = None
@@ -64,10 +64,10 @@ class MenuItem:
 
 @dataclass
 class MenuItemGroup:
-	menu_items: List[MenuItem]
+	menu_items: list[MenuItem]
 	focus_item: Optional[MenuItem] = None
 	default_item: Optional[MenuItem] = None
-	selected_items: List[MenuItem] = field(default_factory=list)
+	selected_items: list[MenuItem] = field(default_factory=list)
 	sort_items: bool = False
 	checkmarks: bool = False
 
@@ -119,7 +119,7 @@ class MenuItemGroup:
 				self.default_item = item
 				break
 
-	def set_selected_by_value(self, values: Optional[Any | List[Any]]) -> None:
+	def set_selected_by_value(self, values: Optional[Any | list[Any]]) -> None:
 		if values is None:
 			return
 
@@ -194,7 +194,7 @@ class MenuItemGroup:
 		return ''
 
 	@property
-	def items(self) -> List[MenuItem]:
+	def items(self) -> list[MenuItem]:
 		f = self._filter_pattern.lower()
 		items = filter(lambda item: item.is_empty() or f in item.text.lower(), self.menu_items)
 		return list(items)
@@ -246,7 +246,7 @@ class MenuItemGroup:
 		else:
 			return item == self.focus_item
 
-	def _first(self, items: List[MenuItem], ignore_empty: bool) -> Optional[MenuItem]:
+	def _first(self, items: list[MenuItem], ignore_empty: bool) -> Optional[MenuItem]:
 		for item in items:
 			if not ignore_empty:
 				return item

--- a/archinstall/tui/types.py
+++ b/archinstall/tui/types.py
@@ -1,7 +1,7 @@
 import curses
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Optional, List, Any
+from typing import Optional, Any
 
 from .menu_item import MenuItem
 
@@ -52,7 +52,7 @@ class MenuKeys(Enum):
 	SCROLL_DOWN = {540}
 
 	@classmethod
-	def from_ord(cls, key: int) -> List['MenuKeys']:
+	def from_ord(cls, key: int) -> list['MenuKeys']:
 		matches = []
 
 		for group in MenuKeys:
@@ -139,7 +139,7 @@ class Chars:
 @dataclass
 class Result:
 	type_: ResultType
-	_item: Optional[MenuItem | List[MenuItem] | str]
+	_item: Optional[MenuItem | list[MenuItem] | str]
 
 	def has_item(self) -> bool:
 		return self._item is not None
@@ -147,14 +147,14 @@ class Result:
 	def get_value(self) -> Any:
 		return self.item().get_value()
 
-	def get_values(self) -> List[Any]:
+	def get_values(self) -> list[Any]:
 		return [i.get_value() for i in self.items()]
 
 	def item(self) -> MenuItem:
 		assert self._item is not None and isinstance(self._item, MenuItem)
 		return self._item
 
-	def items(self) -> List[MenuItem]:
+	def items(self) -> list[MenuItem]:
 		assert self._item is not None and isinstance(self._item, list)
 		return self._item
 

--- a/examples/minimal_installation.py
+++ b/examples/minimal_installation.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List
 
 import archinstall
 from archinstall import info, debug
@@ -72,8 +71,8 @@ def prompt_disk_layout() -> None:
 
 def parse_disk_encryption() -> None:
 	if enc_password := archinstall.arguments.get('!encryption-password', None):
-		modification: List[disk.DeviceModification] = archinstall.arguments['disk_config']
-		partitions: List[disk.PartitionModification] = []
+		modification: list[disk.DeviceModification] = archinstall.arguments['disk_config']
+		partitions: list[disk.PartitionModification] = []
 
 		# encrypt all partitions except the /boot
 		for mod in modification:


### PR DESCRIPTION
## PR Description:

`typing.List` is deprecated:
- https://docs.python.org/3/library/typing.html#typing.List
- https://docs.astral.sh/ruff/rules/deprecated-import/

This PR doesn't touch some disk-related code to avoid merge conflicts with #2775 .

Follow-up to #2673.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
