### PR TITLE
Enable --strict-bytes checks in mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ disallow_untyped_decorators = true
 disallow_untyped_defs = true
 extra_checks = true
 strict = false
+strict_bytes = true
 strict_equality = true
 warn_redundant_casts = true
 warn_return_any = true


### PR DESCRIPTION
## PR Description:

Strict-bytes checks will be enabled by default in mypy 2.0, so this commit will help prevent violations from being introduced into the codebase.

Docs:
- https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict-bytes