### PR TITLE
Fix a used-dummy-variable ruff warning

### DIFF
--- a/archinstall/tui/menu_item.py
+++ b/archinstall/tui/menu_item.py
@@ -197,8 +197,8 @@ class MenuItemGroup:
 
 	@cached_property
 	def items(self) -> list[MenuItem]:
-		_filter = self._filter_pattern.lower()
-		items = filter(lambda item: item.is_empty() or _filter in item.text.lower(), self.menu_items)
+		pattern = self._filter_pattern.lower()
+		items = filter(lambda item: item.is_empty() or pattern in item.text.lower(), self.menu_items)
 		return list(items)
 
 	@property


### PR DESCRIPTION
## PR Description:

This commit fixes a warning when running ruff with `--preview`:

```
archinstall/tui/menu_item.py:200:3: RUF052 Local dummy variable `_filter` is accessed
    |
198 |     @cached_property
199 |     def items(self) -> list[MenuItem]:
200 |         _filter = self._filter_pattern.lower()
    |         ^^^^^^^ RUF052
201 |         items = filter(lambda item: item.is_empty() or _filter in item.text.lower(), self.menu_items)
202 |         return list(items)
    |
    = help: Prefer using trailing underscores to avoid shadowing a built-in
```