### PR TITLE
Fix version parsing for local branches

### DIFF
--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -82,7 +82,7 @@ class ArchConfig:
 		return config
 
 	def safe_json(self) -> dict[str, Any]:
-		config = {
+		config: Any = {
 			'version': self.version,
 			'archinstall-language': self.archinstall_language.json(),
 			'hostname': self.hostname,

--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -44,7 +44,7 @@ class Arguments:
 
 @dataclass
 class ArchConfig:
-	version: str = field(default_factory=lambda: version('archinstall'))
+	version: str | None = None
 	locale_config: LocaleConfiguration | None = None
 	archinstall_language: Language = field(default_factory=lambda: translation_handler.get_language_by_abbr('en'))
 	disk_config: DiskLayoutConfiguration | None = None
@@ -215,6 +215,12 @@ class ArchConfigHandler:
 	def print_help(self) -> None:
 		self._parser.print_help()
 
+	def _get_version(self) -> str:
+		try:
+			return version('archinstall')
+		except Exception:
+			return 'Archinstall version not found'
+
 	def _define_arguments(self) -> ArgumentParser:
 		parser = ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 		parser.add_argument(
@@ -222,7 +228,7 @@ class ArchConfigHandler:
 			"--version",
 			action="version",
 			default=False,
-			version="%(prog)s " + version('archinstall')
+			version="%(prog)s " + self._get_version()
 		)
 		parser.add_argument(
 			"--config",

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -102,6 +102,10 @@ def test_config_file_parsing(
 	handler = ArchConfigHandler()
 	arch_config = handler.config
 
+	# the version is retrieved dynamically from an installed archinstall package
+	# as there is no version present in the test environment we'll set it manually
+	arch_config.version = '3.0.2'
+
 	# TODO: Use the real values from the test fixture instead of clearing out the entries
 	arch_config.disk_config.device_modifications = []  # type: ignore[union-attr]
 

--- a/tests/test_configuration_output.py
+++ b/tests/test_configuration_output.py
@@ -16,6 +16,10 @@ def test_user_config_roundtrip(
 	handler = ArchConfigHandler()
 	arch_config = handler.config
 
+	# the version is retrieved dynamically from an installed archinstall package
+	# as there is no version present in the test environment we'll set it manually
+	arch_config.version = '3.0.2'
+
 	config_output = ConfigurationOutput(arch_config)
 
 	test_out_dir = Path('/tmp/')


### PR DESCRIPTION
This fixes #3188 , the new version parser from the `importlib.metadata` can only handle packages that are installed. When running archinstall from a cloned git repository wihout it being installed it will fail. 