### PR TITLE
general: rework environment_vars

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -107,13 +107,12 @@ class SysCommandWorker:
 		cmd: str | list[str],
 		callbacks: dict[str, Any] | None = None,
 		peek_output: bool | None = False,
-		environment_vars: dict[str, Any] | None = None,
+		environment_vars: dict[str, str] | None = None,
 		logfile: None = None,
 		working_directory: str | None = './',
 		remove_vt100_escape_codes_from_lines: bool = True
 	):
 		callbacks = callbacks or {}
-		environment_vars = environment_vars or {}
 
 		if isinstance(cmd, str):
 			cmd = shlex.split(cmd)
@@ -126,7 +125,10 @@ class SysCommandWorker:
 		self.callbacks = callbacks
 		self.peek_output = peek_output
 		# define the standard locale for command outputs. For now the C ascii one. Can be overridden
-		self.environment_vars = {**storage.get('CMD_LOCALE', {}), **environment_vars}
+		self.environment_vars = {'LC_ALL': 'C'}
+		if environment_vars:
+			self.environment_vars.update(environment_vars)
+
 		self.logfile = logfile
 		self.working_directory = working_directory
 
@@ -353,7 +355,7 @@ class SysCommand:
 		callbacks: dict[str, Callable[[Any], Any]] = {},
 		start_callback: Callable[[Any], Any] | None = None,
 		peek_output: bool | None = False,
-		environment_vars: dict[str, Any] | None = None,
+		environment_vars: dict[str, str] | None = None,
 		working_directory: str | None = './',
 		remove_vt100_escape_codes_from_lines: bool = True):
 

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -208,7 +208,7 @@ class Luks2:
 		debug(f'Adding additional key-file {key_file}')
 
 		command = f'/usr/bin/cryptsetup -q -v luksAddKey {self.luks_dev_path} {key_file}'
-		worker = SysCommandWorker(command, environment_vars={'LC_ALL': 'C'})
+		worker = SysCommandWorker(command)
 		pw_injected = False
 
 		while worker.is_alive():

--- a/archinstall/lib/storage.py
+++ b/archinstall/lib/storage.py
@@ -14,6 +14,4 @@ storage: dict[str, Any] = {
 	'LOG_FILE': Path('install.log'),
 	'MOUNT_POINT': Path('/mnt/archinstall'),
 	'ENC_IDENTIFIER': 'ainst',
-	'CMD_LOCALE': {'LC_ALL': 'C'},  # default locale for execution commands. Can be overridden with set_cmd_locale()
-	'CMD_LOCALE_DEFAULT': {'LC_ALL': 'C'},  # should be the same as the former. Not be used except in reset_cmd_locale()
 }


### PR DESCRIPTION
- Remove `CMD_LOCALE` and `CMD_LOCALE_DEFAULT` (the comments for these reference nonexistent functions)
- Fix typing for `environment_var` since all values should be str
