### PR TITLE
Simplify translation call in f-string

### DIFF
--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -79,7 +79,7 @@ class ConfigurationOutput:
 		debug(self.user_config_to_json())
 
 	def confirm_config(self) -> bool:
-		header = f'{str(_("The specified configuration will be applied"))}. '
+		header = f'{_("The specified configuration will be applied")}. '
 		header += str(_('Would you like to continue?')) + '\n'
 
 		with Tui():

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -167,7 +167,7 @@ class DiskEncryptionMenu(AbstractSubMenu):
 
 		if enc_type:
 			enc_text = EncryptionType.type_to_text(enc_type)
-			return f'{str(_("Encryption type"))}: {enc_text}'
+			return f'{_("Encryption type")}: {enc_text}'
 
 		return None
 
@@ -176,7 +176,7 @@ class DiskEncryptionMenu(AbstractSubMenu):
 
 		if enc_pwd:
 			pwd_text = '*' * len(enc_pwd)
-			return f'{str(_("Encryption password"))}: {pwd_text}'
+			return f'{_("Encryption password")}: {pwd_text}'
 
 		return None
 
@@ -208,7 +208,7 @@ class DiskEncryptionMenu(AbstractSubMenu):
 
 		output = str(fido_device.path)
 		output += f' ({fido_device.manufacturer}, {fido_device.product})'
-		return f'{str(_("HSM device"))}: {output}'
+		return f'{_("HSM device")}: {output}'
 
 
 def select_encryption_type(disk_config: DiskLayoutConfiguration, preset: EncryptionType) -> Optional[EncryptionType]:

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -318,17 +318,17 @@ class GlobalMenu(AbstractMenu):
 	def _prev_additional_repos(self, item: MenuItem) -> Optional[str]:
 		if item.value:
 			repos = ', '.join(item.value)
-			return f'{str(_("Additional repositories"))}: {repos}'
+			return f'{_("Additional repositories")}: {repos}'
 		return None
 
 	def _prev_tz(self, item: MenuItem) -> Optional[str]:
 		if item.value:
-			return f'{str(_("Timezone"))}: {item.value}'
+			return f'{_("Timezone")}: {item.value}'
 		return None
 
 	def _prev_ntp(self, item: MenuItem) -> Optional[str]:
 		if item.value is not None:
-			output = f'{str(_("NTP"))}: '
+			output = f'{_("NTP")}: '
 			output += str(_('Enabled')) if item.value else str(_('Disabled'))
 			return output
 		return None
@@ -351,7 +351,7 @@ class GlobalMenu(AbstractMenu):
 
 	def _prev_swap(self, item: MenuItem) -> Optional[str]:
 		if item.value is not None:
-			output = f'{str(_("Swap on zram"))}: '
+			output = f'{_("Swap on zram")}: '
 			output += str(_('Enabled')) if item.value else str(_('Disabled'))
 			return output
 		return None
@@ -365,34 +365,34 @@ class GlobalMenu(AbstractMenu):
 
 	def _prev_hostname(self, item: MenuItem) -> Optional[str]:
 		if item.value is not None:
-			return f'{str(_("Hostname"))}: {item.value}'
+			return f'{_("Hostname")}: {item.value}'
 		return None
 
 	def _prev_root_pwd(self, item: MenuItem) -> Optional[str]:
 		if item.value is not None:
-			return f'{str(_("Root password"))}: {secret(item.value)}'
+			return f'{_("Root password")}: {secret(item.value)}'
 		return None
 
 	def _prev_audio(self, item: MenuItem) -> Optional[str]:
 		if item.value is not None:
 			config: AudioConfiguration = item.value
-			return f'{str(_("Audio"))}: {config.audio.value}'
+			return f'{_("Audio")}: {config.audio.value}'
 		return None
 
 	def _prev_parallel_dw(self, item: MenuItem) -> Optional[str]:
 		if item.value is not None:
-			return f'{str(_("Parallel Downloads"))}: {item.value}'
+			return f'{_("Parallel Downloads")}: {item.value}'
 		return None
 
 	def _prev_kernel(self, item: MenuItem) -> Optional[str]:
 		if item.value:
 			kernel = ', '.join(item.value)
