### PR TITLE
Fix falsy-dict-get-fallback ruff warning

### DIFF
--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -299,7 +299,7 @@ class MirrorConfiguration:
 			for region, urls in mirror_regions.items():
 				config.mirror_regions.append(MirrorRegion(region, urls))
 
-		if args.get('custom_servers', []):
+		if args.get('custom_servers'):
 			config.custom_servers = CustomServer.parse_args(args['custom_servers'])
 
 		# backwards compatibility with the new custom_repository


### PR DESCRIPTION
## PR Description:

This commit fixes the following warning when running `ruff check --preview`:

```
archinstall/lib/models/mirrors.py:302:33: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
    |
300 |                 config.mirror_regions.append(MirrorRegion(region, urls))
301 |
302 |         if args.get('custom_servers', []):
    |                                       ^^ RUF056
303 |             config.custom_servers = CustomServer.parse_args(args['custom_servers'])
    |
    = help: Remove falsy fallback from `dict.get()`
```