### PR TITLE
Add missing xdg-user-dirs and Cosmic Greeter

### DIFF
--- a/archinstall/default_profiles/desktops/cosmic.py
+++ b/archinstall/default_profiles/desktops/cosmic.py
@@ -13,9 +13,10 @@ class CosmicProfile(XorgProfile):
 	def packages(self) -> list[str]:
 		return [
 			"cosmic",
+			"xdg-user-dirs"
 		]
 
 	@property
 	@override
 	def default_greeter_type(self) -> GreeterType:
-		return GreeterType.CosmicSession
+		return GreeterType.CosmicGreeter


### PR DESCRIPTION
Installing Cosmic as is results in no greeter so service needs to be started. Also added missing xdg-user-dirs for user directories in cosmic-file-manager.. 