### PR TITLE
Fix mutable-class-default ruff warnings

### DIFF
--- a/archinstall/lib/disk/fido.py
+++ b/archinstall/lib/disk/fido.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import getpass
 from pathlib import Path
+from typing import ClassVar
 
 from ..exceptions import SysCallError
 from ..general import SysCommand, SysCommandWorker, clear_vt100_escape_codes
@@ -11,7 +12,7 @@ from .device_model import Fido2Device
 
 class Fido2:
 	_loaded: bool = False
-	_fido2_devices: list[Fido2Device] = []
+	_fido2_devices: ClassVar[list[Fido2Device]] = []
 
 	@classmethod
 	def get_fido2_devices(cls, reload: bool = False) -> list[Fido2Device]:

--- a/archinstall/tui/types.py
+++ b/archinstall/tui/types.py
@@ -18,37 +18,37 @@ class STYLE(Enum):
 
 class MenuKeys(Enum):
 	# latin keys
-	STD_KEYS = set(range(32, 127))
+	STD_KEYS = frozenset(range(32, 127))
 	# numbers
-	NUM_KEYS = set(range(49, 58))
+	NUM_KEYS = frozenset(range(49, 58))
 	# Menu up: up, k
-	MENU_UP = {259, 107}
+	MENU_UP = frozenset({259, 107})
 	# Menu down: down, j
-	MENU_DOWN = {258, 106}
+	MENU_DOWN = frozenset({258, 106})
 	# Menu left: left, h
-	MENU_LEFT = {260, 104}
+	MENU_LEFT = frozenset({260, 104})
 	# Menu right: right, l
-	MENU_RIGHT = {261, 108}
+	MENU_RIGHT = frozenset({261, 108})
 	# Menu start: home CTRL-a
-	MENU_START = {262, 1}
+	MENU_START = frozenset({262, 1})
 	# Menu end: end CTRL-e
-	MENU_END = {360, 5}
+	MENU_END = frozenset({360, 5})
 	# Enter
-	ACCEPT = {10}
+	ACCEPT = frozenset({10})
 	# Selection: space, tab
-	MULTI_SELECT = {32, 9}
+	MULTI_SELECT = frozenset({32, 9})
 	# Search: /
-	ENABLE_SEARCH = {47}
+	ENABLE_SEARCH = frozenset({47})
 	# ESC
-	ESC = {27}
+	ESC = frozenset({27})
 	# BACKSPACE (search)
-	BACKSPACE = {127, 263}
+	BACKSPACE = frozenset({127, 263})
 	# Help view: ctrl+h
-	HELP = {8}
+	HELP = frozenset({8})
 	# Scroll up: CTRL+up
-	SCROLL_UP = {581}
+	SCROLL_UP = frozenset({581})
 	# Scroll down: CTRL+down
-	SCROLL_DOWN = {540}
+	SCROLL_DOWN = frozenset({540})
 
 	@classmethod
 	def from_ord(cls, key: int) -> list['MenuKeys']:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,6 @@ ignore = [
     "PLW1641",  # eq-without-hash
     "PLW2901",  # redefined-loop-name
     "RUF005",   # collection-literal-concatenation
-    "RUF012",   # mutable-class-default
     "RUF015",   # unnecessary-iterable-allocation-for-first-element
     "RUF039",   # unraw-re-pattern
     "RUF051",   # if-key-in-dict-del


### PR DESCRIPTION
## PR Description:
Using `frozenset` helps guard against accidental changes to class variables.

Docs:
- https://docs.astral.sh/ruff/rules/mutable-class-default/

## Tests and Checks
- [x] I have tested the code!