### PR TITLE
Enable arguments-renamed Pylint rule and fix warnings

### DIFF
--- a/archinstall/lib/disk/partitioning_menu.py
+++ b/archinstall/lib/disk/partitioning_menu.py
@@ -52,11 +52,11 @@ class PartitioningList(ListManager):
 		display_actions = list(self._actions.values())
 		super().__init__(prompt, device_partitions, display_actions[:2], display_actions[3:])
 
-	def selected_action_display(self, partition: PartitionModification) -> str:
-		if partition.status == ModificationStatus.Create:
+	def selected_action_display(self, selection: PartitionModification) -> str:
+		if selection.status == ModificationStatus.Create:
 			return str(_('Partition - New'))
 		else:
-			return str(partition.dev_path)
+			return str(selection.dev_path)
 
 	def filter_options(self, selection: PartitionModification, options: list[str]) -> list[str]:
 		not_filter = []

--- a/archinstall/lib/disk/subvolume_menu.py
+++ b/archinstall/lib/disk/subvolume_menu.py
@@ -22,8 +22,8 @@ class SubvolumeMenu(ListManager):
 		]
 		super().__init__(prompt, btrfs_subvols, [self._actions[0]], self._actions[1:])
 
-	def selected_action_display(self, subvolume: SubvolumeModification) -> str:
-		return str(subvolume.name)
+	def selected_action_display(self, selection: SubvolumeModification) -> str:
+		return str(selection.name)
 
 	def _add_subvolume(self, preset: SubvolumeModification | None = None) -> SubvolumeModification | None:
 		result = EditMenu(

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -87,8 +87,8 @@ class JSON(json.JSONEncoder, json.JSONDecoder):
 	A safe JSON encoder that will omit private information in dicts (starting with !)
 	"""
 
-	def encode(self, obj: Any) -> str:
-		return super().encode(jsonify(obj))
+	def encode(self, o: Any) -> str:
+		return super().encode(jsonify(o))
 
 
 class UNSAFE_JSON(json.JSONEncoder, json.JSONDecoder):
@@ -96,8 +96,8 @@ class UNSAFE_JSON(json.JSONEncoder, json.JSONDecoder):
 	UNSAFE_JSON will call/encode and keep private information in dicts (starting with !)
 	"""
 
-	def encode(self, obj: Any) -> str:
-		return super().encode(jsonify(obj, safe=False))
+	def encode(self, o: Any) -> str:
+		return super().encode(jsonify(o, safe=False))
 
 
 class SysCommandWorker:

--- a/archinstall/lib/interactions/manage_users_conf.py
+++ b/archinstall/lib/interactions/manage_users_conf.py
@@ -28,8 +28,8 @@ class UserList(ListManager):
 		]
 		super().__init__(prompt, lusers, [self._actions[0]], self._actions[1:])
 
-	def selected_action_display(self, user: User) -> str:
-		return user.username
+	def selected_action_display(self, selection: User) -> str:
+		return selection.username
 
 	def handle_action(self, action: str, entry: User | None, data: list[User]) -> list[User]:
 		if action == self._actions[0]:  # add

--- a/archinstall/lib/interactions/network_menu.py
+++ b/archinstall/lib/interactions/network_menu.py
@@ -26,8 +26,8 @@ class ManualNetworkConfig(ListManager):
 		]
 		super().__init__(prompt, preset, [self._actions[0]], self._actions[1:])
 
-	def selected_action_display(self, nic: Nic) -> str:
-		return nic.iface if nic.iface else ''
+	def selected_action_display(self, selection: Nic) -> str:
+		return selection.iface if selection.iface else ''
 
 	def handle_action(self, action: str, entry: Nic | None, data: list[Nic]) -> list[Nic]:
 		if action == self._actions[0]:  # add

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -137,8 +137,8 @@ class CustomMirrorList(ListManager):
 			self._actions[1:]
 		)
 
-	def selected_action_display(self, mirror: CustomMirror) -> str:
-		return mirror.name
+	def selected_action_display(self, selection: CustomMirror) -> str:
+		return selection.name
 
 	def handle_action(
 		self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ max-line-length = 220
 disable = [
     "C",
     "R",
-    "arguments-renamed",
     "attribute-defined-outside-init",
     "bad-indentation",
     "bare-except",


### PR DESCRIPTION
## PR Description:

Docs: https://pylint.pycqa.org/en/latest/user_guide/messages/warning/arguments-renamed.html

The `selection` parameter is defined in the base `ListManager` class: https://github.com/archlinux/archinstall/blob/25172bd0f8718d151ee2cb332a05bb5fe0eadd8d/archinstall/lib/menu/list_manager.py#L161

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
