### PR TITLE
Only skip unused-import checks in  __init__.py files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,6 @@ select = [
 ignore = [
     "E701",     # multiple-statements-on-one-line-colon
     "E722",     # bare-except
-    "F401",     # unused-import
     "PLW2901",  # redefined-loop-name
     "UP006",    # non-pep585-annotation
     "UP007",    # non-pep604-annotation
@@ -209,3 +208,6 @@ ignore = [
 
 [tool.ruff.lint.mccabe]
 max-complexity = 40
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]  # unused-import


### PR DESCRIPTION
## PR Description:

This will help catch unused imports in other files when using Ruff.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
