### PR TITLE
Avoid reassigning a parameter value to fix Pyright warnings

### DIFF
--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -126,11 +126,11 @@ class ConfigurationOutput:
 				target.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
 
 	def save(self, dest_path: Path | None = None) -> None:
-		dest_path = dest_path or self._default_save_path
+		save_path = dest_path or self._default_save_path
 
-		if self._is_valid_path(dest_path):
-			self.save_user_config(dest_path)
-			self.save_user_creds(dest_path)
+		if self._is_valid_path(save_path):
+			self.save_user_config(save_path)
+			self.save_user_creds(save_path)
 
 
 def save_config(config: dict[str, Any]) -> None:


### PR DESCRIPTION
## PR Description:

This PR fixes the following Pyright warnings:

```
archinstall/lib/configuration.py:131:26 - error: Argument of type "Path | None" cannot be assigned to parameter "dest_path" of type "Path" in function "_is_valid_path"
    Type "Path | None" is not assignable to type "Path"
      "None" is not assignable to "Path" (reportArgumentType)
archinstall/lib/configuration.py:132:26 - error: Argument of type "Path | None" cannot be assigned to parameter "dest_path" of type "Path" in function "save_user_config"
    Type "Path | None" is not assignable to type "Path"
      "None" is not assignable to "Path" (reportArgumentType)
archinstall/lib/configuration.py:133:25 - error: Argument of type "Path | None" cannot be assigned to parameter "dest_path" of type "Path" in function "save_user_creds"
    Type "Path | None" is not assignable to type "Path"
```