### PR TITLE
Remove most of the remaining deprecated typing imports

### DIFF
--- a/archinstall/lib/boot.py
+++ b/archinstall/lib/boot.py
@@ -1,5 +1,6 @@
 import time
-from typing import Iterator, Optional
+from collections.abc import Iterator
+from typing import Optional
 from .exceptions import SysCallError
 from .general import SysCommand, SysCommandWorker, locate_binary
 from .installer import Installer

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Any, Optional, TYPE_CHECKING, Set
+from typing import Any, Optional, TYPE_CHECKING
 
 from ..interactions.general_conf import ask_abort
 from .device_handler import device_handler
@@ -251,7 +251,7 @@ class FilesystemHandler:
 		lvm_config: LvmConfiguration,
 		enc_mods: dict[PartitionModification, Luks2] = {}
 	) -> None:
-		pv_paths: Set[Path] = set()
+		pv_paths: set[Path] = set()
 
 		for vg in lvm_config.vol_groups:
 			pv_paths |= self._get_all_pv_dev_paths(vg.pvs, enc_mods)
@@ -262,8 +262,8 @@ class FilesystemHandler:
 		self,
 		pvs: list[PartitionModification],
 		enc_mods: dict[PartitionModification, Luks2] = {}
-	) -> Set[Path]:
-		pv_paths: Set[Path] = set()
+	) -> set[Path]:
+		pv_paths: set[Path] = set()
 
 		for pv in pvs:
 			if enc_pv := enc_mods.get(pv, None):

--- a/archinstall/lib/disk/partitioning_menu.py
+++ b/archinstall/lib/disk/partitioning_menu.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, TYPE_CHECKING, Optional, Tuple
+from typing import Any, TYPE_CHECKING, Optional
 from dataclasses import dataclass
 
 from ..utils.util import prompt_dir
@@ -287,7 +287,7 @@ class PartitioningList(ListManager):
 		assert size
 		return size
 
-	def _prompt_size(self) -> Tuple[Size, Size]:
+	def _prompt_size(self) -> tuple[Size, Size]:
 		device_info = self._device.device_info
 
 		text = str(_('Current free sectors on device {}:')).format(device_info.path) + '\n\n'

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -14,9 +14,10 @@ import urllib.parse
 from urllib.request import Request, urlopen
 import urllib.error
 import pathlib
+from collections.abc import Callable, Iterator
 from datetime import datetime, date
 from enum import Enum
-from typing import Callable, Optional, Any, Union, Iterator, TYPE_CHECKING
+from typing import Optional, Any, Union, TYPE_CHECKING
 from select import epoll, EPOLLIN, EPOLLHUP
 from shutil import which
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -5,8 +5,9 @@ import shlex
 import shutil
 import subprocess
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Optional, TYPE_CHECKING, Union, Callable
+from typing import Any, Optional, TYPE_CHECKING, Union
 
 from . import disk
 from .exceptions import DiskError, ServiceException, RequirementError, HardwareIncompatibilityError, SysCallError

--- a/archinstall/lib/interactions/disk_conf.py
+++ b/archinstall/lib/interactions/disk_conf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
-from typing import Optional, Tuple
+from typing import Optional
 
 from .. import disk
 from ..disk.device_model import BtrfsMountOption
