### PR TITLE
Detect boot partition regardless of boot flags if mounted on /boot

### DIFF
--- a/archinstall/lib/models/device_model.py
+++ b/archinstall/lib/models/device_model.py
@@ -964,8 +964,9 @@ class PartitionModification:
 	def is_boot(self) -> bool:
 		"""
 		Returns True if any of the boot indicator flags are found in self.flags
+		or if the partition is mounted on /boot
 		"""
-		return any(set(self.flags) & set(self._boot_indicator_flags))
+		return any(set(self.flags) & set(self._boot_indicator_flags)) or Path('/boot') == self.mountpoint
 
 	def is_root(self) -> bool:
 		if self.mountpoint is not None:


### PR DESCRIPTION
## PR Description:

The boot partition is always to be mounted to `/boot` (afaik). This allows skipping potentially misleading checks of partition type to determine whether to use a certain partition as `/boot`, if it is already mounted there.

## Tests and Checks
- [x] I have tested the code!<br>