### PR TITLE
Add missing typing.override annotations reported by Pyright

### DIFF
--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -5,7 +5,7 @@ import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, NotRequired, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict, override
 
 import parted
 from parted import Disk, Geometry, Partition
@@ -376,9 +376,11 @@ class Size:
 	def __le__(self, other: Size) -> bool:
 		return self._normalize() <= other._normalize()
 
+	@override
 	def __eq__(self, other) -> bool:
 		return self._normalize() == other._normalize()
 
+	@override
 	def __ne__(self, other) -> bool:
 		return self._normalize() != other._normalize()
 
@@ -624,6 +626,7 @@ class BDevice:
 	device_info: _DeviceInfo
 	partition_infos: list[_PartitionInfo]
 
+	@override
 	def __hash__(self) -> int:
 		return hash(self.disk.device.path)
 
@@ -807,6 +810,7 @@ class PartitionModification:
 		if self.fs_type is None and self.status == ModificationStatus.Modify:
 			raise ValueError('FS type must not be empty on modifications with status type modify')
 
+	@override
 	def __hash__(self) -> int:
 		return hash(self._obj_id)
 
@@ -1059,6 +1063,7 @@ class LvmVolume:
 		if not hasattr(self, '_obj_id'):
 			self._obj_id = uuid.uuid4()
 
+	@override
 	def __hash__(self) -> int:
 		return hash(self._obj_id)
 

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -18,7 +18,7 @@ from datetime import date, datetime
 from enum import Enum
 from select import EPOLLHUP, EPOLLIN, epoll
 from shutil import which
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 from urllib.request import Request, urlopen
 
 from .exceptions import RequirementError, SysCallError
@@ -86,6 +86,7 @@ class JSON(json.JSONEncoder, json.JSONDecoder):
 	A safe JSON encoder that will omit private information in dicts (starting with !)
 	"""
 
+	@override
 	def encode(self, o: Any) -> str:
 		return super().encode(jsonify(o))
 
@@ -95,6 +96,7 @@ class UNSAFE_JSON(json.JSONEncoder, json.JSONDecoder):
 	UNSAFE_JSON will call/encode and keep private information in dicts (starting with !)
 	"""
 
+	@override
 	def encode(self, o: Any) -> str:
 		return super().encode(jsonify(o, safe=False))
 
@@ -162,10 +164,12 @@ class SysCommandWorker:
 
 		self._trace_log_pos = last_line
 
+	@override
 	def __repr__(self) -> str:
 		self.make_sure_we_are_executing()
 		return str(self._trace_log)
 
+	@override
 	def __str__(self) -> str:
 		try:
 			return self._trace_log.decode('utf-8')
@@ -393,6 +397,7 @@ class SysCommand:
 		else:
 			raise ValueError("SysCommand() doesn't have key & value pairs, only slices, SysCommand('ls')[:10] as an example.")
 
+	@override
 	def __repr__(self, *args: list[Any], **kwargs: dict[str, Any]) -> str:
 		return self.decode('UTF-8', errors='backslashreplace') or ''
 

--- a/archinstall/lib/models/gen.py
+++ b/archinstall/lib/models/gen.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 
 @dataclass
@@ -39,6 +39,7 @@ class PackageSearchResult:
 	def pkg_version(self) -> str:
 		return self.pkgver
 
+	@override
 	def __eq__(self, other) -> bool:
 		return self.pkg_version == other.pkg_version
 
@@ -97,6 +98,7 @@ class LocalPackage:
 	def pkg_version(self) -> str:
 		return self.version
 
+	@override
 	def __eq__(self, other) -> bool:
 		return self.pkg_version == other.pkg_version
 

--- a/archinstall/lib/models/users.py
+++ b/archinstall/lib/models/users.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 if TYPE_CHECKING:
 	from collections.abc import Callable
@@ -17,6 +17,7 @@ class PasswordStrength(Enum):
 	STRONG = 'strong'
 
 	@property
+	@override
 	def value(self) -> str:  # pylint: disable=invalid-overridden-method
 		match self:
 			case PasswordStrength.VERY_WEAK:

--- a/archinstall/lib/translationhandler.py
+++ b/archinstall/lib/translationhandler.py
@@ -5,7 +5,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from .output import debug, error
 
@@ -180,6 +180,7 @@ class DeferredTranslation:
 	def __len__(self) -> int:
 		return len(self.message)
 
+	@override
 	def __str__(self) -> str:
 		translate = _
 		if translate is DeferredTranslation:

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -596,10 +596,6 @@ class Viewport(AbstractViewport):
 
 		return modified
 
-	def _replace_str(self, text: str, index: int = 0, replacement: str = '') -> str:
-		len_replace = len(replacement)
-		return f'{text[:index]}{replacement}{text[index + len_replace:]}'
-
 	def _unique_rows(self, entries: list[ViewportEntry]) -> int:
 		return len(set([e.row for e in entries]))
 


### PR DESCRIPTION
## PR Description:

This commit also removes duplicated code in `Viewport._replace_str`.