### PR TITLE
Remove redundant simple-term-menu package

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -38,6 +38,7 @@ makedepends=(
   'python-build'
   'python-installer'
   'python-wheel'
+  'python-sphinx_rtd_theme'
 )
 optdepends=(
   'python-systemd: Adds journald logging'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,7 +24,6 @@ depends=(
   'python'
   'python-pydantic'
   'python-pyparted'
-  'python-simple-term-menu'
   'systemd'
   'util-linux'
   'xfsprogs'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-    "simple-term-menu==1.6.4",
     "pyparted @ https://github.com//dcantrell/pyparted/archive/v3.13.0.tar.gz#sha512=26819e28d73420937874f52fda03eb50ab1b136574ea9867a69d46ae4976d38c4f26a2697fa70597eed90dd78a5ea209bafcc3227a17a7a5d63cff6d107c2b11",
     "pydantic==2.9.2"
 ]
@@ -111,7 +110,6 @@ warn_unreachable = false
 [[tool.mypy.overrides]]
 module = [
     "parted",
-    "simple_term_menu",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
As the new curses menu is merged, the `simple-term-menu` package is no longer needed as a dependency