### PR TITLE
Enable the W504 binary operator rule in flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 count = True
 # Several of the following could be autofixed or improved by running the code through psf/black
-ignore = E128,E722,W191,W503,W504
+ignore = E128,E722,W191,W503
 max-complexity = 40
 max-line-length = 220
 show-source = True

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -1,5 +1,5 @@
 on: [ push, pull_request ]
-name: flake8 linting (5 ignores)
+name: flake8 linting (4 ignores)
 jobs:
     flake8:
         runs-on: ubuntu-latest

--- a/archinstall/tui/help.py
+++ b/archinstall/tui/help.py
@@ -83,8 +83,8 @@ class Help:
 
 			for entry in help.group_entries:
 				help_output += (
-					entry.description.ljust(max_desc_width, ' ') +
-					', '.join(entry.keys) + '\n'
+					entry.description.ljust(max_desc_width, ' ')
+					+ ', '.join(entry.keys) + '\n'
 				)
 
 			help_output += '\n'


### PR DESCRIPTION
## PR Description:

Rules W503 and W504 are mutually exclusive, so I picked the one that is suggested for new code:
- https://peps.python.org/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
- https://www.flake8rules.com/rules/W503.html
- https://www.flake8rules.com/rules/W504.html

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
