### PR TITLE
Remove unused variable reported by Pyright

### DIFF
--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -29,7 +29,7 @@ _VT100_ESCAPE_REGEX_BYTES = _VT100_ESCAPE_REGEX.encode()
 
 def generate_password(length: int = 64) -> str:
 	haystack = string.printable  # digits, ascii_letters, punctuation (!"#$[] etc) and whitespace
-	return ''.join(secrets.choice(haystack) for i in range(length))
+	return ''.join(secrets.choice(haystack) for _ in range(length))
 
 
 def locate_binary(name: str) -> str:


### PR DESCRIPTION
## PR Description:

Pyright detects an unused variable that is missed by ruff and Pylint:
```
archinstall/lib/general.py:32:46 - error: Variable "i" is not accessed (reportUnusedVariable)
```