### PR TITLE
Use curses.window instead of curses._CursesWindow in annotations

### DIFF
--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -46,7 +46,7 @@ class AbstractCurses(metaclass=ABCMeta):
 		pass
 
 	@abstractmethod
-	def kickoff(self, win: 'curses._CursesWindow') -> Result:
+	def kickoff(self, win: curses.window) -> Result:
 		pass
 
 	def clear_all(self) -> None:
@@ -123,7 +123,7 @@ class AbstractViewport:
 	def __init__(self) -> None:
 		pass
 
-	def add_str(self, screen: 'curses._CursesWindow', row: int, col: int, text: str, color: STYLE) -> None:
+	def add_str(self, screen: curses.window, row: int, col: int, text: str, color: STYLE) -> None:
 		try:
 			screen.addstr(row, col, text, Tui.t().get_color(color))
 		except curses.error:
@@ -323,8 +323,8 @@ class EditViewport(AbstractViewport):
 		self._alignment = alignment
 		self._hide_input = hide_input
 
-		self._main_win: 'curses._CursesWindow | None' = None
-		self._edit_win: 'curses._CursesWindow | None' = None
+		self._main_win: curses.window | None = None
+		self._edit_win: curses.window | None = None
 		self._textbox: Textbox | None = None
 
 		self._init_wins()
@@ -595,7 +595,7 @@ class EditMenu(AbstractCurses):
 			self._input_vp.edit(default_text=self._default_text)
 
 	@override
-	def kickoff(self, win: 'curses._CursesWindow') -> Result:
+	def kickoff(self, win: curses.window) -> Result:
 		try:
 			self._draw()
 		except KeyboardInterrupt:
@@ -777,7 +777,7 @@ class SelectMenu(AbstractCurses):
 		return result
 
 	@override
-	def kickoff(self, win: 'curses._CursesWindow') -> Result:
+	def kickoff(self, win: curses.window) -> Result:
 		self._draw()
 
 		while True:
@@ -1256,7 +1256,7 @@ class Tui:
 		self.stop()
 
 	@property
-	def screen(self) -> 'curses._CursesWindow':
+	def screen(self) -> curses.window:
 		return self._screen
 
 	@staticmethod


### PR DESCRIPTION
## PR Description:

This commit fixes some warnings like this reported by Pyright:
```
archinstall/tui/curses_menu.py:49:33 - error: "_CursesWindow" is private and used outside of the module in which it is declared (reportPrivateUsage)
```

Related PR:
- https://github.com/python/typeshed/pull/12744