### PR TITLE
Add missing typing.override annotation reported by Pyright

### DIFF
--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -7,7 +7,7 @@ import urllib.request
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from pydantic import BaseModel, field_validator, model_validator
 
@@ -146,6 +146,7 @@ class MirrorRegion:
 	def json(self) -> dict[str, list[str]]:
 		return {self.name: self.urls}
 
+	@override
 	def __eq__(self, other: object) -> bool:
 		if not isinstance(other, MirrorRegion):
 			return NotImplemented


### PR DESCRIPTION
## PR Description:

This commit fixes a minor warning:
```
archinstall/archinstall/lib/models/mirrors.py:149:6 - error: Method "__eq__" is not marked as override but is overriding a method in class "object" (reportImplicitOverride)
/home/s/code/archinstall/archinstall/tui/curses_menu.py
```