### PR TITLE
Replace deprecated socket.error exception with OSError

### DIFF
--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -192,7 +192,7 @@ def ping(hostname, timeout=5) -> int:
 				if icmp_type == 0 and response[-len(random_identifier):] == random_identifier:
 					latency = round((time.time() - started) * 1000)
 					break
-		except socket.error as error:
+		except OSError as error:
 			debug(f"Error: {error}")
 			break
 


### PR DESCRIPTION
## PR Description:

This warning was raised by the UP024 rule in Ruff.

Docs:
- https://docs.python.org/3/library/socket.html#socket.error
- https://docs.astral.sh/ruff/rules/os-error-alias/

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
