### PR TITLE
Use preferred Limine config option names for kernel/cmdline

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1311,8 +1311,8 @@ Exec = /bin/sh -c "{hook_command}"
 			for variant in ('', '-fallback'):
 				entry = [
 					'protocol: linux',
-					f'kernel_path: boot():/vmlinuz-{kernel}',
-					f'kernel_cmdline: {kernel_params}',
+					f'path: boot():/vmlinuz-{kernel}',
+					f'cmdline: {kernel_params}',
 					f'module_path: boot():/initramfs-{kernel}{variant}.img',
 				]
 


### PR DESCRIPTION
## PR Description:

As per title; it also makes archinstall's generated Limine config more similar to how it is in the Arch wiki page.

## Tests and Checks
- [x] I have tested the code!<br>
