### PR TITLE
replace GTK theme package for Budgie build with an active one

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -41,6 +41,7 @@ makedepends=(
 )
 optdepends=(
   'python-systemd: Adds journald logging'
+  'materia-gtk-theme: theming for GTK-based desktop environments'
 )
 provides=(python-archinstall archinstall)
 conflicts=(python-archinstall archinstall-git)

--- a/archinstall/default_profiles/desktops/budgie.py
+++ b/archinstall/default_profiles/desktops/budgie.py
@@ -12,7 +12,7 @@ class BudgieProfile(XorgProfile):
 	@override
 	def packages(self) -> list[str]:
 		return [
-			"arc-gtk-theme",
+			"materia-gtk-theme",
 			"budgie",
 			"mate-terminal",
 			"nemo",


### PR DESCRIPTION
- This fix issue:

```error: target not found: arc-gtk-theme```

![image](https://github.com/user-attachments/assets/265d6258-1536-4636-a421-802bb36e1a27)


## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

Ran into an issue with a fresh ISO trying to get Arch Budgie on my machine. A quick search let to a conclusion that the theme package seized to exist, and is only now maintained as a fork on AUR. Materia is but one option of many available, can be a different one as default, just something within `extra` repository, adding a list of currently available below the diff.

```
@override
	def packages(self) -> list[str]:
		return [
			"arc-gtk-theme", => "materia-gtk-theme",
			"budgie",
			"mate-terminal",
			"nemo",
```
```
extra/deepin-gtk-theme 2020.06.10-2 (300.6 KiB 3.5 MiB) [deepin] 
    Deepin GTK Theme
extra/adw-gtk-theme 5.6-1 (101.8 KiB 1.8 MiB) 
    Unofficial GTK 3 port of the libadwaita theme
extra/lxde-icon-theme 0.5.2-1 (4.4 MiB 4.4 MiB) [lxde lxde-gtk3] 
    LXDE default icon theme based on nuoveXT2
extra/adapta-gtk-theme 3.95.0.11-3 (696.4 KiB 17.2 MiB) 
    An adaptive Gtk+ theme based on Material Design Guidelines
extra/materia-gtk-theme 20210322-3 (339.0 KiB 6.0 MiB) 
    A Material Design theme for GNOME/GTK+ based desktop environments
extra/orchis-theme 2024_11_03-4 (330.2 KiB 9.5 MiB) 
    A Material Design theme for GNOME/GTK based desktop environments
extra/pop-gtk-theme 5.5.1.r7.25ea85d9-1 (551.1 KiB 3.3 MiB) 
    System76 Pop GTK+ Theme
extra/breeze-gtk 6.3.3-1 (192.4 KiB 1.2 MiB) [plasma]
    Breeze widget theme for GTK 2 and 3
extra/gtk-theme-elementary 8.2.0-1 (83.2 KiB 10.8 MiB) [pantheon] 
    elementary GTK theme
```

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
