### PR TITLE
Clean up most no-implicit-reexport warnings from mypy

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -18,7 +18,7 @@ from .lib.output import FormattedOutput, debug, error, info, log, warn
 from .lib.pacman import Pacman
 from .lib.plugins import load_plugin, plugins
 from .lib.translationhandler import DeferredTranslation, Language, translation_handler
-from .tui import Tui
+from .tui.curses_menu import Tui
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -4,7 +4,7 @@ from archinstall.default_profiles.profile import Profile, ProfileType
 
 if TYPE_CHECKING:
 	from archinstall.lib.installer import Installer
-	from archinstall.lib.models import User
+	from archinstall.lib.models.users import User
 
 
 class PipewireProfile(Profile):

--- a/archinstall/default_profiles/desktop.py
+++ b/archinstall/default_profiles/desktop.py
@@ -3,7 +3,9 @@ from typing import TYPE_CHECKING, override
 from archinstall.default_profiles.profile import GreeterType, Profile, ProfileType, SelectResult
 from archinstall.lib.output import info
 from archinstall.lib.profile.profiles_handler import profile_handler
-from archinstall.tui import FrameProperties, MenuItem, MenuItemGroup, PreviewStyle, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import FrameProperties, PreviewStyle, ResultType
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -3,7 +3,9 @@ from typing import TYPE_CHECKING, override
 from archinstall.default_profiles.desktops import SeatAccess
 from archinstall.default_profiles.profile import GreeterType, ProfileType, SelectResult
 from archinstall.default_profiles.xorg import XorgProfile
-from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, ResultType
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/default_profiles/desktops/sway.py
+++ b/archinstall/default_profiles/desktops/sway.py
@@ -3,7 +3,9 @@ from typing import TYPE_CHECKING, override
 from archinstall.default_profiles.desktops import SeatAccess
 from archinstall.default_profiles.profile import GreeterType, ProfileType, SelectResult
 from archinstall.default_profiles.xorg import XorgProfile
-from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, ResultType
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/default_profiles/server.py
+++ b/archinstall/default_profiles/server.py
@@ -3,7 +3,9 @@ from typing import TYPE_CHECKING, override
 from archinstall.default_profiles.profile import Profile, ProfileType, SelectResult
 from archinstall.lib.output import info
 from archinstall.lib.profile.profiles_handler import profile_handler
-from archinstall.tui import FrameProperties, MenuItem, MenuItemGroup, PreviewStyle, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import FrameProperties, PreviewStyle, ResultType
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -11,12 +11,15 @@ from urllib.request import Request, urlopen
 
 from pydantic.dataclasses import dataclass as p_dataclass
 
-from archinstall.lib.mirrors import MirrorConfiguration
-from archinstall.lib.models import AudioConfiguration, Bootloader, NetworkConfiguration, User
+from archinstall.lib.models.audio_configuration import AudioConfiguration
+from archinstall.lib.models.bootloader import Bootloader
 from archinstall.lib.models.device_model import DiskEncryption, DiskLayoutConfiguration
 from archinstall.lib.models.gen import Repository
 from archinstall.lib.models.locale import LocaleConfiguration
+from archinstall.lib.models.mirrors import MirrorConfiguration
+from archinstall.lib.models.network_configuration import NetworkConfiguration
 from archinstall.lib.models.profile_model import ProfileConfiguration
+from archinstall.lib.models.users import User
 from archinstall.lib.output import error, warn
 from archinstall.lib.plugins import load_plugin
 from archinstall.lib.storage import storage

--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -4,7 +4,9 @@ import stat
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, Orientation, PreviewStyle, ResultType, SelectMenu, Tui
+from archinstall.tui.curses_menu import SelectMenu, Tui
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle, ResultType
 
 from .args import ArchConfig
 from .general import JSON, UNSAFE_JSON

--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -10,8 +10,8 @@ from typing import Literal, overload
 
 from parted import Device, Disk, DiskException, FileSystem, Geometry, IOException, Partition, PartitionException, freshDisk, getAllDevices, getDevice, newDisk
 
