### PR TITLE
Move run_custom_user_commands to fix an import cycle

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -16,14 +16,11 @@ from enum import Enum
 from pathlib import Path
 from select import EPOLLHUP, EPOLLIN, epoll
 from shutil import which
-from typing import TYPE_CHECKING, Any, override
+from typing import Any, override
 
 from .exceptions import RequirementError, SysCallError
-from .output import debug, error, info
+from .output import debug, error
 from .storage import storage
-
-if TYPE_CHECKING:
-	from .installer import Installer
 
 # https://stackoverflow.com/a/43627833/929999
 _VT100_ESCAPE_REGEX = r'\x1B\[[?0-9;]*[a-zA-Z]'
@@ -477,20 +474,6 @@ def _pid_exists(pid: int) -> bool:
 		return any(subprocess.check_output(['ps', '--no-headers', '-o', 'pid', '-p', str(pid)]).strip())
 	except subprocess.CalledProcessError:
 		return False
-
-
-def run_custom_user_commands(commands: list[str], installation: Installer) -> None:
-	for index, command in enumerate(commands):
-		script_path = f"/var/tmp/user-command.{index}.sh"
-		chroot_path = f"{installation.target}/{script_path}"
-
-		info(f'Executing custom command "{command}" ...')
-		with open(chroot_path, "w") as user_script:
-			user_script.write(command)
-
-		SysCommand(f"arch-chroot {installation.target} bash {script_path}")
-
-		os.unlink(chroot_path)
 
 
 def secret(x: str) -> str:

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -5,9 +5,8 @@ from archinstall.lib.args import ArchConfig, arch_config_handler
 from archinstall.lib.configuration import ConfigurationOutput
 from archinstall.lib.disk.filesystem import FilesystemHandler
 from archinstall.lib.disk.utils import disk_layouts
-from archinstall.lib.general import run_custom_user_commands
 from archinstall.lib.global_menu import GlobalMenu
-from archinstall.lib.installer import Installer, accessibility_tools_in_use
+from archinstall.lib.installer import Installer, accessibility_tools_in_use, run_custom_user_commands
 from archinstall.lib.interactions.general_conf import ask_chroot
 from archinstall.lib.models import AudioConfiguration, Bootloader
 from archinstall.lib.models.device_model import (

--- a/examples/interactive_installation.py
+++ b/examples/interactive_installation.py
@@ -5,9 +5,8 @@ from archinstall.lib.args import ArchConfig, arch_config_handler
 from archinstall.lib.configuration import ConfigurationOutput
 from archinstall.lib.disk.filesystem import FilesystemHandler
 from archinstall.lib.disk.utils import disk_layouts
-from archinstall.lib.general import run_custom_user_commands
 from archinstall.lib.global_menu import GlobalMenu
-from archinstall.lib.installer import Installer, accessibility_tools_in_use
+from archinstall.lib.installer import Installer, accessibility_tools_in_use, run_custom_user_commands
 from archinstall.lib.interactions.general_conf import ask_chroot
 from archinstall.lib.models import AudioConfiguration, Bootloader
 from archinstall.lib.models.device_model import (


### PR DESCRIPTION
## PR Description:

This commit fixes the following Pyright warning:
```
  archinstall/lib/general.py: error: Cycle detected in import chain
    archinstall/lib/general.py
    archinstall/lib/installer.py
    archinstall/lib/models/device_model.py
    archinstall/lib/hardware.py (reportImportCycles)
```

I marked this as a draft PR because it will cause merge conflicts with #3247.