### PR TITLE
Fix used-dummy-variable ruff warnings

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -147,11 +147,11 @@ class Installer:
 		if not storage['arguments'].get('skip_ntp', False):
 			info(_('Waiting for time sync (timedatectl show) to complete.'))
 
-			_started_wait = time.time()
-			_notified = False
+			started_wait = time.time()
+			notified = False
 			while True:
-				if not _notified and time.time() - _started_wait > 5:
-					_notified = True
+				if not notified and time.time() - started_wait > 5:
+					notified = True
 					warn(
 						_("Time synchronization not completing, while you wait - check the docs for workarounds: https://archinstall.readthedocs.io/"))
 

--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -48,8 +48,8 @@ class MirrorStatusEntryV3(BaseModel):
 			elif self._speedtest_retries < 1:
 				self._speedtest_retries = 1
 
-			_retry = 0
-			while _retry < self._speedtest_retries and self._speed is None:
+			retry = 0
+			while retry < self._speedtest_retries and self._speed is None:
 				debug(f"Checking download speed of {self._hostname}[{self.score}] by fetching: {self.url}core/os/x86_64/core.db")
 				req = urllib.request.Request(url=f"{self.url}core/os/x86_64/core.db")
 
@@ -71,7 +71,7 @@ class MirrorStatusEntryV3(BaseModel):
 					debug(f"    speed: <undetermined> ({error}), skip")
 					self._speed = 0
 
-				_retry += 1
+				retry += 1
 
 			if self._speed is None:
 				self._speed = 0
@@ -103,8 +103,8 @@ class MirrorStatusEntryV3(BaseModel):
 
 	@model_validator(mode='after')
 	def debug_output(self, validation_info) -> 'MirrorStatusEntryV3':
-		self._hostname, *_port = urllib.parse.urlparse(self.url).netloc.split(':', 1)
-		self._port = int(_port[0]) if _port and len(_port) >= 1 else None
+		self._hostname, *port = urllib.parse.urlparse(self.url).netloc.split(':', 1)
+		self._port = int(port[0]) if port and len(port) >= 1 else None
 
 		debug(f"Loaded mirror {self._hostname}" + (f" with current score of {round(self.score)}" if self.score else ''))
 		return self


### PR DESCRIPTION
## PR Description:

This PR fixes some warnings that show up when running `ruff check --preview` locally:

```
archinstall/lib/installer.py:150:4: RUF052 Local dummy variable `_started_wait` is accessed
archinstall/lib/installer.py:151:4: RUF052 Local dummy variable `_notified` is accessed
archinstall/lib/installer.py:154:6: RUF052 Local dummy variable `_notified` is accessed
archinstall/lib/models/mirrors.py:51:4: RUF052 Local dummy variable `_retry` is accessed
archinstall/lib/models/mirrors.py:74:5: RUF052 Local dummy variable `_retry` is accessed
archinstall/lib/models/mirrors.py:106:20: RUF052 Local dummy variable `_port` is accessed
```

Docs:
- https://docs.astral.sh/ruff/rules/used-dummy-variable/