### PR TITLE
Add disk sync on partition add to prevent table corruption

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -561,6 +561,8 @@ class DeviceHandler:
 
 		try:
 			disk.addPartition(partition=partition, constraint=disk.device.optimalAlignedConstraint)
+
+			disk.commit()
 		except PartitionException as ex:
 			raise DiskError(f'Unable to add partition, most likely due to overlapping sectors: {ex}') from ex
 


### PR DESCRIPTION
- This fix issue: #3168 

## PR Description:

The disk is not synced after adding a partition, meaning other writes might corrupt the partition table.

Calling `disk.commit()` afterward solved the problem.

## Tests and Checks
- [x] I have tested the code!

To test this, just use `archinstall` normally, noticing the not-corrupted partition table (with `fdisk`).