### PR TITLE
Fixed grammar under function "get_arguments"

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -174,7 +174,7 @@ def get_arguments() -> dict[str, Any]:
 	0) we create a dict to store the arguments and their values
 	1) preprocess.
 		We take those arguments which use JSON files, and read them into the argument dict. So each first level entry
-		becomes a argument on it's own right
+		becomes an argument on its own right
 	2) Load.
 		We convert the predefined argument list directly into the dict via the vars() function. Non specified arguments
 		are loaded with value None or false if they are booleans (action="store_true"). The name is chosen according to
@@ -182,7 +182,7 @@ def get_arguments() -> dict[str, Any]:
 		then load all the undefined arguments. In this case the names are taken as written.
 		Important. This way explicit command line arguments take precedence over configuration files.
 	3) Amend
-		Change whatever is needed on the configuration dictionary (it could be done in post_process_arguments but  this
+		Change whatever is needed on the configuration dictionary (it could be done in post_process_arguments but this
 		ougth to be left to changes anywhere else in the code, not in the arguments dictionary
 	"""
 	config: dict[str, Any] = {}


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->
In the comments of get_arguments I changed:
a -> an
it's -> its
and removed a double space

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
