### PR TITLE
Enable the redefined-outer-name pylint rule and fix warnings

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -264,16 +264,16 @@ def load_config() -> None:
 		)
 
 
-def post_process_arguments(arguments: dict[str, Any]) -> None:
-	storage['arguments'] = arguments
-	if mountpoint := arguments.get('mount_point', None):
+def post_process_arguments(args: dict[str, Any]) -> None:
+	storage['arguments'] = args
+	if mountpoint := args.get('mount_point', None):
 		storage['MOUNT_POINT'] = Path(mountpoint)
 
-	if arguments.get('debug', False):
+	if args.get('debug', False):
 		warn(f"Warning: --debug mode will write certain credentials to {storage['LOG_PATH']}/{storage['LOG_FILE']}!")
 
-	if arguments.get('plugin', None):
-		path = arguments['plugin']
+	if args.get('plugin', None):
+		path = args['plugin']
 		load_plugin(path)
 
 	load_config()

--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -430,7 +430,7 @@ class _PartitionInfo:
 		fs_type: FilesystemType | None,
 		partn: int | None,
 		partuuid: str | None,
-		uuid: str | None,
+		uuid: str | None,  # pylint: disable=redefined-outer-name
 		mountpoints: list[Path],
 		btrfs_subvol_infos: list[_BtrfsSubvolumeInfo] = []
 	) -> _PartitionInfo:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -732,9 +732,9 @@ class Installer:
 		try:
 			SysCommand(f'/usr/bin/arch-chroot {self.target} mkinitcpio {" ".join(flags)}', peek_output=True)
 			return True
-		except SysCallError as error:
-			if error.worker:
-				log(error.worker._trace_log.decode())
+		except SysCallError as e:
+			if e.worker:
+				log(e.worker._trace_log.decode())
 			return False
 
 	def _get_microcode(self) -> Path | None:

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -191,8 +191,8 @@ def ping(hostname, timeout=5) -> int:
 				if icmp_type == 0 and response[-len(random_identifier):] == random_identifier:
 					latency = round((time.time() - started) * 1000)
 					break
-		except OSError as error:
-			debug(f"Error: {error}")
+		except OSError as e:
+			debug(f"Error: {e}")
 			break
 
 	icmp_socket.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,6 @@ disable = [
     "protected-access",
     "raise-missing-from",
     "redefined-builtin",
-    "redefined-outer-name",
     "unnecessary-lambda",
     "unreachable",
     "unspecified-encoding",


### PR DESCRIPTION
## PR Description:
This rule can help catch the accidental misuse of a variable from an outer scope.  It also makes it easier to search the codebase for function names like `error`.