### PR TITLE
Fix a non-pep695-generic-function ruff warning

### DIFF
--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -1,7 +1,6 @@
 import json
 import ssl
 from functools import lru_cache
-from typing import TypeVar
 from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import urlopen
@@ -10,9 +9,6 @@ from urllib.response import addinfourl
 from ..exceptions import PackageError, SysCallError
 from ..models.gen import AvailablePackage, LocalPackage, PackageSearch, PackageSearchResult, Repository
 from ..pacman import Pacman
-
-PackageType = TypeVar("PackageType", AvailablePackage, LocalPackage)
-
 
 BASE_URL_PKG_SEARCH = 'https://archlinux.org/packages/search/json/'
 # BASE_URL_PKG_CONTENT = 'https://archlinux.org/packages/search/json/'
@@ -143,7 +139,7 @@ def list_available_packages(
 	return packages
 
 
-def _parse_package_output(
+def _parse_package_output[PackageType: (AvailablePackage, LocalPackage)](
 	package_meta: list[str],
 	cls: type[PackageType]
 ) -> PackageType:


### PR DESCRIPTION
## PR Description:

This commit fixes the last warning from `ruff --preview`, which will make it easier to upgrade to future versions:

```
archinstall/lib/packages/packages.py:146:5: UP047 Generic function `_parse_package_output` should use type parameters
    |
146 |   def _parse_package_output(
    |  _____^
147 | |     package_meta: list[str],
148 | |     cls: type[PackageType]
149 | | ) -> PackageType:
    | |_^ UP047
150 |       package = {}
    |
    = help: Use type parameters

Found 1 error.
```

Docs: https://docs.astral.sh/ruff/rules/non-pep695-generic-function/