### PR TITLE
Add support for qemu venus

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -105,7 +105,8 @@ class GfxDriver(Enum):
 					GfxPackage.LibvaIntelDriver,
 					GfxPackage.IntelMediaDriver,
 					GfxPackage.VulkanRadeon,
-					GfxPackage.VulkanIntel
+					GfxPackage.VulkanIntel,
+					GfxPackage.VulkanVirtio
 				]
 			case GfxDriver.AmdOpenSource:
 				packages += [

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -54,6 +54,7 @@ class GfxPackage(Enum):
 	NvidiaOpenDkms = 'nvidia-open-dkms'
 	VulkanIntel = 'vulkan-intel'
 	VulkanRadeon = 'vulkan-radeon'
+	VulkanVirtio = 'vulkan-virtio'
 	Xf86VideoAmdgpu = "xf86-video-amdgpu"
 	Xf86VideoAti = "xf86-video-ati"
 	Xf86VideoNouveau = 'xf86-video-nouveau'
@@ -69,7 +70,7 @@ class GfxDriver(Enum):
 	NvidiaOpenKernel = 'Nvidia (open kernel module for newer GPUs, Turing+)'
 	NvidiaOpenSource = 'Nvidia (open-source nouveau driver)'
 	NvidiaProprietary = 'Nvidia (proprietary)'
-	VMOpenSource = 'VMware / VirtualBox (open-source)'
+	VMOpenSource = 'Qemu / VMware / VirtualBox (open-source)'
 
 	def is_nvidia(self) -> bool:
 		match self:
@@ -141,7 +142,8 @@ class GfxDriver(Enum):
 			case GfxDriver.VMOpenSource:
 				packages += [
 					GfxPackage.Mesa,
-					GfxPackage.Xf86VideoVmware
+					GfxPackage.Xf86VideoVmware,
+					GfxPackage.VulkanVirtio
 				]
 
 		return packages


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:
Adds support for the Venus in qemu to the graphics drivers. Venus is a way to have gpu acceleration in qemu with vulkan. Adds it to the all open source and to the open source vm.
<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
