### PR TITLE
Remove unused imports reported by Pyright

### DIFF
--- a/archinstall/lib/crypt.py
+++ b/archinstall/lib/crypt.py
@@ -1,5 +1,4 @@
 import ctypes
-import ctypes.util
 from pathlib import Path
 
 from .output import debug

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import curses
-import curses.panel
 import os
 import signal
 import sys


### PR DESCRIPTION
## PR Description:

Pyright detected some unused imports that were missed by ruff and Pylint:

```
archinstall/lib/crypt.py:2:8 - error: Import "ctypes.util" is not accessed (reportUnusedImport)
archinstall/tui/curses_menu.py:4:8 - error: Import "curses.panel" is not accessed (reportUnusedImport)
```