### PR TITLE
Fix Pyright warning with urllib.parse

### DIFF
--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -1,5 +1,5 @@
 import time
-import urllib
+import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING, override
 


### PR DESCRIPTION
## PR Description:

Pyright reported the following warning because `urllib` was imported in the file rather than `urllib.parse`:

```
archinstall/lib/mirrors.py:501:22 - error: "parse" is not a known attribute of module "urllib" (reportAttributeAccessIssue)
```