### PR TITLE
Enable the printf-string-formatting ruff rule and fix warnings

### DIFF
--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -71,7 +71,7 @@ def get_hw_addr(ifname: str) -> str:
 	import fcntl
 	s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 	ret = fcntl.ioctl(s.fileno(), 0x8927, struct.pack('256s', bytes(ifname, 'utf-8')[:15]))
-	return ':'.join('%02x' % b for b in ret[18:24])
+	return ':'.join(f'{b:02x}' for b in ret[18:24])
 
 
 def list_interfaces(skip_loopback: bool = True) -> dict[str, str]:

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -237,7 +237,7 @@ def _stylize_output(
 	code_list = []
 
 	if text == '' and reset:
-		return '\x1b[%sm' % '0'
+		return '\x1b[0m'
 
 	code_list.append(foreground[str(fg)])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,6 @@ ignore = [
     "RUF015",   # unnecessary-iterable-allocation-for-first-element
     "RUF039",   # unraw-re-pattern
     "UP028",    # yield-in-for-loop
-    "UP031",    # printf-string-formatting
     "UP037",    # quoted-annotation
     "W191",     # tab-indentation
 ]


### PR DESCRIPTION
## PR Description:

This rule mainly helps with stylistic consistency across the codebase.