### PR TITLE
Fix pypi auto release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,5 +28,9 @@ jobs:
           pacman --noconfirm -Syyu
           pacman --noconfirm -Sy python-uv python-setuptools python-pip
           pacman --noconfirm -Sy python-pyparted python-pydantic
+      - name: Build archinstall
+        run: |
           uv build --no-build-isolation --wheel
+      - name: Publish archinstall to PyPi
+        run: |
           uv publish --trusted-publishing always

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,11 +3,9 @@
 
 name: Upload archinstall to PyPi
 
-# on:
-#   release:
-#     types: [ published ]
-
-on: [ push, pull_request ]
+on:
+  release:
+    types: [ published ]
 
 jobs:
   deploy:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,17 +17,12 @@ jobs:
       options: --privileged
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: '3.x'
       - name: Prepare arch
         run: |
           pacman-key --init
           pacman --noconfirm -Sy archlinux-keyring
           pacman --noconfirm -Syyu
-          pacman --noconfirm -Sy python-uv python-setuptools python-pip
-          pacman --noconfirm -Sy python-pyparted python-pydantic
+          pacman --noconfirm -Sy python python-uv python-setuptools python-pip python-pyparted python-pydantic
       - name: Build archinstall
         run: |
           uv build --no-build-isolation --wheel

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,9 +3,10 @@
 
 name: Upload archinstall to PyPi
 
-on:
-  release:
-    types: [ published ]
+# on:
+#   release:
+#     types: [ published ]
+on: [ push, pull_request ]
 
 jobs:
   deploy:
@@ -26,6 +27,7 @@ jobs:
           pacman --noconfirm -Sy archlinux-keyring
           pacman --noconfirm -Syyu
           pacman --noconfirm -Sy python-uv python-setuptools python-pip
+          pacman --noconfirm -Sy python-pyparted python-pydantic
       - name: Build archinstall
         run: |
           uv build --no-build-isolation --wheel

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,6 +6,7 @@ name: Upload archinstall to PyPi
 # on:
 #   release:
 #     types: [ published ]
+
 on: [ push, pull_request ]
 
 jobs:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,9 +28,5 @@ jobs:
           pacman --noconfirm -Syyu
           pacman --noconfirm -Sy python-uv python-setuptools python-pip
           pacman --noconfirm -Sy python-pyparted python-pydantic
-      - name: Build archinstall
-        run: |
           uv build --no-build-isolation --wheel
-      - name: Publish archinstall to PyPi
-        run: |
           uv publish --trusted-publishing always

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,6 +13,9 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
     container:
       image: archlinux/archlinux:latest
       options: --privileged

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-    "pyparted @ https://github.com//dcantrell/pyparted/archive/v3.13.0.tar.gz#sha512=26819e28d73420937874f52fda03eb50ab1b136574ea9867a69d46ae4976d38c4f26a2697fa70597eed90dd78a5ea209bafcc3227a17a7a5d63cff6d107c2b11",
+    "pyparted>=3.13.0",
     "pydantic==2.11.4",
     "cryptography>=44.0.2",
 ]


### PR DESCRIPTION
This fixes PyPi auto-publish using `uv`.

The reason why pyshing to PyPi has been broken in general is that you are not allowed to do:

```toml
dependencies = [
    "pyparted @ https://github.com//dcantrell/pyparted/archive/v3.13.0.tar.gz#sha512=26819e28d73420937874f52fda03eb50ab1b136574ea9867a69d46ae4976d38c4f26a2697fa70597eed90dd78a5ea209bafcc3227a17a7a5d63cff6d107c2b11",
]
```

Because that won't resolve well when someone is trying to install the package.
So in order for PyPi (and tools using it, like pip) to be happy with the requirement is to go back to 
```toml
dependencies = [
    "pyparted>=3.13.0",
]
```

But since dcantrell published this version to pypi, we can now go back to using it.
And this, allows for auto-publish to PyPi for us :tada: 