### PR TITLE
Changed the invitation link to discord to go from #general to #help

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Patch releases will be done against their own branches, branched from stable tag
 ## Discussions
 
 Currently, questions, bugs and suggestions should be reported through [GitHub issue tracker](https://github.com/archlinux/archinstall/issues).<br>
-For less formal discussions there is also an [archinstall Discord server](https://discord.gg/cqXU88y).
+For less formal discussions there is also an [archinstall Discord server](https://discord.gg/aDeMffrxNg).
 
 ## Coding convention
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Just another guided/automated [Arch Linux](https://wiki.archlinux.org/index.php/Arch_Linux) installer with a twist.
 The installer also doubles as a python library to install Arch Linux and manage services, packages, and other things inside the installed system *(Usually from a live medium)*.
 
-* archinstall [discord](https://discord.gg/cqXU88y) server
+* archinstall [discord](https://discord.gg/aDeMffrxNg) server
 * archinstall [matrix.org](https://app.element.io/#/room/#archinstall:matrix.org) channel
 * archinstall [#archinstall@irc.libera.chat](irc://#archinstall@irc.libera.chat:6697)
 * archinstall [documentation](https://archinstall.archlinux.page/)
@@ -59,7 +59,7 @@ archinstall --config <path to user config file or URL> --creds <path to user cre
 # Help or Issues
 
 If you come across any issues, kindly submit your issue here on Github or post your query in the
-[discord](https://discord.gg/cqXU88y) help channel.
+[discord](https://discord.gg/aDeMffrxNg) help channel.
 
 When submitting an issue, please:
 * Provide the stacktrace of the output if applicable

--- a/docs/help/discord.rst
+++ b/docs/help/discord.rst
@@ -5,7 +5,7 @@ Discord
 
 There's a discord channel which is frequented by some `contributors <https://github.com/archlinux/archinstall/graphs/contributors>`_.
 
-To join the server, head over to `https://discord.gg/cqXU88y <https://discord.gg/cqXU88y>`_ and join in.
+To join the server, head over to `https://discord.gg/aDeMffrxNg <https://discord.gg/aDeMffrxNg>`_ and join in.
 There's not many rules other than common sense and to treat others with respect. The general chat is for off-topic things as well.
 
 There's the ``@Party Animals`` role if you want notifications of new releases which is posted in the ``#Release Party`` channel.


### PR DESCRIPTION
This just helps sort out the discord community a little bit.
As people tend to ask for help in the channel they land in, which before this PR was #general causing a bit of frustration.