### PR TITLE
Fix "Pssword" typo

### DIFF
--- a/archinstall/lib/utils/util.py
+++ b/archinstall/lib/utils/util.py
@@ -45,7 +45,7 @@ def get_password(
 		hidden = secret(password)
 
 		if header is not None:
-			confirmation_header = f'{header}{_("Pssword")}: {hidden}\n'
+			confirmation_header = f'{header}{_("Password")}: {hidden}\n'
 		else:
 			confirmation_header = f'{_("Password")}: {hidden}\n'
 


### PR DESCRIPTION
## PR Description:
Fixes the following typo:
![password_typo](https://github.com/user-attachments/assets/e789d523-c478-4882-9663-82d44f2f5d78)
