### PR TITLE
Remove unneeded flake8 ignore for __init__.py files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,5 +6,5 @@ max-line-length = 160
 show-source = True
 statistics = True
 builtins = _
-per-file-ignores = __init__.py:E128,F401
+per-file-ignores = __init__.py:F401
 exclude = .git,__pycache__,build,docs,actions-runner


### PR DESCRIPTION
## PR Description:

I verified that the flake8 checks still pass with this ignore removed.