### PR TITLE
Fix typing syntax for multiple string literals

### DIFF
--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -1216,7 +1216,7 @@ class SelectMenu(AbstractCurses):
 
 		return None
 
-	def _focus_item(self, direction: Literal['next' | 'prev' | 'first' | 'last']) -> None:
+	def _focus_item(self, direction: Literal['next', 'prev', 'first', 'last']) -> None:
 		# reset the preview scroll as the newly focused item
 		# may have a different preview row count and it'll blow up
 		self._prev_scroll_pos = 0


### PR DESCRIPTION
## PR Description:

mypy didn't seem to issue any warnings, but Pyright reported these:
```
archinstall/archinstall/tui/curses_menu.py:1219:43 - error: Operator "|" not supported for types "Literal['next']" and "Literal['prev']" (reportOperatorIssue)
archinstall/archinstall/tui/curses_menu.py:1219:43 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
```