### PR TITLE
Remove unused stdlib imports from __init__.py files

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -1,13 +1,10 @@
 """Arch Linux installer - guided, templates etc."""
 
-import curses
 import importlib
 import os
 import sys
 import time
 import traceback
-from argparse import ArgumentParser, Namespace
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from archinstall.lib.args import arch_config_handler

--- a/archinstall/lib/pacman/__init__.py
+++ b/archinstall/lib/pacman/__init__.py
@@ -1,9 +1,7 @@
-import re
 import time
 from collections.abc import Callable
 from pathlib import Path
-from shutil import copy2
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ..exceptions import RequirementError
 from ..general import SysCommand


### PR DESCRIPTION
## PR Description:

This is a step toward enabling unused import rules for all `__init__.py` files