### PR TITLE
Enable the f-string ruff rule and fix warnings

### DIFF
--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -219,7 +219,7 @@ def save_config(config: dict[str, Any]) -> None:
 			if result.item() == MenuItem.no():
 				return
 
-	debug("Saving configuration files to {}".format(dest_path.absolute()))
+	debug(f"Saving configuration files to {dest_path.absolute()}")
 
 	match save_option:
 		case "user_config":

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -413,9 +413,9 @@ class GlobalMenu(AbstractMenu):
 			output += str(_('Password')) + f': {secret(enc_config.encryption_password)}\n'
 
 			if enc_config.partitions:
-				output += 'Partitions: {} selected'.format(len(enc_config.partitions)) + '\n'
+				output += f'Partitions: {len(enc_config.partitions)} selected\n'
 			elif enc_config.lvm_volumes:
-				output += 'LVM volumes: {} selected'.format(len(enc_config.lvm_volumes)) + '\n'
+				output += f'LVM volumes: {len(enc_config.lvm_volumes)} selected\n'
 
 			if enc_config.hsm_device:
 				output += f'HSM: {enc_config.hsm_device.manufacturer}'

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1494,7 +1494,7 @@ Exec = /bin/sh -c "{hook_command}"
 
 		# We count how many files are there already so we know which number to prefix the file with
 		num_of_rules_already = len(os.listdir(sudoers_dir))
-		file_num_str = "{:02d}".format(num_of_rules_already)  # We want 00_user1, 01_user2, etc
+		file_num_str = f"{num_of_rules_already:02d}"  # We want 00_user1, 01_user2, etc
 
 		# Guarantees that entity str does not contain invalid characters for a linux file name:
 		# \ / : * ? " < > |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,6 @@ ignore = [
     "RUF039",   # unraw-re-pattern
     "UP028",    # yield-in-for-loop
     "UP031",    # printf-string-formatting
-    "UP032",    # f-string
     "UP037",    # quoted-annotation
     "W191",     # tab-indentation
 ]


### PR DESCRIPTION
## PR Description:
This rule mainly helps with consistency across the codebase.