### PR TITLE
Pin astral-sh/ruff-action to a specific commit

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -5,4 +5,4 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: astral-sh/ruff-action@v3
+            - uses: astral-sh/ruff-action@9828f49eb4cadf267b40eaa330295c412c68c1f9  # v3.2.2

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigests"
   ],
   "pre-commit": {
     "enabled": true


### PR DESCRIPTION
## PR Description:

The GitHub docs recommend pinning third-party actions to specific commits for security hardening purposes:

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

A recent security issue:
- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised