### PR TITLE
Use the ruff version specified in pyproject.toml for CI checks

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -7,6 +7,16 @@ jobs:
             image: archlinux/archlinux:latest
         steps:
             - uses: actions/checkout@v4
-            - run: pacman --noconfirm -Syu ruff
+            - name: Prepare arch
+              run: |
+                pacman-key --init
+                pacman --noconfirm -Sy archlinux-keyring
+                pacman --noconfirm -Syyu
+                pacman --noconfirm -Sy python-pip python-pyparted pkgconfig gcc
+            - run: pip install --break-system-packages --upgrade pip
+            - name: Install ruff
+              run: pip install --break-system-packages .[dev]
+            - run: python --version
+            - run: ruff --version
             - name: Lint with ruff
               run: ruff check


### PR DESCRIPTION
## PR Description:

Previously, the ruff system package was used, which could lag behind the PyPI version.

For example, a PR to bump ruff to 0.8.1 used ruff 0.8.0 during the CI checks:
- https://github.com/archlinux/archinstall/actions/runs/12078814090/job/33683765387?pr=2955