### PR TITLE
Add niri package to niri profile

### DIFF
--- a/archinstall/default_profiles/desktops/niri.py
+++ b/archinstall/default_profiles/desktops/niri.py
@@ -33,6 +33,7 @@ class NiriProfile(XorgProfile):
 			additional = [seat]
 
 		return [
+			"niri",
 			"alacritty",
 			"fuzzel",
 			"mako",


### PR DESCRIPTION
## PR Description:

I noticed that the `niri` package was missing from the niri profile which was added in https://github.com/archlinux/archinstall/pull/3323

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
