### PR TITLE
Enable additional mypy error codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,15 @@ exclude = "^build/"
 disallow_any_explicit = false
 disallow_any_expr = false
 disallow_any_unimported = true
+enable_error_code = [
+    "explicit-override",
+    "mutable-override",
+    "redundant-expr",
+    "redundant-self",
+    "truthy-iterable",
+    "unimported-reveal",
+    "unused-awaitable",
+]
 strict = true
 strict_bytes = true
 warn_unreachable = true


### PR DESCRIPTION
## PR Description:

Docs: https://mypy.readthedocs.io/en/stable/error_code_list2.html

There are a few others that can be enabled once the relevant warnings are fixed.