### PR TITLE
Delete ignore directive for Ruff rule that was removed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,6 @@ select = [
 ignore = [
     "E722",     # bare-except
     "PLW2901",  # redefined-loop-name
-    "UP027",    # unpacked-list-comprehension
     "UP028",    # yield-in-for-loop
     "UP031",    # printf-string-formatting
     "UP032",    # f-string


### PR DESCRIPTION
## PR Description:

The `unpacked-list-comprehension` rule was removed in Ruff 0.8.0:
- https://docs.astral.sh/ruff/rules/unpacked-list-comprehension/
- https://astral.sh/blog/ruff-v0.8.0#removal-of-six-deprecated-rules

This PR fixes the following warning with Ruff 0.8.0:
```
warning: The following rules have been removed and ignoring them has no effect:
    - UP027
```