### PR TITLE
Make libera.chat irc link clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The installer also doubles as a python library to install Arch Linux and manage 
 
 * archinstall [discord](https://discord.gg/aDeMffrxNg) server
 * archinstall [matrix.org](https://app.element.io/#/room/#archinstall:matrix.org) channel
-* archinstall [#archinstall@irc.libera.chat](irc://#archinstall@irc.libera.chat:6697)
+* archinstall [#archinstall@irc.libera.chat:6697](https://web.libera.chat/?channel=#archinstall)
 * archinstall [documentation](https://archinstall.archlinux.page/)
 
 # Installation & Usage


### PR DESCRIPTION
## PR Description:

Fix libera IRC link in markdown, since the current `irc://` protocol is not valid by the markdown parser in GitHub. Meaning the there is no link created currently.

This PR fixes that.

---

Before:

![image](https://github.com/user-attachments/assets/b08ae6c1-1473-4e0b-a130-871a628db8e7)

After:

![image](https://github.com/user-attachments/assets/d0123f65-8ae2-4218-bb94-77f3ab6895dc)
