### PR TITLE
Remove unreachable return statement in _handle_interrupt

### DIFF
--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -1218,8 +1218,6 @@ class SelectMenu(AbstractCurses):
 		else:
 			return False
 
-		return True
-
 	def _process_input_key(self, key: int) -> Result | None:
 		key_handles = MenuKeys.from_ord(key)
 


### PR DESCRIPTION
## PR Description:

mypy flags the return statement when you enable unreachable warnings for tui/.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
