### PR TITLE
Split out Result and ResultType to break import cycle

### DIFF
--- a/archinstall/default_profiles/desktop.py
+++ b/archinstall/default_profiles/desktop.py
@@ -5,7 +5,8 @@ from archinstall.lib.output import info
 from archinstall.lib.profile.profiles_handler import profile_handler
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import FrameProperties, PreviewStyle, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import FrameProperties, PreviewStyle
 
 if TYPE_CHECKING:
 	from archinstall.lib.installer import Installer

--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -5,7 +5,8 @@ from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/default_profiles/desktops/labwc.py
+++ b/archinstall/default_profiles/desktops/labwc.py
@@ -5,7 +5,8 @@ from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/default_profiles/desktops/niri.py
+++ b/archinstall/default_profiles/desktops/niri.py
@@ -5,7 +5,8 @@ from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/default_profiles/desktops/sway.py
+++ b/archinstall/default_profiles/desktops/sway.py
@@ -5,7 +5,8 @@ from archinstall.default_profiles.profile import GreeterType, ProfileType
 from archinstall.default_profiles.xorg import XorgProfile
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties
 
 if TYPE_CHECKING:
 	from collections.abc import Callable

--- a/archinstall/default_profiles/server.py
+++ b/archinstall/default_profiles/server.py
@@ -5,7 +5,8 @@ from archinstall.lib.output import info
 from archinstall.lib.profile.profiles_handler import profile_handler
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import FrameProperties, PreviewStyle, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import FrameProperties, PreviewStyle
 
 if TYPE_CHECKING:
 	from archinstall.lib.installer import Installer

--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING
 
 from archinstall.tui.curses_menu import SelectMenu, Tui
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle
 
 from .args import ArchConfig
 from .general import JSON, UNSAFE_JSON

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -13,7 +13,8 @@ from archinstall.lib.models.device_model import (
 )
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties
 
 from ..menu.abstract_menu import AbstractSubMenu
 from ..models.device_model import Fido2Device

--- a/archinstall/lib/disk/partitioning_menu.py
+++ b/archinstall/lib/disk/partitioning_menu.py
@@ -19,7 +19,8 @@ from archinstall.lib.models.device_model import (
 )
 from archinstall.tui.curses_menu import EditMenu, SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, Orientation, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties, Orientation
 
 from ..menu.list_manager import ListManager
 from ..output import FormattedOutput

--- a/archinstall/lib/disk/subvolume_menu.py
+++ b/archinstall/lib/disk/subvolume_menu.py
@@ -3,7 +3,8 @@ from typing import TYPE_CHECKING, assert_never, override
 
 from archinstall.lib.models.device_model import SubvolumeModification
 from archinstall.tui.curses_menu import EditMenu
-from archinstall.tui.types import Alignment, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment
 
 from ..menu.list_manager import ListManager
 from ..utils.util import prompt_dir

