### PR TITLE
Bump the minimum Python version to 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,4 +12,4 @@ sphinx:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ authors = [
 ]
 license = {text = "GPL-3.0-only"}
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 keywords = ["linux", "arch", "archinstall", "installer"]
 classifiers = [
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
@@ -63,7 +63,7 @@ include-package-data = true
 archinstall = "archinstall"
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 files = "."
 exclude = "^build/"
 check_untyped_defs = true
@@ -131,7 +131,7 @@ ignore-paths = [
 ]
 load-plugins = ["pylint_pydantic"]
 persistent = false
-py-version = "3.11"
+py-version = "3.12"
 recursive = true
 
 [tool.pylint.format]
@@ -168,7 +168,7 @@ score = false
 additional-builtins = ["_"]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 builtins = ["_"]
 line-length = 160
 


### PR DESCRIPTION
## PR Description:

This will allow us to use the `@override` decorator from the `typing` module instead of `typing_extensions`:
- https://docs.python.org/3/library/typing.html#typing.override