### PR TITLE
Update pkgs in hardware.py

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -90,11 +90,11 @@ class GfxDriver(Enum):
 		match self:
 			case GfxDriver.AllOpenSource:
 				packages += [
-					GfxPackage.Mesa,
 					GfxPackage.IntelMediaDriver,
-					GfxPackage.VulkanRadeon,
-					GfxPackage.VulkanNouveau,
+					GfxPackage.Mesa,
 					GfxPackage.VulkanIntel,
+					GfxPackage.VulkanNouveau,
+					GfxPackage.VulkanRadeon,
 					GfxPackage.Xf86VideoVmware
 				]
 			case GfxDriver.AmdOpenSource:
@@ -104,8 +104,8 @@ class GfxDriver(Enum):
 				]
 			case GfxDriver.IntelOpenSource:
 				packages += [
-					GfxPackage.Mesa,
 					GfxPackage.IntelMediaDriver,
+					GfxPackage.Mesa,
 					GfxPackage.VulkanIntel
 				]
 			case GfxDriver.NvidiaOpenKernel:

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -44,19 +44,14 @@ class CpuVendor(Enum):
 
 
 class GfxPackage(Enum):
-	Dkms = 'dkms'
 	IntelMediaDriver = 'intel-media-driver'
-	LibvaIntelDriver = 'libva-intel-driver'
-	LibvaMesaDriver = 'libva-mesa-driver'
 	Mesa = "mesa"
+	VulkanNouveau = 'vulkan-nouveau'
 	NvidiaDkms = 'nvidia-dkms'
-	NvidiaOpen = 'nvidia-open'
 	NvidiaOpenDkms = 'nvidia-open-dkms'
+	NvidiaUtils = 'nvidia-utils'
 	VulkanIntel = 'vulkan-intel'
 	VulkanRadeon = 'vulkan-radeon'
-	Xf86VideoAmdgpu = "xf86-video-amdgpu"
-	Xf86VideoAti = "xf86-video-ati"
-	Xf86VideoNouveau = 'xf86-video-nouveau'
 	Xf86VideoVmware = 'xf86-video-vmware'
 	XorgServer = 'xorg-server'
 	XorgXinit = 'xorg-xinit'
@@ -96,54 +91,43 @@ class GfxDriver(Enum):
 			case GfxDriver.AllOpenSource:
 				packages += [
 					GfxPackage.Mesa,
-					GfxPackage.Xf86VideoAmdgpu,
-					GfxPackage.Xf86VideoAti,
-					GfxPackage.Xf86VideoNouveau,
-					GfxPackage.Xf86VideoVmware,
-					GfxPackage.LibvaMesaDriver,
-					GfxPackage.LibvaIntelDriver,
 					GfxPackage.IntelMediaDriver,
 					GfxPackage.VulkanRadeon,
-					GfxPackage.VulkanIntel
+					GfxPackage.VulkanNouveau
+					GfxPackage.VulkanIntel,
+					GfxPackage.Xf86VideoVmware
 				]
 			case GfxDriver.AmdOpenSource:
 				packages += [
 					GfxPackage.Mesa,
-					GfxPackage.Xf86VideoAmdgpu,
-					GfxPackage.Xf86VideoAti,
-					GfxPackage.LibvaMesaDriver,
 					GfxPackage.VulkanRadeon
 				]
 			case GfxDriver.IntelOpenSource:
 				packages += [
 					GfxPackage.Mesa,
-					GfxPackage.LibvaIntelDriver,
 					GfxPackage.IntelMediaDriver,
 					GfxPackage.VulkanIntel
 				]
 			case GfxDriver.NvidiaOpenKernel:
 				packages += [
-					GfxPackage.NvidiaOpen,
-					GfxPackage.Dkms,
-					GfxPackage.NvidiaOpenDkms
+					GfxPackage.NvidiaOpenDkms,
+					GfxPackage.NvidiaUtils
 				]
 			case GfxDriver.NvidiaOpenSource:
 				packages += [
 					GfxPackage.Mesa,
-					GfxPackage.Xf86VideoNouveau,
-					GfxPackage.LibvaMesaDriver
+					GfxPackage.VulkanNouveau
 				]
 			case GfxDriver.NvidiaProprietary:
 				packages += [
-					GfxPackage.NvidiaDkms,
-					GfxPackage.Dkms,
+					GfxPackage.NvidiaDkms
 				]
 			case GfxDriver.VMOpenSource:
 				packages += [
 					GfxPackage.Mesa,
 					GfxPackage.Xf86VideoVmware
 				]
-
+				
 		return packages
 
 

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -45,7 +45,7 @@ class CpuVendor(Enum):
 
 class GfxPackage(Enum):
 	IntelMediaDriver = 'intel-media-driver'
-	Mesa = "mesa"
+	Mesa = 'mesa'
 	VulkanNouveau = 'vulkan-nouveau'
 	NvidiaDkms = 'nvidia-dkms'
 	NvidiaOpenDkms = 'nvidia-open-dkms'
@@ -93,7 +93,7 @@ class GfxDriver(Enum):
 					GfxPackage.Mesa,
 					GfxPackage.IntelMediaDriver,
 					GfxPackage.VulkanRadeon,
-					GfxPackage.VulkanNouveau
+					GfxPackage.VulkanNouveau,
 					GfxPackage.VulkanIntel,
 					GfxPackage.Xf86VideoVmware
 				]


### PR DESCRIPTION
Removed the defunct "libva-mesa-driver" package, "dkms", "nvidia-open", "libva-intel-driver", almost all xf86 packages and added "vulkan-nouveau" and "nvidia-utils" packages in hardware.py.