### PR TITLE
Fix "selction" typo

### DIFF
--- a/archinstall/tui/help.py
+++ b/archinstall/tui/help.py
@@ -52,7 +52,7 @@ class Help:
 	selection = HelpGroup(
 		group_id=HelpTextGroupId.SELECTION,
 		group_entries=[
-			HelpText('Skip selction (if available)', ['Esc']),
+			HelpText('Skip selection (if available)', ['Esc']),
 			HelpText('Reset selection (if available)', ['Ctrl+c']),
 			HelpText('Select on single select', ['Enter']),
 			HelpText('Select on select', ['Space', 'Tab']),


### PR DESCRIPTION
## PR Description:
Fixes the following typo in the help text:

![selection_typo](https://github.com/user-attachments/assets/353bb735-f329-4d43-ae63-cd945d29b175)
