### PR TITLE
updating plasma.py

### DIFF
--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -14,11 +14,10 @@ class PlasmaProfile(XorgProfile):
 		return [
 			"plasma-meta",
 			"konsole",
-			"kwrite",
+			"kate",
 			"dolphin",
 			"ark",
-			"plasma-workspace",
-			"egl-wayland"
+			"plasma-workspace"
 		]
 
 	@property


### PR DESCRIPTION
changed kwrite to kate as the two packages merged together in 2022 and removed egl-wayland (why was it there in the first place?) it gets pulled by the nvidia package anyway.
