### PR TITLE
Remove unused pydantic-settings dependency from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
       fail_fast: true
       additional_dependencies:
         - pydantic
-        - pydantic-settings
         - pytest
         - cryptography
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
## PR Description:

pydantic-settings doesn't seem to be needed.  I ran `pre-commit run --all-files` and didn't see any errors.