### PR TITLE
Enable the "unreachable" pylint warning and remove unused code

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -220,7 +220,6 @@ class SysCommandWorker:
 
 		if self.child_fd:
 			return os.write(self.child_fd, data + (b'\n' if line_ending else b''))
-			os.fsync(self.child_fd)
 
 		return 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,6 @@ disable = [
     "fixme",
     "protected-access",
     "raise-missing-from",
-    "unreachable",
     "unspecified-encoding",
     "unused-argument",
 ]


### PR DESCRIPTION
## PR Description:

The `os.fsync` call causes an "invalid argument" OSError when it actually runs, so it has been removed altogether.

Closes #2773

## Tests and Checks
- [x] I have tested the code!