### PR TITLE
Remove unneeded mypy override for archinstall.scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,10 +115,6 @@ module = "archinstall.lib.utils"
 disallow_any_explicit = true
 
 [[tool.mypy.overrides]]
-module = "archinstall.scripts.*"
-warn_unreachable = false
-
-[[tool.mypy.overrides]]
 module = "archinstall.tui.*"
 warn_unreachable = false
 


### PR DESCRIPTION
## PR Description:

The override is no longer needed after commit fc63d45fe6.