### PR TITLE
Disable the loop-iterator-mutation rule in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,7 @@ ignore = [
     "B008",     # function-call-in-default-argument
     "B904",     # raise-without-from-inside-except
     "B905",     # zip-without-explicit-strict
+    "B909",     # loop-iterator-mutation
     "COM812",   # missing-trailing-comma
     "PLC0415",  # import-outside-top-level
     "PLC1901",  # compare-to-empty-string


### PR DESCRIPTION
## PR Description:

This allows `ruff check --preview` to succeed again.

Here's the warning that is now suppressed:

```
archinstall/lib/pacman/config.py:46:6: B909 Mutation to loop iterable `content` during iteration
   |
44 |                 # also uncomment the next line (Include statement) if it exists and is commented
45 |                 if row + 1 < len(content) and content[row + 1].lstrip().startswith('#'):
46 |                     content[row + 1] = re.sub(r'^#\s*', '', content[row + 1])
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B909
47 |
48 |         # Write the modified content back to the file
   |

Found 1 error.
```