### PR TITLE
Generate empty string on empty custom_servers config

### DIFF
--- a/archinstall/lib/models/mirrors.py
+++ b/archinstall/lib/models/mirrors.py
@@ -258,10 +258,12 @@ class MirrorConfiguration:
 		}
 
 	def custom_servers_config(self) -> str:
-		config = "## Custom Servers\n"
+		config = ""
 
-		for server in self.custom_servers:
-			config += f"Server = {server.url}\n"
+		if self.custom_servers:
+			config += "## Custom Servers\n"
+			for server in self.custom_servers:
+				config += f"Server = {server.url}\n"
 
 		return config.strip()
 


### PR DESCRIPTION
- This fix issue: #3497 

## PR Description:

This fixes the bug I described at #3497 - now, there's an empty `custom_servers` string when there is no matching config.

## Tests and Checks
- [x] I have tested the code!