### PR TITLE
Fix disk config validation regression

### DIFF
--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -207,7 +207,12 @@ class ArchConfigHandler:
 		self._args: Arguments = self._parse_args()
 
 		config = self._parse_config()
-		self._config = ArchConfig.from_config(config)
+
+		try:
+			self._config = ArchConfig.from_config(config)
+		except ValueError as err:
+			warn(str(err))
+			exit(1)
 
 	@property
 	def config(self) -> ArchConfig:


### PR DESCRIPTION
Fixes #3354

This should be fine considering `_fetch_from_url()` and `_read_file()` exit on error and can be called by `_parse_config()`, which is being called in this `__init__()`.
