### PR TITLE
Remove disk retries and timeouts

### DIFF
--- a/archinstall/lib/storage.py
+++ b/archinstall/lib/storage.py
@@ -14,8 +14,6 @@ storage: dict[str, Any] = {
 	'LOG_FILE': Path('install.log'),
 	'MOUNT_POINT': Path('/mnt/archinstall'),
 	'ENC_IDENTIFIER': 'ainst',
-	'DISK_TIMEOUTS': 1,  # seconds
-	'DISK_RETRY_ATTEMPTS': 5,  # RETRY_ATTEMPTS * DISK_TIMEOUTS is used in disk operations
 	'CMD_LOCALE': {'LC_ALL': 'C'},  # default locale for execution commands. Can be overridden with set_cmd_locale()
 	'CMD_LOCALE_DEFAULT': {'LC_ALL': 'C'},  # should be the same as the former. Not be used except in reset_cmd_locale()
 }


### PR DESCRIPTION
The retires in `encrypt()` should not be necessary and it is the only place `DISK_RETRY_ATTEMPTS` and `DISK_TIMEOUTS` ever get used anymore. The rationale for removal is that encrypting takes place after partitioning just as formatting does. If the partitions are able to be formatted directly after partitioning then they should also be able to be encrypted directly after partitioning, it is the same. Prior to 00b0ae7b, [formatting](https://github.com/archlinux/archinstall/blob/5253e57e9f26cf3e59cb2460544af13f56e485bb/archinstall/lib/disk/partition.py#L490-L583) had similar logic which has since been removed without issue.