### PR TITLE
btrfs improvements and fixes

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -599,12 +599,12 @@ class DeviceHandler:
 
 		self.mount(path, self._TMP_BTRFS_MOUNT, create_target_mountpoint=True)
 
-		for sub_vol in btrfs_subvols:
+		for sub_vol in sorted(btrfs_subvols, key=lambda x: x.name):
 			debug(f'Creating subvolume: {sub_vol.name}')
 
 			subvol_path = self._TMP_BTRFS_MOUNT / sub_vol.name
 
-			SysCommand(f"btrfs subvolume create {subvol_path}")
+			SysCommand(f"btrfs subvolume create -p {subvol_path}")
 
 			if BtrfsMountOption.nodatacow.value in mount_options:
 				try:
@@ -653,12 +653,12 @@ class DeviceHandler:
 			options=part_mod.mount_options
 		)
 
-		for sub_vol in part_mod.btrfs_subvols:
+		for sub_vol in sorted(part_mod.btrfs_subvols, key=lambda x: x.name):
 			debug(f'Creating subvolume: {sub_vol.name}')
 
 			subvol_path = self._TMP_BTRFS_MOUNT / sub_vol.name
 
-			SysCommand(f"btrfs subvolume create {subvol_path}")
+			SysCommand(f"btrfs subvolume create -p {subvol_path}")
 
 		self.umount(dev_path)
 

--- a/archinstall/lib/disk/subvolume_menu.py
+++ b/archinstall/lib/disk/subvolume_menu.py
@@ -59,7 +59,8 @@ class SubvolumeMenu(ListManager):
 		path = prompt_dir(
 			str(_("Subvolume mountpoint")),
 			header=header,
-			allow_skip=True
+			allow_skip=True,
+			validate=False
 		)
 
 		if not path:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -361,7 +361,7 @@ class Installer:
 		subvolumes: list[disk.SubvolumeModification],
 		mount_options: list[str] = []
 	) -> None:
-		for subvol in subvolumes:
+		for subvol in sorted(subvolumes, key=lambda x: x.relative_mountpoint):
 			mountpoint = self.target / subvol.relative_mountpoint
 			mount_options = mount_options + [f'subvol={subvol.name}']
 			disk.device_handler.mount(dev_path, mountpoint, options=mount_options)


### PR DESCRIPTION
A few small fixes and improvements to btrfs partitioning to better support manual layouts.
- Fix: Don't require subvolume mount points to exist on host system
- Fix: Mount subvolumes in sorted order to properly support nesting
- Enhance: Support deeply nested subvolume names as allowed by `btrfs`

## Tests and Checks
- [x] I have tested the code!
  - Tested and verified in qemu using the example config below

<details>
<summary>

### Example Config

</summary>

```json
{
    "config_version": "3.0.1",
    "disk_config": {
        "config_type": "manual_partitioning",
        "device_modifications": [
            {
                "device": "/dev/sda",
                "partitions": [
                    {
                        "btrfs": [],
                        "dev_path": null,
                        "flags": [
                            "boot",
                            "esp"
                        ],
                        "fs_type": "fat32",
                        "mount_options": [],
                        "mountpoint": "/boot",
                        "obj_id": "415b73ac-e232-4dba-b5fa-04691ab05b1c",
                        "size": {
                            "sector_size": {
                                "unit": "B",
                                "value": 512
                            },
                            "unit": "GiB",
                            "value": 1
                        },
                        "start": {
                            "sector_size": {
                                "unit": "B",
                                "value": 512
                            },
                            "unit": "MiB",
                            "value": 1
                        },
                        "status": "create",
                        "type": "primary"
                    },
                    {
                        "btrfs": [
                            {
                                "mountpoint": "/var/log",
                                "name": "@log"
                            },
                            {
                                "mountpoint": "/var/cache",
                                "name": "@cache"
                            },
                            {
                                "mountpoint": "/",
                                "name": "@/live/snapshot"
                            },
                            {
                                "mountpoint": "/.snapshots",
                                "name": "@"
                            },
                            {
                                "mountpoint": "/home",
                                "name": "@home/live/snapshot"
                            },
                            {
                                "mountpoint": "/home/.snapshots",
                                "name": "@home"
                            }
                        ],
                        "dev_path": null,
                        "flags": [],
                        "fs_type": "btrfs",
                        "mount_options": [
                            "compress=zstd"
                        ],
                        "mountpoint": null,
                        "obj_id": "824a7f4e-29a3-4414-a425-e575ba8861d4",
                        "size": {
                            "sector_size": {
                                "unit": "B",
                                "value": 512
                            },
                            "unit": "B",
                            "value": 33283899392
                        },
                        "start": {
                            "sector_size": {
                                "unit": "B",
                                "value": 512
                            },
                            "unit": "B",
                            "value": 1074790400
                        },
                        "status": "create",
                        "type": "primary"
                    }
                ],
                "wipe": true
            }
        ]
    },
    "version": "3.0.1"
}
```

</details>