### PR TITLE
Enable the unused-variable pylint rule and fix warnings

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -268,7 +268,7 @@ class SysCommandWorker:
 
 		if self.child_fd:
 			got_output = False
-			for fileno, event in self.poll_object.poll(0.1):
+			for _fileno, _event in self.poll_object.poll(0.1):
 				try:
 					output = os.read(self.child_fd, 8192)
 					got_output = True

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -181,7 +181,7 @@ def ask_additional_packages_to_install(preset: list[str] = []) -> list[str]:
 		# Verify packages that were given
 		out = str(_("Verifying that additional packages exist (this might take a few seconds)"))
 		Tui.print(out, 0)
-		valid, invalid = validate_package_list(packages)
+		_valid, invalid = validate_package_list(packages)
 
 		if invalid:
 			return f'{_("Some packages could not be found in the repository")}: {invalid}'

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -77,7 +77,7 @@ def get_hw_addr(ifname: str) -> str:
 def list_interfaces(skip_loopback: bool = True) -> dict[str, str]:
 	interfaces = {}
 
-	for index, iface in socket.if_nameindex():
+	for _index, iface in socket.if_nameindex():
 		if skip_loopback and iface == "lo":
 			continue
 
@@ -183,7 +183,7 @@ def ping(hostname, timeout=5) -> int:
 	# for a ICMP response or exit with no latency
 	while latency == -1 and time.time() - started < timeout:
 		try:
-			for fileno, event in watchdog.poll(0.1):
+			for _fileno, _event in watchdog.poll(0.1):
 				response, _ = icmp_socket.recvfrom(1024)
 				icmp_type = struct.unpack('!B', response[20:21])[0]
 

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -278,7 +278,7 @@ class ProfileHandler:
 		Load all default_profiles defined in a module
 		"""
 		profiles = []
-		for k, v in module.__dict__.items():
+		for v in module.__dict__.values():
 			if isinstance(v, type) and v.__module__ == module.__name__:
 				bases = inspect.getmro(v)
 

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -1175,7 +1175,7 @@ class SelectMenu(AbstractCurses):
 		items = self._get_visible_items()
 		entries = []
 
-		for row_idx, item in enumerate(items):
+		for item in items:
 			item_text = ''
 
 			if self._multi and not item.is_empty():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ disable = [
     "unreachable",
     "unspecified-encoding",
     "unused-argument",
-    "unused-variable",
 ]
 
 [tool.pylint.refactoring]


### PR DESCRIPTION
## PR Description:

I used names like `_fileno` instead of `_` to avoid potential conflicts with the translation handler.