### PR TITLE
Remove python-simple-term-menu installation from build_iso.sh

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -14,7 +14,6 @@ packages=(
 	python-build
 	python-setuptools
 	python-wheel
-	python-simple-term-menu
 	python-pyparted
 )
 


### PR DESCRIPTION
## PR Description:

The dependency is no longer needed as of 0f2e0095.