### PR TITLE
Fix 3091 -  scrolling in console

### DIFF
--- a/archinstall/tui/help.py
+++ b/archinstall/tui/help.py
@@ -39,8 +39,8 @@ class Help:
 	navigation = HelpGroup(
 		group_id=HelpTextGroupId.NAVIGATION,
 		group_entries=[
-			HelpText('Scroll up', ['Ctrl+↑']),
-			HelpText('Scroll down', ['Ctrl+↓']),
+			HelpText('Preview scroll up', ['PgUp']),
+			HelpText('Preview scroll down', ['PgDown']),
 			HelpText('Move up', ['k', '↑']),
 			HelpText('Move down', ['j', '↓']),
 			HelpText('Move right', ['l', '→']),

--- a/archinstall/tui/types.py
+++ b/archinstall/tui/types.py
@@ -45,10 +45,10 @@ class MenuKeys(Enum):
 	BACKSPACE = frozenset({127, 263})
 	# Help view: ctrl+h
 	HELP = frozenset({8})
-	# Scroll up: CTRL+up
-	SCROLL_UP = frozenset({581})
-	# Scroll down: CTRL+down
-	SCROLL_DOWN = frozenset({540})
+	# Scroll up: PGUP
+	SCROLL_UP = frozenset({339})
+	# Scroll down: PGDOWN
+	SCROLL_DOWN = frozenset({338})
 
 	@classmethod
 	def from_ord(cls, key: int) -> list['MenuKeys']:


### PR DESCRIPTION
Fixes #3091, it seems that the key shortcuts `ctrl+up/down` are not recognized in the console (but in a terminal emulator), also other combinations like `alt+up/down` don't work. 

`PgUp` and `PgDown` seem to work though and they are unused so far so I opted for using those for now. 
