### PR TITLE
Use assert_never to fix some possibly-undefined mypy warnings

### DIFF
--- a/archinstall/lib/disk/subvolume_menu.py
+++ b/archinstall/lib/disk/subvolume_menu.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, assert_never, override
 
 from archinstall.lib.models.device_model import SubvolumeModification
 from archinstall.tui.curses_menu import EditMenu
@@ -54,6 +54,8 @@ class SubvolumeMenu(ListManager):
 				name = result.text()
 			case ResultType.Reset:
 				raise ValueError('Unhandled result type')
+			case _:
+				assert_never(result.type_)
 
 		header = f"{_('Subvolume name')}: {name}\n"
 

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_never
 
 from archinstall.lib.models.packages import Repository
 from archinstall.lib.packages.packages import list_available_packages
@@ -263,6 +263,8 @@ def add_number_of_parallel_downloads(preset: int | None = None) -> int | None:
 			return 0
 		case ResultType.Selection:
 			downloads: int = int(result.text())
+		case _:
+			assert_never(result.type_)
 
 	pacman_conf_path = Path("/etc/pacman.conf")
 	with pacman_conf_path.open() as f:


### PR DESCRIPTION
## PR Description:

This commit fixes some of the warnings reported by `mypy --enable-error-code=possibly-undefined`:

```
archinstall/lib/disk/subvolume_menu.py:58: error: Name "name" may be undefined  [possibly-undefined]
archinstall/lib/interactions/general_conf.py:274: error: Name "downloads" may be undefined  [possibly-undefined]
archinstall/lib/interactions/general_conf.py:278: error: Name "downloads" may be undefined  [possibly-undefined]
```