### PR TITLE
Enable stricter global mypy defaults

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -102,7 +102,7 @@ if 'sphinx' not in sys.modules:
 		exit(1)
 
 
-def parse_unspecified_argument_list(unknowns: list, multiple: bool = False, err: bool = False) -> dict:
+def parse_unspecified_argument_list(unknowns: list, multiple: bool = False, err: bool = False) -> dict:  # type: ignore[type-arg]
 	"""We accept arguments not defined to the parser. (arguments "ad hoc").
 	Internally argparse return to us a list of words so we have to parse its contents, manually.
 	We accept following individual syntax for each argument
@@ -150,7 +150,7 @@ def parse_unspecified_argument_list(unknowns: list, multiple: bool = False, err:
 	return config
 
 
-def cleanup_empty_args(args: Union[Namespace, dict]) -> dict:
+def cleanup_empty_args(args: Union[Namespace, dict]) -> dict:  # type: ignore[type-arg]
 	"""
 	Takes arguments (dictionary or argparse Namespace) and removes any
 	None values. This ensures clean mergers during dict.update(args)
@@ -284,7 +284,7 @@ post_process_arguments(arguments)
 
 # @archinstall.plugin decorator hook to programmatically add
 # plugins in runtime. Useful in profiles_bck and other things.
-def plugin(f, *args, **kwargs) -> None:
+def plugin(f, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
 	plugins[f.__name__] = f
 
 

--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -119,7 +119,7 @@ class Profile:
 		are needed
 		"""
 
-	def json(self) -> dict:
+	def json(self) -> dict[str, Any]:
 		"""
 		Returns a json representation of the profile
 		"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,13 +5,13 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 
 
-def process_docstring(app, what, name, obj, options, lines) -> None:
+def process_docstring(app, what, name, obj, options, lines) -> None:  # type: ignore[no-untyped-def]
 	spaces_pat = re.compile(r"( {8})")
 	ll = [spaces_pat.sub("    ", line) for line in lines]
 	lines[:] = ll
 
 
-def setup(app) -> None:
+def setup(app) -> None:  # type: ignore[no-untyped-def]
 	app.connect('autodoc-process-docstring', process_docstring)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,13 +70,13 @@ exclude = "^build/"
 check_untyped_defs = true
 disallow_any_explicit = false
 disallow_any_expr = false
-disallow_any_generics = false
-disallow_any_unimported = false
-disallow_incomplete_defs = false
+disallow_any_generics = true
+disallow_any_unimported = true
+disallow_incomplete_defs = true
 disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
-disallow_untyped_defs = false
+disallow_untyped_defs = true
 extra_checks = true
 strict = false
 strict_equality = true
@@ -89,14 +89,14 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = "archinstall.examples.*"
 disallow_any_explicit = true
-disallow_any_generics = true
-disallow_any_unimported = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
 follow_imports = "silent"
 
 [[tool.mypy.overrides]]
 module = "archinstall.lib.*"
+disallow_any_generics = false
+disallow_any_unimported = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
 warn_return_any = false
 warn_unreachable = false
 


### PR DESCRIPTION
## PR Description:
Some checks only need to be disabled for the lib/ directory now.

The new `type: ignore` statements can be revisited in the future.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
