### PR TITLE
Converting systemctl call to a simple ln call for debus reasons 

### DIFF
--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -37,7 +37,7 @@ class PipewireProfile(Profile):
 			service_dir.mkdir(parents=True, exist_ok=True)
 
 			# Set ownership of the entire user catalogue
-			install_session.arch_chroot(f'chown -R {user.username}:{user.username} "/home/{user.username}"', run_as=user.username)
+			install_session.arch_chroot(f'chown -R {user.username}:{user.username} /home/{user.username}')
 
 			# symlink in the correct pipewire systemd items
 			install_session.arch_chroot(f'ln -s /usr/lib/systemd/user/pipewire-pulse.service {service_dir}/pipewire-pulse.service', run_as=user.username)

--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -32,6 +32,7 @@ class PipewireProfile(Profile):
 			users = [users]
 
 		for user in users:
+			(install_session.target / "home" / user / ".config" / "systemd" / "user" / "default.target.wants").mkdir(parents=True, exist_ok=True)
 			install_session.arch_chroot('ln -s /usr/lib/systemd/user/pipewire-pulse.service ~/.config/systemd/user/default.target.wants/pipewire-pulse.service', run_as=user.username)
 			install_session.arch_chroot('ln -s /usr/lib/systemd/user/pipewire-pulse.socket ~/.config/systemd/user/default.target.wants/pipewire-pulse.socket', run_as=user.username)
 

--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -32,7 +32,7 @@ class PipewireProfile(Profile):
 			users = [users]
 
 		for user in users:
-			(install_session.target / "home" / user / ".config" / "systemd" / "user" / "default.target.wants").mkdir(parents=True, exist_ok=True)
+			(install_session.target / "home" / user.username / ".config" / "systemd" / "user" / "default.target.wants").mkdir(parents=True, exist_ok=True)
 			install_session.arch_chroot('ln -s /usr/lib/systemd/user/pipewire-pulse.service ~/.config/systemd/user/default.target.wants/pipewire-pulse.service', run_as=user.username)
 			install_session.arch_chroot('ln -s /usr/lib/systemd/user/pipewire-pulse.socket ~/.config/systemd/user/default.target.wants/pipewire-pulse.socket', run_as=user.username)
 

--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -40,8 +40,8 @@ class PipewireProfile(Profile):
 			install_session.arch_chroot(f'chown -R {user.username}:{user.username} /home/{user.username}')
 
 			# symlink in the correct pipewire systemd items
-			install_session.arch_chroot(f'ln -s /usr/lib/systemd/user/pipewire-pulse.service {service_dir}/pipewire-pulse.service', run_as=user.username)
-			install_session.arch_chroot(f'ln -s /usr/lib/systemd/user/pipewire-pulse.socket {service_dir}/pipewire-pulse.socket', run_as=user.username)
+			install_session.arch_chroot(f'ln -s /usr/lib/systemd/user/pipewire-pulse.service /home/{user.username}/.config/systemd/user/default.target.wants/pipewire-pulse.service', run_as=user.username)
+			install_session.arch_chroot(f'ln -s /usr/lib/systemd/user/pipewire-pulse.socket /home/{user.username}/.config/systemd/user/default.target.wants/pipewire-pulse.socket', run_as=user.username)
 
 	def install(self, install_session: 'Installer') -> None:
 		super().install(install_session)

--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -32,7 +32,8 @@ class PipewireProfile(Profile):
 			users = [users]
 
 		for user in users:
-			install_session.arch_chroot('systemctl enable --user pipewire-pulse.service', run_as=user.username)
+			install_session.arch_chroot('ln -s /usr/lib/systemd/user/pipewire-pulse.service ~/.config/systemd/user/default.target.wants/pipewire-pulse.service', run_as=user.username)
+			install_session.arch_chroot('ln -s /usr/lib/systemd/user/pipewire-pulse.socket ~/.config/systemd/user/default.target.wants/pipewire-pulse.socket', run_as=user.username)
 
 	def install(self, install_session: 'Installer') -> None:
 		super().install(install_session)

--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -37,7 +37,7 @@ class PipewireProfile(Profile):
 			service_dir.mkdir(parents=True, exist_ok=True)
 
 			# Set ownership of the entire user catalogue
-			install_session.arch_chroot(f'chown -R {user.username}:{user.username} {install_session.target / "home" / user.username}', run_as=user.username)
+			install_session.arch_chroot(f'chown -R {user.username}:{user.username} "/home/{user.username}"', run_as=user.username)
 
 			# symlink in the correct pipewire systemd items
 			install_session.arch_chroot(f'ln -s /usr/lib/systemd/user/pipewire-pulse.service {service_dir}/pipewire-pulse.service', run_as=user.username)


### PR DESCRIPTION
- This fix issue: #2764

## PR Description:

Due to certain `dbus` concerns, instead of using the slightly more complicated and untested `Boot()` method where we `systemd-nspawn` the installation, we simply `arch-chroot ln -s ...` in the service and socket needed for each user when enabling pipewire.

The old code appears to work in `master`, so this is just an additional safeguard against issue #2764