--- a/archinstall/lib/interactions/disk_conf.py
+++ b/archinstall/lib/interactions/disk_conf.py
@@ -30,7 +30,8 @@ from archinstall.lib.models.device_model import (
 from archinstall.lib.output import debug
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle
 
 from ..output import FormattedOutput
 from ..utils.util import prompt_dir

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -7,7 +7,8 @@ from archinstall.lib.models.packages import Repository
 from archinstall.lib.packages.packages import list_available_packages
 from archinstall.tui.curses_menu import EditMenu, SelectMenu, Tui
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle
 
 from ..locale.utils import list_timezones
 from ..models.audio_configuration import Audio, AudioConfiguration

--- a/archinstall/lib/interactions/manage_users_conf.py
+++ b/archinstall/lib/interactions/manage_users_conf.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, override
 
 from archinstall.tui.curses_menu import EditMenu, SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, Orientation, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, Orientation
 
 from ..menu.list_manager import ListManager
 from ..models.users import User

--- a/archinstall/lib/interactions/network_menu.py
+++ b/archinstall/lib/interactions/network_menu.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, assert_never, override
 
 from archinstall.tui.curses_menu import EditMenu, SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties
 
 from ..menu.list_manager import ListManager
 from ..models.network_configuration import NetworkConfiguration, Nic, NicType

--- a/archinstall/lib/interactions/system_conf.py
+++ b/archinstall/lib/interactions/system_conf.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING
 
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, FrameStyle, Orientation, PreviewStyle, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties, FrameStyle, Orientation, PreviewStyle
 
 from ..hardware import GfxDriver, SysInfo
 from ..models.bootloader import Bootloader

--- a/archinstall/lib/locale/locale_menu.py
+++ b/archinstall/lib/locale/locale_menu.py
@@ -2,7 +2,8 @@ from typing import TYPE_CHECKING, override
 
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties
 
 from ..menu.abstract_menu import AbstractSubMenu
 from ..models.locale import LocaleConfiguration

--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, Any, Self
 
 from archinstall.tui.curses_menu import SelectMenu, Tui
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Chars, FrameProperties, FrameStyle, PreviewStyle, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Chars, FrameProperties, FrameStyle, PreviewStyle
 
 from ..output import error
 

--- a/archinstall/lib/menu/list_manager.py
+++ b/archinstall/lib/menu/list_manager.py
@@ -3,7 +3,8 @@ from typing import TYPE_CHECKING, Any
 
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment
 
 from ..output import FormattedOutput
 

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, override
 
 from archinstall.tui.curses_menu import EditMenu, SelectMenu, Tui
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties
 
 from .menu.abstract_menu import AbstractSubMenu
 from .menu.list_manager import ListManager

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, override
 from archinstall.default_profiles.profile import GreeterType, Profile
 from archinstall.tui.curses_menu import SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
-from archinstall.tui.types import Alignment, FrameProperties, Orientation, ResultType
+from archinstall.tui.result import ResultType
+from archinstall.tui.types import Alignment, FrameProperties, Orientation
 
 from ..hardware import GfxDriver
 from ..interactions.system_conf import select_driver

--- a/archinstall/tui/__init__.py
+++ b/archinstall/tui/__init__.py
@@ -1,6 +1,7 @@
 from .curses_menu import EditMenu, SelectMenu, Tui
 from .menu_item import MenuItem, MenuItemGroup
-from .types import Alignment, Chars, FrameProperties, FrameStyle, Orientation, PreviewStyle, Result, ResultType
+from .result import Result, ResultType
+from .types import Alignment, Chars, FrameProperties, FrameStyle, Orientation, PreviewStyle
 
 __all__ = [
     'Alignment',

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Literal, override
 from ..lib.output import debug
 from .help import Help
 from .menu_item import MenuItem, MenuItemGroup, MenuItemsState
+from .result import Result, ResultType
 from .types import (
 	SCROLL_INTERVAL,
 	STYLE,
@@ -24,8 +25,6 @@ from .types import (
 	MenuKeys,
 	Orientation,
 	PreviewStyle,
-	Result,
-	ResultType,
 	ViewportEntry,
 	_FrameDim,
 )

--- a/archinstall/tui/result.py
+++ b/archinstall/tui/result.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any
+
+from .menu_item import MenuItem
+
+
+class ResultType(Enum):
+	Selection = auto()
+	Skip = auto()
+	Reset = auto()
+
+
+@dataclass
+class Result:
+	type_: ResultType
+	_item: MenuItem | list[MenuItem] | str | None
+
+	def has_item(self) -> bool:
+		return self._item is not None
+
+	def get_value(self) -> Any:
+		return self.item().get_value()
+
+	def get_values(self) -> list[Any]:
+		return [i.get_value() for i in self.items()]
+
+	def item(self) -> MenuItem:
+		assert self._item is not None and isinstance(self._item, MenuItem)
+		return self._item
+
+	def items(self) -> list[MenuItem]:
+		assert self._item is not None and isinstance(self._item, list)
+		return self._item
+
+	def text(self) -> str:
+		assert self._item is not None and isinstance(self._item, str)
+		return self._item

--- a/archinstall/tui/types.py
+++ b/archinstall/tui/types.py
@@ -1,9 +1,6 @@
 import curses
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any
-
-from .menu_item import MenuItem
 
 SCROLL_INTERVAL = 10
 
@@ -94,21 +91,9 @@ class FrameProperties:
 		)
 
 
-class ResultType(Enum):
-	Selection = auto()
-	Skip = auto()
-	Reset = auto()
-
-
 class Orientation(Enum):
 	VERTICAL = auto()
 	HORIZONTAL = auto()
-
-
-@dataclass
-class MenuCell:
-	item: MenuItem
-	text: str
 
 
 class PreviewStyle(Enum):
@@ -133,33 +118,6 @@ class Chars:
 	Check = "+"
 	Cross = "x"
 	Right_arrow = "←"
-
-
-@dataclass
-class Result:
-	type_: ResultType
-	_item: MenuItem | list[MenuItem] | str | None
-
-	def has_item(self) -> bool:
-		return self._item is not None
-
-	def get_value(self) -> Any:
-		return self.item().get_value()
-
-	def get_values(self) -> list[Any]:
-		return [i.get_value() for i in self.items()]
-
-	def item(self) -> MenuItem:
-		assert self._item is not None and isinstance(self._item, MenuItem)
-		return self._item
-
-	def items(self) -> list[MenuItem]:
-		assert self._item is not None and isinstance(self._item, list)
-		return self._item
-
-	def text(self) -> str:
-		assert self._item is not None and isinstance(self._item, str)
-		return self._item
 
 
 @dataclass


### PR DESCRIPTION
## PR Description:

Previously, there was an import cycle between `tui.menu_item` and `tui.types`:

```
archinstall/tui/menu_item.py: error: Cycle detected in import chain
  archinstall/tui/menu_item.py
  archinstall/tui/types.py (reportImportCycles)
```