### PR TITLE
Fix Pyright warnings with importlib.util

### DIFF
--- a/archinstall/lib/plugins.py
+++ b/archinstall/lib/plugins.py
@@ -1,5 +1,5 @@
 import hashlib
-import importlib
+import importlib.util
 import os
 import sys
 import urllib.parse


### PR DESCRIPTION
## PR Description:

Pyright reports the following warnings because `importlib` is imported in the file, but `importlib.util` is not:

```
archinstall/archinstall/lib/plugins.py:56:20 - error: "util" is not a known attribute of module "importlib" (reportAttributeAccessIssue)
archinstall/archinstall/lib/plugins.py:58:25 - error: "util" is not a known attribute of module "importlib" (reportAttributeAccessIssue)
```