### PR TITLE
Use float instead of int for pre-validated mirror score fields

### DIFF
--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -94,7 +94,7 @@ class MirrorStatusEntryV3(BaseModel):
 
 	@classmethod
 	@field_validator('score', mode='before')
-	def validate_score(cls, value: int) -> int | None:
+	def validate_score(cls, value: float) -> int | None:
 		if value is not None:
 			value = round(value)
 			debug(f"    score: {value}")
@@ -106,7 +106,7 @@ class MirrorStatusEntryV3(BaseModel):
 		self._hostname, *_port = urllib.parse.urlparse(self.url).netloc.split(':', 1)
 		self._port = int(_port[0]) if _port and len(_port) >= 1 else None
 
-		debug(f"Loaded mirror {self._hostname}" + (f" with current score of {round(self.score)}" if self.score else ''))
+		debug(f"Loaded mirror {self._hostname}" + (f" with current score of {self.score}" if self.score else ''))
 		return self
 
 


### PR DESCRIPTION
## PR Description:
This fixes an unnecessary-round ruff warning in `validate_score`:

```
archinstall/lib/models/mirrors.py:99:12: RUF057 Value being rounded is already an integer
```

It also makes the code match the types seen in https://archlinux.org/mirrors/status/json/.