-from ..exceptions import DiskError, UnknownFilesystemFormat
-from ..general import SysCallError, SysCommand, SysCommandWorker
+from ..exceptions import DiskError, SysCallError, UnknownFilesystemFormat
+from ..general import SysCommand, SysCommandWorker
 from ..luks import Luks2
 from ..models.device_model import (
 	BDevice,

--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -2,11 +2,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, override
 
 from archinstall.lib.models.device_model import DiskLayoutConfiguration, DiskLayoutType, LvmConfiguration
-from archinstall.tui import MenuItem, MenuItemGroup
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
 
-from ..interactions import select_disk_config
-from ..interactions.disk_conf import select_lvm_config
-from ..menu import AbstractSubMenu
+from ..interactions.disk_conf import select_disk_config, select_lvm_config
+from ..menu.abstract_menu import AbstractSubMenu
 from ..output import FormattedOutput
 
 if TYPE_CHECKING:

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -11,12 +11,15 @@ from archinstall.lib.models.device_model import (
 	LvmVolume,
 	PartitionModification,
 )
-from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, ResultType
 
-from ..menu import AbstractSubMenu
+from ..menu.abstract_menu import AbstractSubMenu
+from ..models.device_model import Fido2Device
 from ..output import FormattedOutput
 from ..utils.util import get_password
-from .fido import Fido2, Fido2Device
+from .fido import Fido2
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from archinstall.tui import Tui
+from archinstall.tui.curses_menu import Tui
 
 from ..interactions.general_conf import ask_abort
 from ..luks import Luks2

--- a/archinstall/lib/disk/partitioning_menu.py
+++ b/archinstall/lib/disk/partitioning_menu.py
@@ -17,9 +17,11 @@ from archinstall.lib.models.device_model import (
 	Size,
 	Unit,
 )
-from archinstall.tui import Alignment, EditMenu, FrameProperties, MenuItem, MenuItemGroup, Orientation, ResultType, SelectMenu
+from archinstall.tui.curses_menu import EditMenu, SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, Orientation, ResultType
 
-from ..menu import ListManager
+from ..menu.list_manager import ListManager
 from ..output import FormattedOutput
 from ..utils.util import prompt_dir
 from .subvolume_menu import SubvolumeMenu

--- a/archinstall/lib/disk/subvolume_menu.py
+++ b/archinstall/lib/disk/subvolume_menu.py
@@ -2,9 +2,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, override
 
 from archinstall.lib.models.device_model import SubvolumeModification
-from archinstall.tui import Alignment, EditMenu, ResultType
+from archinstall.tui.curses_menu import EditMenu
+from archinstall.tui.types import Alignment, ResultType
 
-from ..menu import ListManager
+from ..menu.list_manager import ListManager
 from ..utils.util import prompt_dir
 
 if TYPE_CHECKING:

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -5,36 +5,34 @@ from typing import TYPE_CHECKING
 from archinstall.lib.disk.disk_menu import DiskLayoutConfigurationMenu
 from archinstall.lib.disk.encryption_menu import DiskEncryptionMenu
 from archinstall.lib.models.device_model import DiskEncryption, DiskLayoutConfiguration, DiskLayoutType, EncryptionType, FilesystemType, PartitionModification
-from archinstall.tui import MenuItem, MenuItemGroup
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
 
 from .args import ArchConfig
 from .configuration import save_config
 from .general import secret
 from .hardware import SysInfo
-from .interactions import (
+from .interactions.general_conf import (
 	add_number_of_parallel_downloads,
 	ask_additional_packages_to_install,
 	ask_for_a_timezone,
-	ask_for_additional_users,
 	ask_for_audio_selection,
-	ask_for_bootloader,
-	ask_for_swap,
-	ask_for_uki,
 	ask_hostname,
 	ask_ntp,
-	ask_to_configure_network,
-	select_kernel,
 )
+from .interactions.manage_users_conf import ask_for_additional_users
+from .interactions.network_menu import ask_to_configure_network
+from .interactions.system_conf import ask_for_bootloader, ask_for_swap, ask_for_uki, select_kernel
 from .locale.locale_menu import LocaleMenu
-from .menu import AbstractMenu
-from .mirrors import MirrorConfiguration, MirrorMenu
-from .models import NetworkConfiguration, NicType
+from .menu.abstract_menu import AbstractMenu
+from .mirrors import MirrorMenu
 from .models.audio_configuration import AudioConfiguration
 from .models.bootloader import Bootloader
 from .models.locale import LocaleConfiguration
+from .models.mirrors import MirrorConfiguration
+from .models.network_configuration import NetworkConfiguration, NicType
+from .models.profile_model import ProfileConfiguration
 from .models.users import User
 from .output import FormattedOutput
-from .profile.profile_menu import ProfileConfiguration
 from .translationhandler import Language, translation_handler
 from .utils.util import get_password
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -28,20 +28,20 @@ from archinstall.lib.models.device_model import (
 from archinstall.lib.models.gen import Repository
 from archinstall.tui.curses_menu import Tui
 
-from . import pacman
 from .args import arch_config_handler
 from .exceptions import DiskError, HardwareIncompatibilityError, RequirementError, ServiceException, SysCallError
 from .general import SysCommand
 from .hardware import SysInfo
-from .locale import verify_keyboard_layout, verify_x11_keyboard_layout
+from .locale.utils import verify_keyboard_layout, verify_x11_keyboard_layout
 from .luks import Luks2
-from .mirrors import MirrorConfiguration
 from .models.bootloader import Bootloader
 from .models.locale import LocaleConfiguration
+from .models.mirrors import MirrorConfiguration
 from .models.network_configuration import Nic
 from .models.users import User
 from .output import debug, error, info, log, warn
 from .pacman import Pacman
+from .pacman.config import Config
 from .plugins import plugins
 from .storage import storage
 
@@ -841,7 +841,7 @@ class Installer:
 		debug(f'Optional repositories: {optional_repositories}')
 
 		# This action takes place on the host system as pacstrap copies over package repository lists.
-		pacman_conf = pacman.Config(self.target)
+		pacman_conf = Config(self.target)
 		pacman_conf.enable(optional_repositories)
 		pacman_conf.apply()
 

--- a/archinstall/lib/interactions/disk_conf.py
+++ b/archinstall/lib/interactions/disk_conf.py
@@ -28,7 +28,9 @@ from archinstall.lib.models.device_model import (
 	_DeviceInfo,
 )
 from archinstall.lib.output import debug
-from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, Orientation, PreviewStyle, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle, ResultType
 
 from ..output import FormattedOutput
 from ..utils.util import prompt_dir

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -4,10 +4,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from archinstall.lib.models.gen import Repository
-from archinstall.lib.packages import list_available_packages
-from archinstall.tui import Alignment, EditMenu, FrameProperties, MenuItem, MenuItemGroup, Orientation, PreviewStyle, ResultType, SelectMenu, Tui
+from archinstall.lib.packages.packages import list_available_packages
+from archinstall.tui.curses_menu import EditMenu, SelectMenu, Tui
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle, ResultType
 
-from ..locale import list_timezones
+from ..locale.utils import list_timezones
 from ..models.audio_configuration import Audio, AudioConfiguration
 from ..models.gen import AvailablePackage
 from ..output import warn

--- a/archinstall/lib/interactions/manage_users_conf.py
+++ b/archinstall/lib/interactions/manage_users_conf.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, override
 
-from archinstall.tui import Alignment, EditMenu, MenuItem, MenuItemGroup, Orientation, ResultType, SelectMenu
+from archinstall.tui.curses_menu import EditMenu, SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, Orientation, ResultType
 
 from ..general import secret
-from ..menu import ListManager
+from ..menu.list_manager import ListManager
 from ..models.users import User
 from ..utils.util import get_password
 

--- a/archinstall/lib/interactions/network_menu.py
+++ b/archinstall/lib/interactions/network_menu.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import ipaddress
 from typing import TYPE_CHECKING, override
 
-from archinstall.tui import Alignment, EditMenu, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu
+from archinstall.tui.curses_menu import EditMenu, SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, ResultType
 
-from ..menu import ListManager
+from ..menu.list_manager import ListManager
 from ..models.network_configuration import NetworkConfiguration, Nic, NicType
 from ..networking import list_interfaces
 

--- a/archinstall/lib/interactions/system_conf.py
+++ b/archinstall/lib/interactions/system_conf.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from archinstall.tui import Alignment, FrameProperties, FrameStyle, MenuItem, MenuItemGroup, Orientation, PreviewStyle, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, FrameStyle, Orientation, PreviewStyle, ResultType
 
 from ..hardware import GfxDriver, SysInfo
 from ..models.bootloader import Bootloader

--- a/archinstall/lib/locale/locale_menu.py
+++ b/archinstall/lib/locale/locale_menu.py
@@ -1,8 +1,10 @@
 from typing import TYPE_CHECKING, override
 
-from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, ResultType
 
-from ..menu import AbstractSubMenu
+from ..menu.abstract_menu import AbstractSubMenu
 from ..models.locale import LocaleConfiguration
 from .utils import list_keyboard_languages, list_locales, set_kb_layout
 

--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from archinstall.tui import Chars, FrameProperties, FrameStyle, MenuItem, MenuItemGroup, PreviewStyle, ResultType, SelectMenu, Tui
+from archinstall.tui.curses_menu import SelectMenu, Tui
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Chars, FrameProperties, FrameStyle, PreviewStyle, ResultType
 
 from ..output import error
 

--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -1,7 +1,9 @@
 import copy
 from typing import TYPE_CHECKING, Any
 
-from archinstall.tui import Alignment, MenuItem, MenuItemGroup, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, ResultType
 
 from ..output import FormattedOutput
 

--- a/archinstall/lib/menu/menu_helper.py
+++ b/archinstall/lib/menu/menu_helper.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from archinstall.lib.output import FormattedOutput
-from archinstall.tui import MenuItem, MenuItemGroup
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
 
 
 class MenuHelper:

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -3,9 +3,12 @@ import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING, override
 
-from archinstall.tui import Alignment, EditMenu, FrameProperties, MenuItem, MenuItemGroup, ResultType, SelectMenu, Tui
+from archinstall.tui.curses_menu import EditMenu, SelectMenu, Tui
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, ResultType
 
-from .menu import AbstractSubMenu, ListManager
+from .menu.abstract_menu import AbstractSubMenu
+from .menu.list_manager import ListManager
 from .models.gen import Repository
 from .models.mirrors import (
 	CustomRepository,

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -323,7 +323,7 @@ def log(
 	Journald.log(text, level=level)
 
 	if level != logging.DEBUG:
-		from archinstall.tui import Tui
+		from archinstall.tui.curses_menu import Tui
 		Tui.print(text)
 
 

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import GreeterType, Profile
-from archinstall.tui import Alignment, FrameProperties, MenuItem, MenuItemGroup, Orientation, ResultType, SelectMenu
+from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.types import Alignment, FrameProperties, Orientation, ResultType
 
 from ..hardware import GfxDriver
 from ..interactions.system_conf import select_driver
-from ..menu import AbstractSubMenu
+from ..menu.abstract_menu import AbstractSubMenu
 from ..models.profile_model import ProfileConfiguration
 
 if TYPE_CHECKING:

--- a/archinstall/lib/utils/util.py
+++ b/archinstall/lib/utils/util.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from archinstall.tui import Alignment, EditMenu
+from archinstall.tui.curses_menu import EditMenu
+from archinstall.tui.types import Alignment
 
 from ..general import secret
 from ..output import FormattedOutput

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -5,12 +5,15 @@ from pytest import MonkeyPatch
 from archinstall.default_profiles.profile import GreeterType
 from archinstall.lib.args import ArchConfig, ArchConfigHandler, Arguments
 from archinstall.lib.hardware import GfxDriver
-from archinstall.lib.mirrors import CustomRepository, MirrorConfiguration, MirrorRegion, SignCheck, SignOption
-from archinstall.lib.models import Audio, AudioConfiguration, Bootloader, DiskLayoutConfiguration, DiskLayoutType, NetworkConfiguration, Repository, User
+from archinstall.lib.models.audio_configuration import Audio, AudioConfiguration
+from archinstall.lib.models.bootloader import Bootloader
+from archinstall.lib.models.device_model import DiskLayoutConfiguration, DiskLayoutType
+from archinstall.lib.models.gen import Repository
 from archinstall.lib.models.locale import LocaleConfiguration
-from archinstall.lib.models.mirrors import CustomServer
-from archinstall.lib.models.network_configuration import Nic, NicType
+from archinstall.lib.models.mirrors import CustomRepository, CustomServer, MirrorConfiguration, MirrorRegion, SignCheck, SignOption
+from archinstall.lib.models.network_configuration import NetworkConfiguration, Nic, NicType
 from archinstall.lib.models.profile_model import ProfileConfiguration
+from archinstall.lib.models.users import User
 from archinstall.lib.profile.profiles_handler import profile_handler
 from archinstall.lib.translationhandler import translation_handler
 


### PR DESCRIPTION
## PR Description:

This makes it easier to run `mypy --strict` from the command line and should hopefully make it easier to clean up import cycles in future commits.

I didn't fix the no-implicit-reexport warnings in `examples/` and `scripts/`. It seems beneficial for user-facing code to continue to use the package-level re-exports to avoid breaking changes when code gets moved around.