-			return f'{str(_("Kernel"))}: {kernel}'
+			return f'{_("Kernel")}: {kernel}'
 		return None
 
 	def _prev_bootloader(self, item: MenuItem) -> Optional[str]:
 		if item.value is not None:
-			return f'{str(_("Bootloader"))}: {item.value.value}'
+			return f'{_("Bootloader")}: {item.value.value}'
 		return None
 
 	def _prev_disk_encryption(self, item: MenuItem) -> Optional[str]:

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -180,7 +180,7 @@ def ask_additional_packages_to_install(preset: list[str] = []) -> list[str]:
 		valid, invalid = validate_package_list(packages)
 
 		if invalid:
-			return f'{str(_("Some packages could not be found in the repository"))}: {invalid}'
+			return f'{_("Some packages could not be found in the repository")}: {invalid}'
 
 		return None
 

--- a/archinstall/lib/interactions/manage_users_conf.py
+++ b/archinstall/lib/interactions/manage_users_conf.py
@@ -40,7 +40,7 @@ class UserList(ListManager):
 				data = [d for d in data if d.username != new_user.username]
 				data += [new_user]
 		elif action == self._actions[1] and entry:  # change password
-			header = f'{str(_("User"))}: {entry.username}\n'
+			header = f'{_("User")}: {entry.username}\n'
 			new_password = get_password(str(_('Password')), header=header)
 
 			if new_password:
@@ -74,14 +74,14 @@ class UserList(ListManager):
 			case _:
 				raise ValueError('Unhandled result type')
 
-		header = f'{str(_("Username"))}: {username}\n'
+		header = f'{_("Username")}: {username}\n'
 
 		password = get_password(str(_('Password')), header=header, allow_skip=True)
 
 		if not password:
 			return None
 
-		header += f'{str(_("Password"))}: {secret(password)}\n\n'
+		header += f'{_("Password")}: {secret(password)}\n\n'
 		header += str(_('Should "{}" be a superuser (sudo)?\n')).format(username)
 
 		group = MenuItemGroup.yes_no()

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -177,7 +177,7 @@ class CustomMirrorList(ListManager):
 			case _:
 				raise ValueError('Unhandled return type')
 
-		header = f'{str(_("Name"))}: {name}'
+		header = f'{_("Name")}: {name}'
 
 		edit_result = EditMenu(
 			str(_('Url')),
@@ -195,7 +195,7 @@ class CustomMirrorList(ListManager):
 			case _:
 				raise ValueError('Unhandled return type')
 
-		header += f'\n{str(_("Url"))}: {url}\n'
+		header += f'\n{_("Url")}: {url}\n'
 		prompt = f'{header}\n' + str(_('Select signature check'))
 
 		sign_chk_items = [MenuItem(s.value, value=s.value) for s in SignCheck]
@@ -217,7 +217,7 @@ class CustomMirrorList(ListManager):
 			case _:
 				raise ValueError('Unhandled return type')
 
-		header += f'{str(_("Signature check"))}: {sign_check.value}\n'
+		header += f'{_("Signature check")}: {sign_check.value}\n'
 		prompt = f'{header}\n' + 'Select signature option'
 
 		sign_opt_items = [MenuItem(s.value, value=s.value) for s in SignOption]

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -139,7 +139,7 @@ class ProfileMenu(AbstractSubMenu):
 
 	def _prev_greeter(self, item: MenuItem) -> Optional[str]:
 		if item.value:
-			return f'{str(_("Greeter"))}: {item.value.value}'
+			return f'{_("Greeter")}: {item.value.value}'
 		return None
 
 	def _preview_profile(self, item: MenuItem) -> Optional[str]:

--- a/archinstall/lib/utils/util.py
+++ b/archinstall/lib/utils/util.py
@@ -43,9 +43,9 @@ def get_password(
 		hidden = secret(password)
 
 		if header is not None:
-			confirmation_header = f'{header}{str(_("Pssword"))}: {hidden}\n'
+			confirmation_header = f'{header}{_("Pssword")}: {hidden}\n'
 		else:
-			confirmation_header = f'{str(_("Password"))}: {hidden}\n'
+			confirmation_header = f'{_("Password")}: {hidden}\n'
 
 		result = EditMenu(
 			str(_('Confirm password')),


### PR DESCRIPTION
Inside an f-string there's no need to use `f'str(_('test'))'` but can simply be `f'{_('test')}'`