### PR TITLE
Remove unused Any instances from TYPE_CHECKING blocks

### DIFF
--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import archinstall
 from archinstall.default_profiles.profile import Profile, ProfileType
@@ -6,7 +6,6 @@ from archinstall.default_profiles.profile import Profile, ProfileType
 if TYPE_CHECKING:
 	from archinstall.lib.installer import Installer
 	from archinstall.lib.models import User
-	_: Any
 
 
 class PipewireProfile(Profile):

--- a/archinstall/default_profiles/desktops/awesome.py
+++ b/archinstall/default_profiles/desktops/awesome.py
@@ -1,11 +1,10 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
 if TYPE_CHECKING:
 	from archinstall.lib.installer import Installer
-	_: Any
 
 
 class AwesomeProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/bspwm.py
+++ b/archinstall/default_profiles/desktops/bspwm.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class BspwmProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/budgie.py
+++ b/archinstall/default_profiles/desktops/budgie.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class BudgieProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/cinnamon.py
+++ b/archinstall/default_profiles/desktops/cinnamon.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class CinnamonProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/cosmic.py
+++ b/archinstall/default_profiles/desktops/cosmic.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class CosmicProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/cutefish.py
+++ b/archinstall/default_profiles/desktops/cutefish.py
@@ -1,11 +1,10 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
 if TYPE_CHECKING:
 	from archinstall.lib.installer import Installer
-	_: Any
 
 
 class CutefishProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/deepin.py
+++ b/archinstall/default_profiles/desktops/deepin.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class DeepinProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/enlightenment.py
+++ b/archinstall/default_profiles/desktops/enlightenment.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class EnlighenmentProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/gnome.py
+++ b/archinstall/default_profiles/desktops/gnome.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class GnomeProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/i3.py
+++ b/archinstall/default_profiles/desktops/i3.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class I3wmProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/lxqt.py
+++ b/archinstall/default_profiles/desktops/lxqt.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class LxqtProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/mate.py
+++ b/archinstall/default_profiles/desktops/mate.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class MateProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class PlasmaProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/qtile.py
+++ b/archinstall/default_profiles/desktops/qtile.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class QtileProfile(XorgProfile):

--- a/archinstall/default_profiles/desktops/xfce4.py
+++ b/archinstall/default_profiles/desktops/xfce4.py
@@ -1,10 +1,5 @@
-from typing import TYPE_CHECKING, Any
-
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class Xfce4Profile(XorgProfile):

--- a/archinstall/default_profiles/tailored.py
+++ b/archinstall/default_profiles/tailored.py
@@ -1,11 +1,10 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from archinstall.default_profiles.profile import ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
 if TYPE_CHECKING:
 	from archinstall.lib.installer import Installer
-	_: Any
 
 
 class TailoredProfile(XorgProfile):

--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from parted import Device, Disk, DiskException, FileSystem, Geometry, IOException, Partition, PartitionException, freshDisk, getAllDevices, getDevice, newDisk
 
@@ -42,9 +42,6 @@ from .device_model import (
 	get_all_lsblk_info,
 	get_lsblk_info,
 )
-
-if TYPE_CHECKING:
-	_: Any
 
 
 class DeviceHandler:

--- a/archinstall/lib/models/audio_configuration.py
+++ b/archinstall/lib/models/audio_configuration.py
@@ -1,13 +1,10 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ...default_profiles.applications.pipewire import PipewireProfile
 from ..hardware import SysInfo
 from ..output import info
-
-if TYPE_CHECKING:
-	_: Any
 
 
 @dataclass

--- a/archinstall/lib/profile/profile_model.py
+++ b/archinstall/lib/profile/profile_model.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from archinstall.default_profiles.profile import GreeterType, Profile
 
 from ..hardware import GfxDriver
-
-if TYPE_CHECKING:
-	_: Any
 
 
 @dataclass

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
 import archinstall
 from archinstall import SysInfo, debug, info
@@ -12,10 +11,6 @@ from archinstall.lib.models import AudioConfiguration, Bootloader
 from archinstall.lib.models.network_configuration import NetworkConfiguration
 from archinstall.lib.profile.profiles_handler import profile_handler
 from archinstall.tui import Tui
-
-if TYPE_CHECKING:
-	_: Any
-
 
 if archinstall.arguments.get('help'):
 	print("See `man archinstall` for help.")

--- a/archinstall/scripts/minimal.py
+++ b/archinstall/scripts/minimal.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
 import archinstall
 from archinstall import ConfigurationOutput, Installer, debug, info
@@ -9,10 +8,6 @@ from archinstall.lib.interactions import select_devices, suggest_single_disk_lay
 from archinstall.lib.models import Bootloader, User
 from archinstall.lib.profile import ProfileConfiguration, profile_handler
 from archinstall.tui import Tui
-
-if TYPE_CHECKING:
-	_: Any
-
 
 info("Minimal only supports:")
 info(" * Being installed to a single disk")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,16 @@ warn_unused_configs = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
+module = "archinstall.default_profiles.applications.*"
+disallow_any_explicit = true
+
+[[tool.mypy.overrides]]
+module = "archinstall.default_profiles.servers.*"
+disallow_any_explicit = true
+
+[[tool.mypy.overrides]]
 module = "archinstall.examples.*"
 disallow_any_explicit = true
-follow_imports = "silent"
 
 [[tool.mypy.overrides]]
 module = "archinstall.lib.*"


### PR DESCRIPTION
## PR Description:

This will make it easier to start removing more `Any` instances from the codebase.

Some of the regressions in 3.0.0 are not being caught by mypy because of the prevalence of `Any` in the code.