### PR TITLE
Swapping to python-uv for building and distribution

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -17,7 +17,8 @@ jobs:
           pacman-key --init
           pacman --noconfirm -Sy archlinux-keyring
           pacman --noconfirm -Syyu
-          pacman --noconfirm -Sy python-uv python-setuptools python-pip python-pyparted
+          pacman --noconfirm -Sy python-uv python-setuptools python-pip
+          pacman --noconfirm -Sy python-pyparted python-pydantic
       - name: Remove existing archinstall (if any)
         run: 
           uv pip uninstall archinstall --break-system-packages --system

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -17,16 +17,14 @@ jobs:
           pacman-key --init
           pacman --noconfirm -Sy archlinux-keyring
           pacman --noconfirm -Syyu
-          pacman --noconfirm -Sy python-pip python-pydantic python-pyparted pkgconfig gcc
-      - name: Install build dependencies
-        run: |
-          python -m pip install --break-system-packages --upgrade pip
-          pip install --break-system-packages --upgrade build twine wheel setuptools installer
-          pip uninstall archinstall -y --break-system-packages
+          pacman --noconfirm -Sy python-uv python-setuptools python-pip
+      - name: Remove existing archinstall (if any)
+        run: 
+          uv pip uninstall archinstall --break-system-packages
       - name: Build archinstall
-        run: python -m build --wheel --no-isolation
+        run: uv build --no-build-isolation --wheel
       - name: Install archinstall
-        run: python -m installer dist/*.whl
+        run: uv pip install dist/*.whl
       - name: Run archinstall
         run: |
           python -V

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -17,14 +17,15 @@ jobs:
           pacman-key --init
           pacman --noconfirm -Sy archlinux-keyring
           pacman --noconfirm -Syyu
-          pacman --noconfirm -Sy python-uv python-setuptools python-pip
+          pacman --noconfirm -Sy python-uv python-setuptools python-pip python-pyparted
       - name: Remove existing archinstall (if any)
         run: 
           uv pip uninstall archinstall --break-system-packages --system
       - name: Build archinstall
         run: uv build --no-build-isolation --wheel
       - name: Install archinstall
-        run: uv pip install dist/*.whl --break-system-packages --system
+        run: |
+          uv pip install dist/*.whl --break-system-packages --system --no-build --no-deps
       - name: Run archinstall
         run: |
           python -V

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -20,11 +20,11 @@ jobs:
           pacman --noconfirm -Sy python-uv python-setuptools python-pip
       - name: Remove existing archinstall (if any)
         run: 
-          uv pip uninstall archinstall --break-system-packages
+          uv pip uninstall archinstall --break-system-packages --system
       - name: Build archinstall
         run: uv build --no-build-isolation --wheel
       - name: Install archinstall
-        run: uv pip install dist/*.whl
+        run: uv pip install dist/*.whl --break-system-packages --system
       - name: Run archinstall
         run: |
           python -V

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,10 +24,7 @@ jobs:
           pip install build twine
       - name: Build archinstall
         run: |
-          python -m build . --wheel
+          uv build --no-build-isolation --wheel
       - name: Publish archinstall to PyPi
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          twine upload dist/*
+          uv publish --trusted-publishing always

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,10 +18,12 @@ jobs:
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
         with:
           python-version: '3.x'
-      - name: Install dependencies
+      - name: Prepare arch
         run: |
-          python -m pip install --upgrade pip
-          pip install build twine
+          pacman-key --init
+          pacman --noconfirm -Sy archlinux-keyring
+          pacman --noconfirm -Syyu
+          pacman --noconfirm -Sy python-uv python-setuptools python-pip
       - name: Build archinstall
         run: |
           uv build --no-build-isolation --wheel

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -11,10 +11,10 @@ packages=(
 	pkgconfig
 	python
 	python-pip
-	python-build
+	python-uv
 	python-setuptools
-	python-wheel
 	python-pyparted
+	python-pydantic
 )
 
 mkdir -p /tmp/archlive/airootfs/root/archinstall-git
@@ -24,8 +24,8 @@ cat <<- _EOF_ | tee /tmp/archlive/airootfs/root/.zprofile
 	cd archinstall-git
 	rm -rf dist
 
-	python -m build --wheel --no-isolation
-	pip install dist/archinstall*.whl --break-system-packages
+	uv build --no-build-isolation --wheel
+	uv pip install dist/*.whl --break-system-packages --system --no-build --no-deps
 
 	echo "This is an unofficial ISO for development and testing of archinstall. No support will be provided."
 	echo "This ISO was built from Git SHA $GITHUB_SHA"


### PR DESCRIPTION
This will swap to [uv](https://docs.astral.sh/uv/) for building and distribution.
Mainly to evaluate, as `twine` has caused minor issues in the past.