### PR TITLE
Add if-key-in-dict-del ruff rule to ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ ignore = [
     "RUF012",   # mutable-class-default
     "RUF015",   # unnecessary-iterable-allocation-for-first-element
     "RUF039",   # unraw-re-pattern
+    "RUF051",   # if-key-in-dict-del
     "UP037",    # quoted-annotation
     "W191",     # tab-indentation
 ]


### PR DESCRIPTION
## PR Description:

The rule is concerned with code style rather than correctness or performance.

Docs:
- https://docs.astral.sh/ruff/rules/if-key-in-dict-del/