### PR TITLE
Force to make pipewire symlinks (#2585)

### DIFF
--- a/archinstall/default_profiles/applications/pipewire.py
+++ b/archinstall/default_profiles/applications/pipewire.py
@@ -41,11 +41,11 @@ class PipewireProfile(Profile):
 
 			# symlink in the correct pipewire systemd items
 			install_session.arch_chroot(
-				f'ln -s /usr/lib/systemd/user/pipewire-pulse.service /home/{user.username}/.config/systemd/user/default.target.wants/pipewire-pulse.service',
+				f'ln -sf /usr/lib/systemd/user/pipewire-pulse.service /home/{user.username}/.config/systemd/user/default.target.wants/pipewire-pulse.service',
 				run_as=user.username
 			)
 			install_session.arch_chroot(
-				f'ln -s /usr/lib/systemd/user/pipewire-pulse.socket /home/{user.username}/.config/systemd/user/default.target.wants/pipewire-pulse.socket',
+				f'ln -sf /usr/lib/systemd/user/pipewire-pulse.socket /home/{user.username}/.config/systemd/user/default.target.wants/pipewire-pulse.socket',
 				run_as=user.username
 			)
 


### PR DESCRIPTION
- This fix issue: #2585

## PR Description:

Archinstall causes errors if we use an existing home directory.
We need to change 'ln -s' to 'ln -sf' to make pipewire symlinks.

## Tests and Checks
- [ ] I have tested the code!<br>

I tested the code on EndeavourOS.
I could install Arch Linux without problems.