### PR TITLE
Enable the yield-in-for-loop ruff rule and fix warnings

### DIFF
--- a/archinstall/lib/boot.py
+++ b/archinstall/lib/boot.py
@@ -80,8 +80,7 @@ class Boot:
 
 	def __iter__(self) -> Iterator[bytes]:
 		if self.session:
-			for value in self.session:
-				yield value
+			yield from self.session
 
 	def __contains__(self, key: bytes) -> bool:
 		if self.session is None:

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -383,8 +383,7 @@ class SysCommand:
 
 	def __iter__(self, *args: list[Any], **kwargs: dict[str, Any]) -> Iterator[bytes]:
 		if self.session:
-			for line in self.session:
-				yield line
+			yield from self.session
 
 	def __getitem__(self, key: slice) -> bytes | None:
 		if not self.session:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,6 @@ ignore = [
     "RUF012",   # mutable-class-default
     "RUF015",   # unnecessary-iterable-allocation-for-first-element
     "RUF039",   # unraw-re-pattern
-    "UP028",    # yield-in-for-loop
     "UP037",    # quoted-annotation
     "W191",     # tab-indentation
 ]


### PR DESCRIPTION
## PR Description:
I didn't notice any issues while testing `SysCommand.__iter__`.  `Boot.__iter__` doesn't seem reachable with the current code.

## Tests and Checks
- [x] I have tested the code!