### PR TITLE
Docs: Use Matrix channel invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Just another guided/automated [Arch Linux](https://wiki.archlinux.org/index.php/
 The installer also doubles as a python library to install Arch Linux and manage services, packages, and other things inside the installed system *(Usually from a live medium)*.
 
 * archinstall [discord](https://discord.gg/aDeMffrxNg) server
-* archinstall [matrix.org](https://app.element.io/#/room/#archinstall:matrix.org) channel
+* archinstall [#archinstall:matrix.org](https://matrix.to/#/#archinstall:matrix.org) Matrix channel
 * archinstall [#archinstall@irc.libera.chat](irc://#archinstall@irc.libera.chat:6697)
 * archinstall [documentation](https://archinstall.archlinux.page/)
 


### PR DESCRIPTION
## PR Description:

Instead of pointing people to the web chat, it's advised to use a https://matrix.to link. Allowing users (like myself) to join the channel using a desktop client (eg. Element). Or basically any Matrix client (web or not).

## Tests and Checks

N/A