### PR TITLE
Removed requirement for root for pylint

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -90,7 +90,7 @@ def define_arguments() -> None:
 						help="Skip the version check when running archinstall")
 
 
-if 'sphinx' not in sys.modules:
+if 'sphinx' not in sys.modules and 'pylint' not in sys.modules:
 	if '--help' in sys.argv or '-h' in sys.argv:
 		define_arguments()
 		parser.print_help()


### PR DESCRIPTION
`pylint` triggered the `root` uid check, which prohibits packaging of `archinstall` due to `check()` calling pylint and ruff before continuing.