### PR TITLE
fix(installer): use platform.machine() for target architecture in grub-install

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import platform
 import re
 import shlex
 import shutil
@@ -1186,7 +1187,7 @@ class Installer:
 				boot_dir = boot_partition.mountpoint
 
 			add_options = [
-				'--target=x86_64-efi',
+				f'--target={platform.machine()}-efi',
 				f'--efi-directory={efi_partition.mountpoint}',
 				*boot_dir_arg,
 				'--bootloader-id=GRUB',


### PR DESCRIPTION
## PR Description:

Set GRUB target to `f'{platform.machine()}-efi'` instead of hard-coded `x86_64-efi` in UEFI mode.

Arch Linux devtools' `checkpkg` already suggests to use `$CARCH` instead of hard-coded `x86_64` in `PKGBUILD`, so we may also follow it. This PR may be friendly to Arch Linux Ports ([see the RFC](https://rfc.archlinux.page/0032-arch-linux-ports/)) and has no negative impact on existing x86_64 architecture.

According to the Arch Linux ports RFC:

> When devices of a port do not (or cannot) support a boot flow following the [Boot Loader Specification](https://uapi-group.org/specifications/specs/boot_loader_specification/), documentation and (if applicable) packages for the boot process must be provided.

So I only added the multi-architecture compatibility in UEFI mode. Architectures without UEFI support should be handled additionally according to the requirements of RFC.

/cc @felixonmars 

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
