### PR TITLE
Enable the redefined-builtin pylint rule and fix warnings

### DIFF
--- a/archinstall/tui/help.py
+++ b/archinstall/tui/help.py
@@ -76,12 +76,12 @@ class Help:
 		max_desc_width = max([help.get_desc_width() for help in help_texts])
 		max_key_width = max([help.get_key_width() for help in help_texts])
 
-		for help in help_texts:
-			help_output += f'{help.group_id.value}\n'
+		for help_group in help_texts:
+			help_output += f'{help_group.group_id.value}\n'
 			divider_len = max_desc_width + max_key_width
 			help_output += '-' * divider_len + '\n'
 
-			for entry in help.group_entries:
+			for entry in help_group.group_entries:
 				help_output += (
 					entry.description.ljust(max_desc_width, ' ')
 					+ ', '.join(entry.keys) + '\n'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,6 @@ disable = [
     "fixme",
     "protected-access",
     "raise-missing-from",
-    "redefined-builtin",
     "unnecessary-lambda",
     "unreachable",
     "unspecified-encoding",


### PR DESCRIPTION
## PR Description:

This rule can help catch the accidental misuse of a variable that shares its name with a built-in (like `help`).