### PR TITLE
Remove debug output for all commands

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -319,8 +319,6 @@ class SysCommandWorker:
 				# If history_logfile does not exist, ignore the error
 				pass
 
-			debug(f"Executing: {" ".join(self.cmd)}")
-
 			try:
 				os.execve(self.cmd[0], list(self.cmd), {**os.environ, **self.environment_vars})
 			except FileNotFoundError:


### PR DESCRIPTION
This debug output was falsely left there from the argument integration PR. Removing it as it might log sensitive information into the logs. 
There is a different log for logging commands that will write to `cmd_history.txt` so that should cover all needed things.
