### PR TITLE
More properly support FAT12 and FAT16 ESPs

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -277,7 +277,7 @@ class DeviceHandler:
 			case FilesystemType.Ext2 | FilesystemType.Ext3 | FilesystemType.Ext4:
 				# Force create
 				options.append('-F')
-			case FilesystemType.Fat16 | FilesystemType.Fat32:
+			case FilesystemType.Fat12 | FilesystemType.Fat16 | FilesystemType.Fat32:
 				mkfs_type = 'fat'
 				# Set FAT size
 				options.extend(('-F', fs_type.value.removeprefix(mkfs_type)))

--- a/archinstall/lib/models/device_model.py
+++ b/archinstall/lib/models/device_model.py
@@ -767,6 +767,7 @@ class FilesystemType(Enum):
 	Ext3 = 'ext3'
 	Ext4 = 'ext4'
 	F2fs = 'f2fs'
+	Fat12 = 'fat12'
 	Fat16 = 'fat16'
 	Fat32 = 'fat32'
 	Ntfs = 'ntfs'
@@ -952,7 +953,11 @@ class PartitionModification:
 	def is_efi(self) -> bool:
 		return (
 			any(set(self.flags) & set(self._efi_indicator_flags))
-			and self.fs_type == FilesystemType.Fat32
+			and (
+				self.fs_type == FilesystemType.Fat12
+				or self.fs_type == FilesystemType.Fat16
+				or self.fs_type == FilesystemType.Fat32
+			)
 			and PartitionFlag.XBOOTLDR not in self.flags
 		)
 


### PR DESCRIPTION
FAT12 and FAT16 are also valid filesystems for ESPs, therefore, try to support them
