### PR TITLE
Fix Pydantic deprecation warnings

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -598,7 +598,7 @@ class DeviceHandler:
 			debug(f'Unable to determine new uuid: {path}\n{lsblk_info}')
 			raise DiskError(f'Unable to determine new uuid: {path}')
 
-		debug(f'partition information found: {lsblk_info.json()}')
+		debug(f'partition information found: {lsblk_info.model_dump_json()}')
 
 		return lsblk_info
 

--- a/archinstall/lib/models/packages.py
+++ b/archinstall/lib/models/packages.py
@@ -155,12 +155,12 @@ class AvailablePackage(BaseModel):
 
 	@cached_property
 	def longest_key(self) -> int:
-		return max(len(key) for key in self.dict().keys())
+		return max(len(key) for key in self.model_dump().keys())
 
 	# return all package info line by line
 	def info(self) -> str:
 		output = ''
-		for key, value in self.dict().items():
+		for key, value in self.model_dump().items():
 			key = key.replace('_', ' ').capitalize()
 			key = key.ljust(self.longest_key)
 			output += f'{key} : {value}\n'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ disallow_any_explicit = false
 disallow_any_expr = false
 disallow_any_unimported = true
 enable_error_code = [
+    "deprecated",
     "explicit-override",
     "ignore-without-code",
     "mutable-override",


### PR DESCRIPTION
## PR Description:

This commit also enables mypy checks for deprecated calls.

Pydantic migration docs:
- https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel