### PR TITLE
Enable import checks in __init__.py files with Pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ score = false
 
 [tool.pylint.variables]
 additional-builtins = ["_"]
+init-import = true
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
## PR Description:

Follow-up to #3252