@@ -452,7 +452,7 @@ def suggest_multi_disk_layout(
 			delta = device.device_info.total_size - desired_root_partition_size
 			devices_delta[device] = delta
 
-	sorted_delta: list[Tuple[disk.BDevice, Any]] = sorted(devices_delta.items(), key=lambda x: x[1])
+	sorted_delta: list[tuple[disk.BDevice, Any]] = sorted(devices_delta.items(), key=lambda x: x[1])
 	root_device: Optional[disk.BDevice] = sorted_delta[0][0]
 
 	if home_device is None or root_device is None:

--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Any, Optional, TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, Optional, TYPE_CHECKING
 
 from ..output import error
 from ..output import unicode_ljust

--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, TYPE_CHECKING, Optional, Tuple
+from typing import Any, TYPE_CHECKING, Optional
 from ..output import FormattedOutput
 
 from archinstall.tui import (
@@ -97,7 +97,7 @@ class ListManager:
 		else:
 			return self._data
 
-	def _prepare_selection(self, data_formatted: dict[str, Any]) -> Tuple[list[str], str]:
+	def _prepare_selection(self, data_formatted: dict[str, Any]) -> tuple[list[str], str]:
 		# header rows are mapped to None so make sure
 		# to exclude those from the selectable data
 		options: list[str] = [key for key, val in data_formatted.items() if val is not None]

--- a/archinstall/lib/menu/menu_helper.py
+++ b/archinstall/lib/menu/menu_helper.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple, Optional
+from typing import Any, Optional
 
 from archinstall.lib.output import FormattedOutput
 
@@ -11,8 +11,8 @@ class MenuHelper:
 	@staticmethod
 	def create_table(
 		data: Optional[list[Any]] = None,
-		table_data: Optional[Tuple[list[Any], str]] = None,
-	) -> Tuple[MenuItemGroup, str]:
+		table_data: Optional[tuple[list[Any], str]] = None,
+	) -> tuple[MenuItemGroup, str]:
 		if data is not None:
 			table_text = FormattedOutput.as_table(data)
 			rows = table_text.split('\n')
@@ -52,7 +52,7 @@ class MenuHelper:
 		return display_data
 
 	@staticmethod
-	def _prepare_selection(table: dict[str, Any]) -> Tuple[dict[str, Any], str]:
+	def _prepare_selection(table: dict[str, Any]) -> tuple[dict[str, Any], str]:
 		# header rows are mapped to None so make sure to exclude those from the selectable data
 		options = {key: val for key, val in table.items() if val is not None}
 		header = ''

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -4,7 +4,7 @@ import urllib.parse
 from pathlib import Path
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional, TYPE_CHECKING, Tuple
+from typing import Any, Optional, TYPE_CHECKING
 
 from .menu import AbstractSubMenu, ListManager
 from .networking import fetch_data_from_url
@@ -339,7 +339,7 @@ def select_mirror_regions(preset: dict[str, list[MirrorStatusEntryV3]]) -> dict[
 		case ResultType.Reset:
 			return {}
 		case ResultType.Selection:
-			selected_mirrors: list[Tuple[str, list[MirrorStatusEntryV3]]] = result.get_values()
+			selected_mirrors: list[tuple[str, list[MirrorStatusEntryV3]]] = result.get_values()
 			return {name: mirror for name, mirror in selected_mirrors}
 
 

--- a/archinstall/lib/models/network_configuration.py
+++ b/archinstall/lib/models/network_configuration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Any, TYPE_CHECKING, Tuple
+from typing import Optional, Any, TYPE_CHECKING
 
 from ..profile import ProfileConfiguration
 
@@ -62,8 +62,8 @@ class Nic:
 		)
 
 	def as_systemd_config(self) -> str:
-		match: list[Tuple[str, str]] = []
-		network: list[Tuple[str, str]] = []
+		match: list[tuple[str, str]] = []
+		network: list[tuple[str, str]] = []
 
 		if self.iface:
 			match.append(('Name', self.iface))

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -2,10 +2,11 @@ import logging
 import os
 import sys
 import unicodedata
+from collections.abc import Callable
 from enum import Enum
 
 from pathlib import Path
-from typing import Union, Any, Callable, Optional, TYPE_CHECKING
+from typing import Union, Any, Optional, TYPE_CHECKING
 from dataclasses import asdict, is_dataclass
 
 from .storage import storage

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -1,7 +1,7 @@
 import dataclasses
 import json
 import ssl
-from typing import Any, Tuple
+from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import urlopen
@@ -91,7 +91,7 @@ def find_packages(*names: str) -> dict[str, Any]:
 	return result
 
 
-def validate_package_list(packages: list) -> Tuple[list, list]:
+def validate_package_list(packages: list) -> tuple[list, list]:
 	"""
 	Validates a list of given packages.
 	return: Tuple of lists containing valid packavges in the first and invalid

--- a/archinstall/lib/pacman/__init__.py
+++ b/archinstall/lib/pacman/__init__.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 import time
 import re
-from typing import TYPE_CHECKING, Any, Callable, Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Union
 from shutil import copy2
 
 from ..general import SysCommand

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -5,11 +5,11 @@ import curses.panel
 import os
 import signal
 from abc import ABCMeta, abstractmethod
+from collections.abc import Callable
 from curses.textpad import Textbox
 from dataclasses import dataclass
 from types import FrameType, TracebackType
-from typing import Any, Optional, Tuple, TYPE_CHECKING, Literal
-from typing import Callable
+from typing import Any, Optional, TYPE_CHECKING, Literal
 
 from .help import Help
 from .menu_item import MenuItem, MenuItemGroup
@@ -1448,7 +1448,7 @@ class Tui:
 		Tui.t().screen.refresh()
 
 	@property
-	def max_yx(self) -> Tuple[int, int]:
+	def max_yx(self) -> tuple[int, int]:
 		return self._screen.getmaxyx()
 
 	@staticmethod

--- a/archinstall/tui/menu_item.py
+++ b/archinstall/tui/menu_item.py
@@ -1,6 +1,7 @@
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Optional, TYPE_CHECKING
-from typing import Callable, ClassVar
+from typing import ClassVar
 
 from ..lib.output import unicode_ljust
 


### PR DESCRIPTION
## PR Description:

This PR brings us closer to enabling Ruff's [UP035 rule](https://docs.astral.sh/ruff/rules/deprecated-import/).  Here's what remains:

```
$ ruff check --select=UP035 --output-format=concise .
archinstall/lib/disk/device_handler.py:9:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
archinstall/lib/disk/device_handler.py:9:1: UP035 `typing.List` is deprecated, use `list` instead
archinstall/lib/disk/device_handler.py:9:1: UP035 `typing.Dict` is deprecated, use `dict` instead
archinstall/lib/disk/device_model.py:11:1: UP035 `typing.List` is deprecated, use `list` instead
archinstall/lib/disk/device_model.py:11:1: UP035 `typing.Dict` is deprecated, use `dict` instead
```

I can fix those warnings after https://github.com/archlinux/archinstall/pull/2775 is reviewed and merged.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
