### PR TITLE
Start using typing.override to annotate overridden methods and properties

### DIFF
--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 import archinstall
 from archinstall.default_profiles.profile import Profile, ProfileType
@@ -13,6 +13,7 @@ class PipewireProfile(Profile):
 		super().__init__('Pipewire', ProfileType.Application)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			'pipewire',
@@ -51,6 +52,7 @@ class PipewireProfile(Profile):
 				run_as=user.username
 			)
 
+	@override
 	def install(self, install_session: 'Installer') -> None:
 		super().install(install_session)
 		install_session.add_additional_packages(self.packages)

--- a/archinstall/default_profiles/desktop.py
+++ b/archinstall/default_profiles/desktop.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import GreeterType, Profile, ProfileType, SelectResult
 from archinstall.lib.output import info
@@ -25,6 +25,7 @@ class DesktopProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			'nano',
@@ -40,6 +41,7 @@ class DesktopProfile(Profile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		combined_greeters: dict[GreeterType, int] = {}
 		for profile in self.current_selection:
@@ -56,6 +58,7 @@ class DesktopProfile(Profile):
 		for profile in self.current_selection:
 			profile.do_on_select()
 
+	@override
 	def do_on_select(self) -> SelectResult | None:
 		items = [
 			MenuItem(
@@ -88,10 +91,12 @@ class DesktopProfile(Profile):
 			case ResultType.Reset:
 				return SelectResult.ResetCurrent
 
+	@override
 	def post_install(self, install_session: 'Installer') -> None:
 		for profile in self.current_selection:
 			profile.post_install(install_session)
 
+	@override
 	def install(self, install_session: 'Installer') -> None:
 		# Install common packages for all desktop environments
 		install_session.add_additional_packages(self.packages)

--- a/archinstall/default_profiles/desktops/awesome.py
+++ b/archinstall/default_profiles/desktops/awesome.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,6 +12,7 @@ class AwesomeProfile(XorgProfile):
 		super().__init__('Awesome', ProfileType.WindowMgr, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return super().packages + [
 			'awesome',
@@ -27,6 +28,7 @@ class AwesomeProfile(XorgProfile):
 			'xsel',
 		]
 
+	@override
 	def install(self, install_session: 'Installer') -> None:
 		super().install(install_session)
 

--- a/archinstall/default_profiles/desktops/bspwm.py
+++ b/archinstall/default_profiles/desktops/bspwm.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class BspwmProfile(XorgProfile):
 		super().__init__('Bspwm', ProfileType.WindowMgr, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		# return super().packages + [
 		return [
@@ -18,5 +21,6 @@ class BspwmProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Lightdm

--- a/archinstall/default_profiles/desktops/budgie.py
+++ b/archinstall/default_profiles/desktops/budgie.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class BudgieProfile(XorgProfile):
 		super().__init__('Budgie', ProfileType.DesktopEnv, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"arc-gtk-theme",
@@ -17,5 +20,6 @@ class BudgieProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.LightdmSlick

--- a/archinstall/default_profiles/desktops/cinnamon.py
+++ b/archinstall/default_profiles/desktops/cinnamon.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class CinnamonProfile(XorgProfile):
 		super().__init__('Cinnamon', ProfileType.DesktopEnv, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"cinnamon",
@@ -23,5 +26,6 @@ class CinnamonProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Lightdm

--- a/archinstall/default_profiles/desktops/cosmic.py
+++ b/archinstall/default_profiles/desktops/cosmic.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,11 +9,13 @@ class CosmicProfile(XorgProfile):
 		super().__init__('cosmic-epoch', ProfileType.DesktopEnv, description='', advanced=True)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"cosmic",
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.CosmicSession

--- a/archinstall/default_profiles/desktops/cutefish.py
+++ b/archinstall/default_profiles/desktops/cutefish.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,6 +12,7 @@ class CutefishProfile(XorgProfile):
 		super().__init__('Cutefish', ProfileType.DesktopEnv, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"cutefish",
@@ -19,8 +20,10 @@ class CutefishProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Sddm
 
+	@override
 	def install(self, install_session: 'Installer') -> None:
 		super().install(install_session)

--- a/archinstall/default_profiles/desktops/deepin.py
+++ b/archinstall/default_profiles/desktops/deepin.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class DeepinProfile(XorgProfile):
 		super().__init__('Deepin', ProfileType.DesktopEnv, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"deepin",
@@ -15,5 +18,6 @@ class DeepinProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Lightdm

--- a/archinstall/default_profiles/desktops/enlightenment.py
+++ b/archinstall/default_profiles/desktops/enlightenment.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class EnlighenmentProfile(XorgProfile):
 		super().__init__('Enlightenment', ProfileType.WindowMgr, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"enlightenment",
@@ -14,5 +17,6 @@ class EnlighenmentProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Lightdm

--- a/archinstall/default_profiles/desktops/gnome.py
+++ b/archinstall/default_profiles/desktops/gnome.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class GnomeProfile(XorgProfile):
 		super().__init__('Gnome', ProfileType.DesktopEnv, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			'gnome',
@@ -14,5 +17,6 @@ class GnomeProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Gdm

--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.desktops import SeatAccess
 from archinstall.default_profiles.profile import GreeterType, ProfileType, SelectResult
@@ -21,6 +21,7 @@ class HyprlandProfile(XorgProfile):
 		self.custom_settings = {'seat_access': None}
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"hyprland",
@@ -37,10 +38,12 @@ class HyprlandProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Sddm
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		if pref := self.custom_settings.get('seat_access', None):
 			return [pref]
@@ -69,9 +72,11 @@ class HyprlandProfile(XorgProfile):
 			if result.item() is not None:
 				self.custom_settings['seat_access'] = result.get_value().value
 
+	@override
 	def do_on_select(self) -> SelectResult | None:
 		self._ask_seat_access()
 		return None
 
+	@override
 	def install(self, install_session: 'Installer') -> None:
 		super().install(install_session)

--- a/archinstall/default_profiles/desktops/i3.py
+++ b/archinstall/default_profiles/desktops/i3.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class I3wmProfile(XorgProfile):
 		super().__init__('i3-wm', ProfileType.WindowMgr, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			'i3-wm',
@@ -21,5 +24,6 @@ class I3wmProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Lightdm

--- a/archinstall/default_profiles/desktops/lxqt.py
+++ b/archinstall/default_profiles/desktops/lxqt.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -10,6 +12,7 @@ class LxqtProfile(XorgProfile):
 	# LXQt works with lightdm, but since this is not supported, we will not default to this.
 	# https://github.com/lxqt/lxqt/issues/795
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"lxqt",
@@ -22,5 +25,6 @@ class LxqtProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Sddm

--- a/archinstall/default_profiles/desktops/mate.py
+++ b/archinstall/default_profiles/desktops/mate.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class MateProfile(XorgProfile):
 		super().__init__('Mate', ProfileType.DesktopEnv, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"mate",
@@ -14,5 +17,6 @@ class MateProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Lightdm

--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class PlasmaProfile(XorgProfile):
 		super().__init__('KDE Plasma', ProfileType.DesktopEnv, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"plasma-meta",
@@ -19,5 +22,6 @@ class PlasmaProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Sddm

--- a/archinstall/default_profiles/desktops/qtile.py
+++ b/archinstall/default_profiles/desktops/qtile.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class QtileProfile(XorgProfile):
 		super().__init__('Qtile', ProfileType.WindowMgr, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			'qtile',
@@ -14,5 +17,6 @@ class QtileProfile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Lightdm

--- a/archinstall/default_profiles/desktops/sway.py
+++ b/archinstall/default_profiles/desktops/sway.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.desktops import SeatAccess
 from archinstall.default_profiles.profile import GreeterType, ProfileType, SelectResult
@@ -25,6 +25,7 @@ class SwayProfile(XorgProfile):
 		self.custom_settings = {'seat_access': None}
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		additional = []
 		if seat := self.custom_settings.get('seat_access', None):
@@ -46,10 +47,12 @@ class SwayProfile(XorgProfile):
 		] + additional
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Lightdm
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		if pref := self.custom_settings.get('seat_access', None):
 			return [pref]
@@ -78,9 +81,11 @@ class SwayProfile(XorgProfile):
 			if result.item() is not None:
 				self.custom_settings['seat_access'] = result.get_value().value
 
+	@override
 	def do_on_select(self) -> SelectResult | None:
 		self._ask_seat_access()
 		return None
 
+	@override
 	def install(self, install_session: 'Installer') -> None:
 		super().install(install_session)

--- a/archinstall/default_profiles/desktops/xfce4.py
+++ b/archinstall/default_profiles/desktops/xfce4.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 
@@ -7,6 +9,7 @@ class Xfce4Profile(XorgProfile):
 		super().__init__('Xfce4', ProfileType.DesktopEnv, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			"xfce4",
@@ -17,5 +20,6 @@ class Xfce4Profile(XorgProfile):
 		]
 
 	@property
+	@override
 	def default_greeter_type(self) -> GreeterType | None:
 		return GreeterType.Lightdm

--- a/archinstall/default_profiles/server.py
+++ b/archinstall/default_profiles/server.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import Profile, ProfileType, SelectResult
 from archinstall.lib.output import info
@@ -23,6 +23,7 @@ class ServerProfile(Profile):
 			current_selection=current_value
 		)
 
+	@override
 	def do_on_select(self) -> SelectResult | None:
 		items = [
 			MenuItem(
@@ -55,10 +56,12 @@ class ServerProfile(Profile):
 			case ResultType.Reset:
 				return SelectResult.ResetCurrent
 
+	@override
 	def post_install(self, install_session: 'Installer') -> None:
 		for profile in self.current_selection:
 			profile.post_install(install_session)
 
+	@override
 	def install(self, install_session: 'Installer') -> None:
 		server_info = self.current_selection_names()
 		details = ', '.join(server_info)

--- a/archinstall/default_profiles/servers/cockpit.py
+++ b/archinstall/default_profiles/servers/cockpit.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -9,9 +11,11 @@ class CockpitProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['cockpit', 'udisks2', 'packagekit']
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		return ['cockpit.socket']

--- a/archinstall/default_profiles/servers/docker.py
+++ b/archinstall/default_profiles/servers/docker.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 import archinstall
 from archinstall.default_profiles.profile import Profile, ProfileType
@@ -16,13 +16,16 @@ class DockerProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['docker']
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		return ['docker']
 
+	@override
 	def post_install(self, install_session: 'Installer') -> None:
 		users: User | list[User] = archinstall.arguments.get('!users', [])
 		if not isinstance(users, list):

--- a/archinstall/default_profiles/servers/httpd.py
+++ b/archinstall/default_profiles/servers/httpd.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -9,9 +11,11 @@ class HttpdProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['apache']
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		return ['httpd']

--- a/archinstall/default_profiles/servers/lighttpd.py
+++ b/archinstall/default_profiles/servers/lighttpd.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -9,9 +11,11 @@ class LighttpdProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['lighttpd']
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		return ['lighttpd']

--- a/archinstall/default_profiles/servers/mariadb.py
+++ b/archinstall/default_profiles/servers/mariadb.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import Profile, ProfileType
 
@@ -14,12 +14,15 @@ class MariadbProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['mariadb']
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		return ['mariadb']
 
+	@override
 	def post_install(self, install_session: 'Installer') -> None:
 		install_session.arch_chroot('mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql')

--- a/archinstall/default_profiles/servers/nginx.py
+++ b/archinstall/default_profiles/servers/nginx.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -9,9 +11,11 @@ class NginxProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['nginx']
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		return ['nginx']

--- a/archinstall/default_profiles/servers/postgresql.py
+++ b/archinstall/default_profiles/servers/postgresql.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import Profile, ProfileType
 
@@ -15,12 +15,15 @@ class PostgresqlProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['postgresql']
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		return ['postgresql']
 
+	@override
 	def post_install(self, install_session: 'Installer') -> None:
 		install_session.arch_chroot("initdb -D /var/lib/postgres/data", run_as='postgres')

--- a/archinstall/default_profiles/servers/sshd.py
+++ b/archinstall/default_profiles/servers/sshd.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -9,9 +11,11 @@ class SshdProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['openssh']
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		return ['sshd']

--- a/archinstall/default_profiles/servers/tomcat.py
+++ b/archinstall/default_profiles/servers/tomcat.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from archinstall.default_profiles.profile import Profile, ProfileType
 
 
@@ -9,9 +11,11 @@ class TomcatProfile(Profile):
 		)
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['tomcat10']
 
 	@property
+	@override
 	def services(self) -> list[str]:
 		return ['tomcat10']

--- a/archinstall/default_profiles/tailored.py
+++ b/archinstall/default_profiles/tailored.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
@@ -12,9 +12,11 @@ class TailoredProfile(XorgProfile):
 		super().__init__('52-54-00-12-34-56', ProfileType.Tailored, description='')
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return ['nano', 'wget', 'git']
 
+	@override
 	def install(self, install_session: 'Installer') -> None:
 		super().install(install_session)
 		# do whatever you like here :)

--- a/archinstall/default_profiles/xorg.py
+++ b/archinstall/default_profiles/xorg.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import Profile, ProfileType
 
@@ -26,6 +26,7 @@ class XorgProfile(Profile):
 			advanced=advanced
 		)
 
+	@override
 	def preview_text(self) -> str | None:
 		text = str(_('Environment type: {}')).format(self.profile_type.value)
 		if packages := self.packages_text():
@@ -34,6 +35,7 @@ class XorgProfile(Profile):
 		return text
 
 	@property
+	@override
 	def packages(self) -> list[str]:
 		return [
 			'xorg-server'

--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from archinstall.tui import MenuItem, MenuItemGroup
 
@@ -52,6 +52,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu):
 			),
 		]
 
+	@override
 	def run(self) -> DiskLayoutConfiguration | None:
 		super().run()
 

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from archinstall.lib.menu.menu_helper import MenuHelper
 from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu
@@ -104,6 +104,7 @@ class DiskEncryptionMenu(AbstractSubMenu):
 			return True
 		return False
 
+	@override
 	def run(self) -> DiskEncryption | None:
 		super().run()
 

--- a/archinstall/lib/disk/partitioning_menu.py
+++ b/archinstall/lib/disk/partitioning_menu.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.tui import Alignment, EditMenu, FrameProperties, MenuItem, MenuItemGroup, Orientation, ResultType, SelectMenu
 
@@ -60,12 +60,14 @@ class PartitioningList(ListManager):
 		display_actions = list(self._actions.values())
 		super().__init__(prompt, device_partitions, display_actions[:2], display_actions[3:])
 
+	@override
 	def selected_action_display(self, selection: PartitionModification) -> str:
 		if selection.status == ModificationStatus.Create:
 			return str(_('Partition - New'))
 		else:
 			return str(selection.dev_path)
 
+	@override
 	def filter_options(self, selection: PartitionModification, options: list[str]) -> list[str]:
 		not_filter = []
 
@@ -98,6 +100,7 @@ class PartitioningList(ListManager):
 
 		return [o for o in options if o not in not_filter]
 
+	@override
 	def handle_action(
 		self,
 		action: str,

--- a/archinstall/lib/disk/subvolume_menu.py
+++ b/archinstall/lib/disk/subvolume_menu.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.tui import Alignment, EditMenu, ResultType
 
@@ -24,6 +24,7 @@ class SubvolumeMenu(ListManager):
 		]
 		super().__init__(prompt, btrfs_subvols, [self._actions[0]], self._actions[1:])
 
+	@override
 	def selected_action_display(self, selection: SubvolumeModification) -> str:
 		return str(selection.name)
 
@@ -56,6 +57,7 @@ class SubvolumeMenu(ListManager):
 
 		return SubvolumeModification(Path(name), path)
 
+	@override
 	def handle_action(
 		self,
 		action: str,

--- a/archinstall/lib/interactions/manage_users_conf.py
+++ b/archinstall/lib/interactions/manage_users_conf.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.tui import Alignment, EditMenu, MenuItem, MenuItemGroup, Orientation, ResultType, SelectMenu
 
@@ -28,9 +28,11 @@ class UserList(ListManager):
 		]
 		super().__init__(prompt, lusers, [self._actions[0]], self._actions[1:])
 
+	@override
 	def selected_action_display(self, selection: User) -> str:
 		return selection.username
 
+	@override
 	def handle_action(self, action: str, entry: User | None, data: list[User]) -> list[User]:
 		if action == self._actions[0]:  # add
 			new_user = self._add_user()

--- a/archinstall/lib/interactions/network_menu.py
+++ b/archinstall/lib/interactions/network_menu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.tui import Alignment, EditMenu, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu
 
@@ -26,9 +26,11 @@ class ManualNetworkConfig(ListManager):
 		]
 		super().__init__(prompt, preset, [self._actions[0]], self._actions[1:])
 
+	@override
 	def selected_action_display(self, selection: Nic) -> str:
 		return selection.iface if selection.iface else ''
 
+	@override
 	def handle_action(self, action: str, entry: Nic | None, data: list[Nic]) -> list[Nic]:
 		if action == self._actions[0]:  # add
 			iface = self._select_iface(data)

--- a/archinstall/lib/locale/locale_menu.py
+++ b/archinstall/lib/locale/locale_menu.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu
 
@@ -108,6 +108,7 @@ class LocaleMenu(AbstractSubMenu):
 		)
 		return temp_locale.preview()
 
+	@override
 	def run(self) -> LocaleConfiguration:
 		super().run()
 

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -4,7 +4,7 @@ import urllib.parse
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from archinstall.tui import Alignment, EditMenu, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu
 
@@ -136,9 +136,11 @@ class CustomMirrorList(ListManager):
 			self._actions[1:]
 		)
 
+	@override
 	def selected_action_display(self, selection: CustomMirror) -> str:
 		return selection.name
 
+	@override
 	def handle_action(
 		self,
 		action: str,
@@ -299,6 +301,7 @@ class MirrorMenu(AbstractSubMenu):
 		output = FormattedOutput.as_table(custom_mirrors)
 		return output.strip()
 
+	@override
 	def run(self) -> MirrorConfiguration:
 		super().run()
 

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from archinstall.default_profiles.profile import GreeterType, Profile
 from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, Orientation, ResultType, SelectMenu
@@ -64,6 +64,7 @@ class ProfileMenu(AbstractSubMenu):
 			)
 		]
 
+	@override
 	def run(self) -> ProfileConfiguration | None:
 		super().run()
 

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from curses.textpad import Textbox
 from dataclasses import dataclass
 from types import FrameType, TracebackType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, override
 
 from ..lib.output import debug
 from .help import Help
@@ -684,6 +684,7 @@ class EditMenu(AbstractCurses):
 		self._clear_all()
 		return result
 
+	@override
 	def resize_win(self) -> None:
 		self._draw()
 
@@ -726,6 +727,7 @@ class EditMenu(AbstractCurses):
 			self._input_vp.update()
 			self._input_vp.edit(default_text=self._default_text)
 
+	@override
 	def kickoff(self, win: 'curses._CursesWindow') -> Result:
 		try:
 			self._draw()
@@ -889,6 +891,7 @@ class SelectMenu(AbstractCurses):
 		self._clear_all()
 		return result
 
+	@override
 	def kickoff(self, win: 'curses._CursesWindow') -> Result:
 		self._draw()
 
@@ -909,6 +912,7 @@ class SelectMenu(AbstractCurses):
 				else:
 					return self.kickoff(win)
 
+	@override
 	def resize_win(self) -> None:
 		self._draw()
 


### PR DESCRIPTION
## PR Description:

The `@override` decorator can help catch accidental mismatches between names in the base class and names in derived classes: https://docs.python.org/3/library/typing.html#typing.override