### PR TITLE
Remove unused VersionDef class

### DIFF
--- a/archinstall/lib/models/__init__.py
+++ b/archinstall/lib/models/__init__.py
@@ -1,5 +1,5 @@
 from .audio_configuration import Audio, AudioConfiguration
 from .bootloader import Bootloader
-from .gen import LocalPackage, PackageSearch, PackageSearchResult, VersionDef
+from .gen import LocalPackage, PackageSearch, PackageSearchResult
 from .network_configuration import NetworkConfiguration, Nic, NicType
 from .users import PasswordStrength, User

--- a/archinstall/lib/models/gen.py
+++ b/archinstall/lib/models/gen.py
@@ -3,62 +3,6 @@ from typing import Any
 
 
 @dataclass
-class VersionDef:
-	version_string: str
-
-	@classmethod
-	def parse_version(cls) -> list[str]:
-		if '.' in cls.version_string:
-			versions = cls.version_string.split('.')
-		else:
-			versions = [cls.version_string]
-
-		return versions
-
-	@classmethod
-	def major(self) -> str:
-		return self.parse_version()[0]
-
-	@classmethod
-	def minor(cls) -> str | None:
-		versions = cls.parse_version()
-		if len(versions) >= 2:
-			return versions[1]
-
-		return None
-
-	@classmethod
-	def patch(cls) -> str | None:
-		versions = cls.parse_version()
-		if '-' in versions[-1]:
-			_, patch_version = versions[-1].split('-', 1)
-			return patch_version
-
-		return None
-
-	def __eq__(self, other) -> bool:
-		if other.major == self.major and \
-			other.minor == self.minor and \
-			other.patch == self.patch:
-
-			return True
-		return False
-
-	def __lt__(self, other) -> bool:
-		if self.major() > other.major():
-			return False
-		elif self.minor() and other.minor() and self.minor() > other.minor():
-			return False
-		elif self.patch() and other.patch() and self.patch() > other.patch():
-			return False
-
-		return True
-
-	def __str__(self) -> str:
-		return self.version_string
-
-
-@dataclass
 class PackageSearchResult:
 	pkgname: str
 	pkgbase: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,6 @@ disable = [
     "bare-except",
     "broad-exception-caught",
     "cell-var-from-loop",
-    "comparison-with-callable",
     "dangerous-default-value",
     "fixme",
     "protected-access",


### PR DESCRIPTION
## PR Description:

This allows the comparison-with-callable pylint rule to be enabled.