### PR TITLE
UWSM for Hyprland

### DIFF
--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -29,6 +29,7 @@ class HyprlandProfile(XorgProfile):
 			"hyprland",
 			"dunst",
 			"kitty",
+			"uwsm",
 			"dolphin",
 			"wofi",
 			"xdg-desktop-portal-hyprland",


### PR DESCRIPTION
Add UWSM.

uwsm is recommended to start hyprland and hyprland with uwsm is the default session.
Currrently, archinstall does not install the package as default.
Including UWSM will make out of the box hyprland experience better.

Note: This code wasn't tested, but its structure aligns with existing profiles.