### PR TITLE
Add ruff auto sort imports hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,9 @@ repos:
     rev: v0.11.3
     hooks:
       - id: ruff
+        args: ["check", "--select", "I", "--fix"]
+        fail_fast: true
+      - id: ruff
   - repo: local
     hooks:
       - id: pylint


### PR DESCRIPTION
Adding a pre-commit hook to auto sort imports as that is required by other checks 