### PR TITLE
Replace deprecated stage name in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_stages: ['commit']
+default_stages: ['pre-commit']
 repos:
   - repo: https://github.com/pycqa/autoflake
     rev: v2.3.1


### PR DESCRIPTION
## PR Description:

This commit fixes the following warning:

"top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version."

Release notes:
- https://github.com/pre-commit/pre-commit/releases/tag/v4.0.0