### PR TITLE
Remove unused SysCommand.__json__ method

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -401,15 +401,6 @@ class SysCommand:
 	def __repr__(self, *args: list[Any], **kwargs: dict[str, Any]) -> str:
 		return self.decode('UTF-8', errors='backslashreplace') or ''
 
-	def __json__(self) -> dict[str, str | bool | list[str] | dict[str, Any] | None]:
-		return {
-			'cmd': self.cmd,
-			'callbacks': self._callbacks,
-			'peak': self.peek_output,
-			'environment_vars': self.environment_vars,
-			'session': self.session is not None
-		}
-
 	def create_session(self) -> bool:
 		"""
 		Initiates a :ref:`SysCommandWorker` session in this class ``.session``.


### PR DESCRIPTION
## PR Description:
This PR removes an `Any` instance and squashes a Ruff warning in preview mode:

```
$ ruff check --preview --select=PLW3201 --output-format=concise
archinstall/lib/general.py:404:6: PLW3201 Dunder method `__json__` has no special meaning in Python 3
```


## Tests and Checks
- [x] I have tested the code