### PR TITLE
Fix a blanket type ignore comment

### DIFF
--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -168,7 +168,7 @@ class ProfileHandler:
 		self._profiles = [p for p in self.profiles if p.name not in remove_names]
 
 	def get_profile_by_name(self, name: str) -> Profile | None:
-		return next(filter(lambda x: x.name == name, self.profiles), None)  # type: ignore
+		return next(filter(lambda x: x.name == name, self.profiles), None)  # type: ignore[arg-type, union-attr]
 
 	def get_top_level_profiles(self) -> list[Profile]:
 		return [p for p in self.profiles if p.is_top_level_profile()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ disallow_any_expr = false
 disallow_any_unimported = true
 enable_error_code = [
     "explicit-override",
+    "ignore-without-code",
     "mutable-override",
     "redundant-expr",
     "redundant-self",
@@ -192,6 +193,7 @@ select = [
     "ICN",    # flake8-import-conventions
     "ISC",    # flake8-implicit-str-concat
     "LOG",    # flake8-logging
+    "PGH",    # pygrep-hooks
     "PIE",    # flake8-pie
     "PLC",    # Pylint conventions
     "PLE",    # Pylint errors


### PR DESCRIPTION
## PR Description:

This commit allows the ignore-without-code mypy warning to be enabled. It also allows the pygrep-hooks ruff rules to be enabled.
