### PR TITLE
Enable mypy checks for tests/ files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,7 @@ repos:
       additional_dependencies:
         - pydantic
         - pydantic-settings
+        - pytest
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,10 +124,6 @@ module = "archinstall.tui.*"
 warn_unreachable = false
 
 [[tool.mypy.overrides]]
-module = "tests.*"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = [
     "parted",
 ]

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -105,7 +105,7 @@ def test_config_file_parsing(
     arch_config = handler.arch_config
 
     # TODO: Use the real values from the test fixture instead of clearing out the entries
-    arch_config.disk_config.device_modifications = []
+    arch_config.disk_config.device_modifications = []  # type: ignore[union-attr]
 
     assert arch_config == ArchConfig(
         version=archinstall.__version__,


### PR DESCRIPTION
## PR Description:

Running mypy on test code can help catch errors.  If the checks become too onerous, then certain warning categories can be disabled in the future.