### PR TITLE
Add linux-home partition flag

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -28,6 +28,7 @@ from .device_model import (
 	LvmVolumeGroup,
 	LvmVolumeInfo,
 	ModificationStatus,
+	PartitionFlag,
 	PartitionGUID,
 	PartitionModification,
 	PartitionTable,
@@ -543,8 +544,11 @@ class DeviceHandler:
 		except PartitionException as ex:
 			raise DiskError(f'Unable to add partition, most likely due to overlapping sectors: {ex}') from ex
 
-		if disk.type == PartitionTable.GPT.value and part_mod.is_root():
-			partition.type_uuid = PartitionGUID.LINUX_ROOT_X86_64.bytes
+		if disk.type == PartitionTable.GPT.value:
+			if part_mod.is_root():
+				partition.type_uuid = PartitionGUID.LINUX_ROOT_X86_64.bytes
+			elif PartitionFlag.LINUX_HOME not in part_mod.flags and part_mod.is_home():
+				partition.setFlag(PartitionFlag.LINUX_HOME.flag_id)
 
 		# the partition has a path now that it has been added
 		part_mod.dev_path = Path(partition.path)

--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -594,6 +594,7 @@ class PartitionFlag(PartitionFlagDataMixin, Enum):
 	Boot = parted.PARTITION_BOOT
 	XBOOTLDR = parted.PARTITION_BLS_BOOT, "bls_boot"
 	ESP = parted.PARTITION_ESP
+	LINUX_HOME = parted.PARTITION_LINUX_HOME, "linux-home"
 
 	@property
 	def description(self) -> str:
@@ -813,6 +814,12 @@ class PartitionModification:
 					return True
 
 		return False
+
+	def is_home(self) -> bool:
+		return (
+			self.mountpoint == Path('/home')
+			or PartitionFlag.LINUX_HOME in self.flags
+		)
 
 	def is_modify(self) -> bool:
 		return self.status == ModificationStatus.Modify

--- a/archinstall/lib/interactions/disk_conf.py
+++ b/archinstall/lib/interactions/disk_conf.py
@@ -411,6 +411,10 @@ def suggest_single_disk_layout(
 		home_start = root_partition.start + root_partition.length
 		home_length = available_space - home_start
 
+		flags = []
+		if using_gpt:
+			flags.append(disk.PartitionFlag.LINUX_HOME)
+
 		home_partition = disk.PartitionModification(
 			status=disk.ModificationStatus.Create,
 			type=disk.PartitionType.Primary,
@@ -418,7 +422,8 @@ def suggest_single_disk_layout(
 			length=home_length,
 			mountpoint=Path('/home'),
 			fs_type=filesystem_type,
-			mount_options=mount_options
+			mount_options=mount_options,
+			flags=flags
 		)
 		device_modification.add_partition(home_partition)
 
@@ -514,8 +519,10 @@ def suggest_multi_disk_layout(
 	home_start = home_align_buffer
 	home_length = home_device.device_info.total_size - home_start
 
+	flags = []
 	if using_gpt:
 		home_length -= home_align_buffer
+		flags.append(disk.PartitionFlag.LINUX_HOME)
 
 	# add home partition to home device
 	home_partition = disk.PartitionModification(
@@ -526,6 +533,7 @@ def suggest_multi_disk_layout(
 		mountpoint=Path('/home'),
 		mount_options=mount_options,
 		fs_type=filesystem_type,
+		flags=flags
 	)
 	home_device_modification.add_partition(home_partition)
 


### PR DESCRIPTION
During creation of a GPT partition with a mounpoint of `/home`, set the parted `linux-home` flag. This will give the partition the appropriate type GUID.

Documentation:

- https://www.gnu.org/software/parted/manual/parted.html#set
- https://wiki.archlinux.org/title/Partitioning#/home
- https://wiki.archlinux.org/title/Systemd#GPT_partition_automounting
