### PR TITLE
Add an inline annotation to avoid a crash with mypy 1.15.0

### DIFF
--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -718,7 +718,10 @@ class SelectMenu[ValueT](AbstractCurses[ValueT]):
 		self._interrupt_warning = reset_warning_msg
 		self._header = header
 
-		self._header_entries = []
+		# TODO: Remove the inline annotation after upgrading to mypy 1.16.0
+		# The inline annotation is needed to avoid a crash in 1.15.0:
+		#  RuntimeError: Partial type "<partial list[?]>" cannot be checked with "issubtype()"
+		self._header_entries: list[ViewportEntry] = []
 		if header:
 			self._header_entries = self.get_header_entries(header)
 


### PR DESCRIPTION
## PR Description:

The annotation prevents intermittent crashes when running mypy with a clean cache:

```
./archinstall/tui/curses_menu.py:723: error: INTERNAL ERROR

RuntimeError: Partial type "<partial list[?]>" cannot be checked with "issubtype()"
```

Example failures:
- https://github.com/archlinux/archinstall/actions/runs/14823504054/job/41613637093?pr=3433
- https://github.com/archlinux/archinstall/actions/runs/14778570983/job/41492200670