### PR TITLE
Fix mypy warnings in tests/test_args.py

### DIFF
--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -15,7 +15,7 @@ from archinstall.lib.profile.profiles_handler import profile_handler
 from archinstall.lib.translationhandler import translation_handler
 
 
-def test_default_args(monkeypatch):
+def test_default_args(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr('sys.argv', ['archinstall'])
     handler = ArchConfigHandler()
     args = handler.args


### PR DESCRIPTION
## PR Description:

This PR would allow the following override to be removed, but I wasn't sure if it was in place for future PRs (so I left it in place):

```
[[tool.mypy.overrides]]
module = "tests.*"
ignore_errors = true
```