### PR TITLE
Fix Pyright warning with curses.textpad

### DIFF
--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -387,7 +387,7 @@ class EditViewport(AbstractViewport):
 		# if this gets initialized multiple times it will be an overlay
 		# and ENTER has to be pressed multiple times to accept
 		if not self._textbox:
-			self._textbox = curses.textpad.Textbox(self._edit_win)
+			self._textbox = Textbox(self._edit_win)
 			self._main_win.refresh()
 
 		self._textbox.edit(self.process_key)  # type: ignore[arg-type]


### PR DESCRIPTION
## PR Description:

Pyright reports the following warning because `curses` is imported in the file, but `curses.textpad` is not:

```
archinstall/archinstall/tui/curses_menu.py:390:27 - error: "textpad" is not a known attribute of module "curses" (reportAttributeAccessIssue)
```

Instead of adding `import curses.textpad`, I reused the existing `from curses.textpad import Textbox` import.