### PR TITLE
Enable possibly-undefined warnings in mypy

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -581,6 +581,7 @@ class Installer:
 		# in the first column of the entry; check for both cases.
 		entry_re = re.compile(rf'#{lang}(\.{encoding})?{modifier} {encoding}')
 
+		lang_value = None
 		for index, line in enumerate(locale_gen_lines):
 			if entry_re.match(line):
 				uncommented_line = line.removeprefix('#')
@@ -588,7 +589,8 @@ class Installer:
 				locale_gen.write_text(''.join(locale_gen_lines))
 				lang_value = uncommented_line.split()[0]
 				break
-		else:
+
+		if lang_value is None:
 			error(f"Invalid locale: language '{locale_config.sys_lang}', encoding '{locale_config.sys_enc}'")
 			return False
 

--- a/archinstall/lib/interactions/network_menu.py
+++ b/archinstall/lib/interactions/network_menu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, assert_never, override
 
 from archinstall.tui.curses_menu import EditMenu, SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
@@ -144,6 +144,10 @@ class ManualNetworkConfig(ListManager):
 				mode = result.get_value()
 			case ResultType.Reset:
 				raise ValueError('Unhandled result type')
+			case ResultType.Skip:
+				raise ValueError('The mode menu should not be skippable')
+			case _:
+				assert_never(result.type_)
 
 		if mode == 'IP (static)':
 			header = str(_('Enter the IP and subnet for {} (example: 192.168.0.5/24): ').format(iface_name)) + '\n'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ enable_error_code = [
     "explicit-override",
     "ignore-without-code",
     "mutable-override",
+    "possibly-undefined",
     "redundant-expr",
     "redundant-self",
     "truthy-iterable",


### PR DESCRIPTION
## PR Description:

This commit also fixes the two remaining possibly-undefined warnings:

```
archinstall/lib/installer.py:601: error: Name "lang_value" may be undefined  [possibly-undefined]
archinstall/lib/interactions/network_menu.py:148: error: Name "mode" may be undefined  [possibly-undefined]
``` 