### PR TITLE
Fix falsy-dict-get-fallback ruff warnings

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -267,10 +267,10 @@ def load_config() -> None:
 def post_process_arguments(args: dict[str, Any]) -> None:
 	storage['arguments'] = args
 
-	if args.get('debug', False):
+	if args.get('debug'):
 		warn(f"Warning: --debug mode will write certain credentials to {storage['LOG_PATH']}/{storage['LOG_FILE']}!")
 
-	if args.get('plugin', None):
+	if args.get('plugin'):
 		path = args['plugin']
 		load_plugin(path)
 
@@ -317,7 +317,7 @@ def main() -> None:
 	OR straight as a module: python -m archinstall
 	In any case we will be attempting to load the provided script to be run from the scripts/ folder
 	"""
-	if not arguments.get('skip_version_check', False):
+	if not arguments.get('skip_version_check'):
 		_check_new_version()
 
 	script = arguments.get('script', None)

--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -94,7 +94,7 @@ class ArchConfig:
 		if bootloader_config := args_config.get('bootloader', None):
 			arch_config.bootloader = Bootloader.from_arg(bootloader_config)
 
-		if args_config.get('uki', False) and not arch_config.bootloader.has_uki_support():
+		if args_config.get('uki') and not arch_config.bootloader.has_uki_support():
 			arch_config.uki = False
 
 		if audio_config := args_config.get('audio_config', None):


### PR DESCRIPTION
## PR Description:

This PR fixes some warnings that show up when running `ruff check --preview` locally:

```
archinstall/__init__.py:270:23: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
archinstall/__init__.py:273:24: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
archinstall/__init__.py:320:45: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
archinstall/lib/args.py:97:29: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
```

Docs:
- https://docs.astral.sh/ruff/rules/falsy-dict-get-fallback/