### PR TITLE
Remove python-simple-term-menu installations from CI workflows

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -12,7 +12,7 @@ jobs:
                 pacman-key --init
                 pacman --noconfirm -Sy archlinux-keyring
                 pacman --noconfirm -Syyu
-                pacman --noconfirm -Sy python-pip python-pyparted python-simple-term-menu pkgconfig gcc
+                pacman --noconfirm -Sy python-pip python-pyparted pkgconfig gcc
             - run: pip install --break-system-packages --upgrade pip
             # this will install the exact version of flake8 that is in the pyproject.toml file
             - name: Install archinstall dependencies

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install pre-dependencies
         run: |
-          pacman -Sy --noconfirm tree git python-pyparted python-simple-term-menu python-setuptools python-sphinx python-sphinx_rtd_theme python-build python-installer python-wheel
+          pacman -Sy --noconfirm tree git python-pyparted python-setuptools python-sphinx python-sphinx_rtd_theme python-build python-installer python-wheel
       - name: Sphinx build
         run: |
           sphinx-build docs _build

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -12,7 +12,7 @@ jobs:
                 pacman-key --init
                 pacman --noconfirm -Sy archlinux-keyring
                 pacman --noconfirm -Syyu
-                pacman --noconfirm -Sy python-pip python-pyparted python-simple-term-menu pkgconfig gcc
+                pacman --noconfirm -Sy python-pip python-pyparted pkgconfig gcc
             - run: pip install --break-system-packages --upgrade pip
             # this will install the exact version of mypy that is in the pyproject.toml file
             - name: Install archinstall dependencies

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -12,7 +12,7 @@ jobs:
                 pacman-key --init
                 pacman --noconfirm -Sy archlinux-keyring
                 pacman --noconfirm -Syyu
-                pacman --noconfirm -Sy python-pip python-pyparted python-simple-term-menu pkgconfig gcc
+                pacman --noconfirm -Sy python-pip python-pyparted pkgconfig gcc
             - run: pip install --break-system-packages --upgrade pip
             - name: Install Pylint and Pylint plug-ins
               run: pip install --break-system-packages .[dev]

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -17,7 +17,7 @@ jobs:
           pacman-key --init
           pacman --noconfirm -Sy archlinux-keyring
           pacman --noconfirm -Syyu
-          pacman --noconfirm -Sy python-pip python-pydantic python-pyparted python-simple-term-menu pkgconfig gcc
+          pacman --noconfirm -Sy python-pip python-pydantic python-pyparted pkgconfig gcc
       - name: Install build dependencies
         run: |
           python -m pip install --break-system-packages --upgrade pip


### PR DESCRIPTION
## PR Description:

The dependency is no longer needed as of 0f2e0095.