### PR TITLE
Fixed missing archlinux container usage

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,7 +11,9 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
+    container:
+      image: archlinux/archlinux:latest
+      options: --privileged
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up Python


### PR DESCRIPTION
The latest release could not auto-push to PyPi because: https://github.com/archlinux/archinstall/actions/runs/15038878435/job/42265775848

This should fix this.