### PR TITLE
Fix SysCallError import cycle between exceptions.py and general.py

### DIFF
--- a/archinstall/lib/disk/utils.py
+++ b/archinstall/lib/disk/utils.py
@@ -32,9 +32,8 @@ def _fetch_lsblk_info(
 		worker = SysCommand(cmd)
 	except SysCallError as err:
 		# Get the output minus the message/info from lsblk if it returns a non-zero exit code.
-		if err.worker:
-			err_str = err.worker.decode()
-			debug(f'Error calling lsblk: {err_str}')
+		if err.worker_log:
+			debug(f'Error calling lsblk: {err.worker_log.decode()}')
 
 		if dev_path:
 			raise DiskError(f'Failed to read disk "{dev_path}" with lsblk')

--- a/archinstall/lib/exceptions.py
+++ b/archinstall/lib/exceptions.py
@@ -1,9 +1,3 @@
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-	from .general import SysCommandWorker
-
-
 class RequirementError(Exception):
 	pass
 
@@ -17,11 +11,11 @@ class UnknownFilesystemFormat(Exception):
 
 
 class SysCallError(Exception):
-	def __init__(self, message: str, exit_code: int | None = None, worker: 'SysCommandWorker | None' = None) -> None:
+	def __init__(self, message: str, exit_code: int | None = None, worker_log: bytes = b'') -> None:
 		super().__init__(message)
 		self.message = message
 		self.exit_code = exit_code
-		self.worker = worker
+		self.worker_log = worker_log
 
 
 class HardwareIncompatibilityError(Exception):

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -205,7 +205,7 @@ class SysCommandWorker:
 			raise SysCallError(
 				f"{self.cmd} exited with abnormal exit code [{self.exit_code}]: {str(self)[-500:]}",
 				self.exit_code,
-				worker=self
+				worker_log=self._trace_log
 			)
 
 	def is_alive(self) -> bool:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -759,8 +759,8 @@ class Installer:
 			SysCommand(f'arch-chroot {self.target} mkinitcpio {" ".join(flags)}', peek_output=True)
 			return True
 		except SysCallError as e:
-			if e.worker:
-				log(e.worker._trace_log.decode())
+			if e.worker_log:
+				log(e.worker_log.decode())
 			return False
 
 	def _get_microcode(self) -> Path | None:


### PR DESCRIPTION
## PR Description:

This commit updates `SysCallError` to accept a worker log argument instead of an entire `SysCommandWorker`.

It fixes an import cycle reported by Pyright:

```
  archinstall/lib/exceptions.py: error: Cycle detected in import chain
    archinstall/lib/exceptions.py
    archinstall/lib/general.py (reportImportCycles)
```

## Tests and Checks
- [x] I have tested the code!