### PR TITLE
Actually prevent installing if the config is invalid

### DIFF
--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from archinstall.lib.disk.disk_menu import DiskLayoutConfigurationMenu
 from archinstall.lib.disk.encryption_menu import DiskEncryptionMenu
@@ -245,6 +245,7 @@ class GlobalMenu(AbstractMenu):
 
 		return list(missing)
 
+	@override
 	def _is_config_valid(self) -> bool:
 		"""
 		Checks the validity of the current configuration.

--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -89,6 +89,9 @@ class AbstractMenu:
 		for item in self._menu_item_group.items:
 			item.enabled = False
 
+	def _is_config_valid(self) -> bool:
+		return True
+
 	def run(self) -> Any | None:
 		self._sync_from_config()
 
@@ -108,6 +111,8 @@ class AbstractMenu:
 					item: MenuItem = result.item()
 
 					if item.action is None:
+						if not self._is_config_valid():
+							continue
 						break
 				case ResultType.Reset:
 					return None


### PR DESCRIPTION
This also makes use of the previously unused _is_config_valid() method.
