### PR TITLE
Added a more humane error message on no initial network

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -40,10 +40,10 @@ def _fetch_arch_db() -> None:
 	try:
 		Pacman.run('-Sy')
 	except Exception as e:
-		error("Failed to sync Arch Linux package database.")
+		error('Failed to sync Arch Linux package database.')
 		if 'could not resolve host' in str(e).lower():
-			error("Most likely due to a missing network connection or DNS issue.")
-		error("Run archinstall --debug and check /var/log/archinstall/install.log for details.")
+			error('Most likely due to a missing network connection or DNS issue.')
+		error('Run archinstall --debug and check /var/log/archinstall/install.log for details.')
 
 		debug(f'Failed to sync Arch Linux package database: {e}')
 		exit(1)


### PR DESCRIPTION
![screenshot](https://github.com/user-attachments/assets/d3f4232d-824f-4a89-91e9-c6d0c16cbddf)

This should help avoid issues/questions like these: https://www.reddit.com/r/archlinux/comments/1kucu86/archinstall_doesnt_work_getting_exitcode_1/

They happen from time to time, and I get why this might be confusing.