### PR TITLE
Remove reiserfs as it's been deprecated since 2022 

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -30,7 +30,6 @@ depends=(
   'lvm2'
   'f2fs-tools'
   'ntfs-3g'
-  'reiserfsprogs'
 )
 makedepends=(
   'python-setuptools'

--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -278,8 +278,6 @@ class DeviceHandler:
 			case FilesystemType.Ntfs:
 				# Skip zeroing and bad sector check
 				options.append('--fast')
-			case FilesystemType.Reiserfs:
-				pass
 			case FilesystemType.LinuxSwap:
 				command = "mkswap"
 			case _:

--- a/archinstall/lib/disk/device_model.py
+++ b/archinstall/lib/disk/device_model.py
@@ -766,7 +766,6 @@ class FilesystemType(Enum):
 	Fat16 = 'fat16'
 	Fat32 = 'fat32'
 	Ntfs = 'ntfs'
-	Reiserfs = 'reiserfs'
 	Xfs = 'xfs'
 	LinuxSwap = 'linux-swap'
 


### PR DESCRIPTION
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a452c4eb404df8a7f2a79a37ac77b90b6db1a2c9)
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c01f664e4ca210823b7594b50669bbd9b0a3c3b0)

And we're the [last package that depends on it before it can be removed from packaging](https://archlinux.org/packages/core/x86_64/reiserfsprogs/)