### PR TITLE
Enable most flake8-pyi rules in ruff and fix a warning

### DIFF
--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 from archinstall.tui.curses_menu import SelectMenu, Tui
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
@@ -37,7 +37,7 @@ class AbstractMenu:
 
 		self._sync_from_config()
 
-	def __enter__(self, *args: Any, **kwargs: Any) -> AbstractMenu:
+	def __enter__(self, *args: Any, **kwargs: Any) -> Self:
 		self.is_context_mgr = True
 		return self
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ select = [
     "PLC",    # Pylint conventions
     "PLE",    # Pylint errors
     "PLW",    # Pylint warnings
+    "PYI",    # flake8-pyi
     "RSE",    # flake8-raise
     "RUF",    # Ruff-specific rules
     "SLOT",   # flake8-slot
@@ -219,6 +220,7 @@ ignore = [
     "PLW1514",  # unspecified-encoding
     "PLW1641",  # eq-without-hash
     "PLW2901",  # redefined-loop-name
+    "PYI036",   # bad-exit-annotation
     "RUF005",   # collection-literal-concatenation
     "RUF015",   # unnecessary-iterable-allocation-for-first-element
     "RUF039",   # unraw-re-pattern


### PR DESCRIPTION
## PR Description:

The flake8-pyi rules mostly apply to .pyi files, but some are also useful for .py files.
