### PR TITLE
Enable bare-except linter rules and fix warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 count = True
-# Several of the following could be autofixed or improved by running the code through psf/black
-ignore = E722,W191,W503
+ignore = W191,W503
 max-complexity = 40
 max-line-length = 160
 show-source = True

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -1,5 +1,5 @@
 on: [ push, pull_request ]
-name: flake8 linting (3 ignores)
+name: flake8 linting
 jobs:
     flake8:
         runs-on: ubuntu-latest

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -186,7 +186,7 @@ class SysCommandWorker:
 		if self.child_fd:
 			try:
 				os.close(self.child_fd)
-			except:
+			except Exception:
 				pass
 
 		if self.peek_output:

--- a/archinstall/lib/locale/utils.py
+++ b/archinstall/lib/locale/utils.py
@@ -48,7 +48,7 @@ def get_kb_layout() -> str:
 			"localectl --no-pager status",
 			environment_vars={'SYSTEMD_COLORS': '0'}
 		).decode().splitlines()
-	except:
+	except Exception:
 		return ""
 
 	vcline = ""

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -151,7 +151,7 @@ def perform_installation(mountpoint: Path) -> None:
 			if chroot:
 				try:
 					installation.drop_to_shell()
-				except:
+				except Exception:
 					pass
 
 	debug(f"Disk states after installing:\n{disk.disk_layouts()}")

--- a/archinstall/scripts/swiss.py
+++ b/archinstall/scripts/swiss.py
@@ -229,7 +229,7 @@ def perform_installation(mountpoint: Path, exec_mode: ExecutionMode) -> None:
 			if chroot:
 				try:
 					installation.drop_to_shell()
-				except:
+				except Exception:
 					pass
 
 		debug(f"Disk states after installing:\n{disk.disk_layouts()}")

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -794,7 +794,7 @@ class EditMenu(AbstractCurses):
 				self._real_input += chr(key)
 				if self._hide_input:
 					key = 42
-			except:
+			except Exception:
 				pass
 
 		return key

--- a/examples/interactive_installation.py
+++ b/examples/interactive_installation.py
@@ -151,7 +151,7 @@ def perform_installation(mountpoint: Path) -> None:
 			if chroot:
 				try:
 					installation.drop_to_shell()
-				except:
+				except Exception:
 					pass
 
 	debug(f"Disk states after installing:\n{disk.disk_layouts()}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ disable = [
     "C",
     "R",
     "attribute-defined-outside-init",
-    "bare-except",
     "broad-exception-caught",
     "cell-var-from-loop",
     "dangerous-default-value",
@@ -205,7 +204,6 @@ select = [
 ]
 
 ignore = [
-    "E722",     # bare-except
     "PLC0415",  # import-outside-top-level
     "PLC1901",  # compare-to-empty-string
     "PLW1514",  # unspecified-encoding


### PR DESCRIPTION
## PR Description:
I didn't notice any issues while testing this patch.  I tried hitting Ctrl + c in various places to try to trigger `KeyboardInterrupt` exceptions, but I didn't see any raised exceptions.


## Tests and Checks
- [x] I have tested the code!