### PR TITLE
Remove unnecessary mypy overrides for lib/models/mirrors.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,11 +115,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = "archinstall.lib.models.mirrors"
-disallow_untyped_decorators = false
-disallow_subclassing_any = false
-
 [tool.bandit]
 targets = ["archinstall"]
 exclude = ["/tests"]


### PR DESCRIPTION
## PR Description:
The overrides make the checks more lenient, so let's remove them.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
