### PR TITLE
Disable some rules that warn when using ruff's preview mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,10 @@ select = [
 
 ignore = [
     "E722",     # bare-except
+    "PLC0415",  # import-outside-top-level
+    "PLC1901",  # compare-to-empty-string
+    "PLW1514",  # unspecified-encoding
+    "PLW1641",  # eq-without-hash
     "PLW2901",  # redefined-loop-name
     "RUF005",   # collection-literal-concatenation
     "RUF012",   # mutable-class-default


### PR DESCRIPTION
## PR Description:

This makes it easier to run `ruff check --preview` locally.