### PR TITLE
Move disk encryption into disk config menu

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -27,13 +27,9 @@ from .device_handler import device_handler
 
 
 class FilesystemHandler:
-	def __init__(
-		self,
-		disk_config: DiskLayoutConfiguration,
-		enc_conf: DiskEncryption | None = None,
-	):
+	def __init__(self, disk_config: DiskLayoutConfiguration):
 		self._disk_config = disk_config
-		self._enc_config = enc_conf
+		self._enc_config = disk_config.disk_encryption
 
 	def perform_filesystem_operations(self, show_countdown: bool = True) -> None:
 		if self._disk_config.config_type == DiskLayoutType.Pre_mount:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -62,7 +62,6 @@ class Installer:
 		self,
 		target: Path,
 		disk_config: DiskLayoutConfiguration,
-		disk_encryption: DiskEncryption | None = None,
 		base_packages: list[str] = [],
 		kernels: list[str] | None = None,
 	):
@@ -74,7 +73,7 @@ class Installer:
 		self.kernels = kernels or ['linux']
 		self._disk_config = disk_config
 
-		self._disk_encryption = disk_encryption or DiskEncryption(EncryptionType.NoEncryption)
+		self._disk_encryption = disk_config.disk_encryption or DiskEncryption(EncryptionType.NoEncryption)
 		self.target: Path = target
 
 		self.init_time = time.strftime('%Y-%m-%d_%H-%M-%S')

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -53,14 +53,12 @@ def perform_installation(mountpoint: Path) -> None:
 	disk_config = config.disk_config
 	run_mkinitcpio = not config.uki
 	locale_config = config.locale_config
-	disk_encryption = config.disk_encryption
 	optional_repositories = config.mirror_config.optional_repositories if config.mirror_config else []
 	mountpoint = disk_config.mountpoint if disk_config.mountpoint else mountpoint
 
 	with Installer(
 		mountpoint,
 		disk_config,
-		disk_encryption=disk_encryption,
 		kernels=config.kernels,
 	) as installation:
 		# Mount all the drives to the desired mountpoint
@@ -70,7 +68,7 @@ def perform_installation(mountpoint: Path) -> None:
 		installation.sanity_check()
 
 		if disk_config.config_type != DiskLayoutType.Pre_mount:
-			if disk_encryption and disk_encryption.encryption_type != EncryptionType.NoEncryption:
+			if disk_config.disk_encryption and disk_config.disk_encryption.encryption_type != EncryptionType.NoEncryption:
 				# generate encryption key files for the mounted luks devices
 				installation.generate_key_files()
 
@@ -190,11 +188,7 @@ def guided() -> None:
 				guided()
 
 	if arch_config_handler.config.disk_config:
-		fs_handler = FilesystemHandler(
-			arch_config_handler.config.disk_config,
-			arch_config_handler.config.disk_encryption,
-		)
-
+		fs_handler = FilesystemHandler(arch_config_handler.config.disk_config)
 		fs_handler.perform_filesystem_operations()
 
 	perform_installation(arch_config_handler.args.mountpoint)

--- a/archinstall/scripts/minimal.py
+++ b/archinstall/scripts/minimal.py
@@ -4,7 +4,6 @@ from archinstall.default_profiles.minimal import MinimalProfile
 from archinstall.lib.args import arch_config_handler
 from archinstall.lib.configuration import ConfigurationOutput
 from archinstall.lib.disk.disk_menu import DiskLayoutConfigurationMenu
-from archinstall.lib.disk.encryption_menu import DiskEncryptionMenu
 from archinstall.lib.disk.filesystem import FilesystemHandler
 from archinstall.lib.installer import Installer
 from archinstall.lib.models import Bootloader
@@ -23,13 +22,11 @@ def perform_installation(mountpoint: Path) -> None:
 		return
 
 	disk_config = config.disk_config
-	disk_encryption = config.disk_encryption
 	mountpoint = disk_config.mountpoint if disk_config.mountpoint else mountpoint
 
 	with Installer(
 		mountpoint,
 		disk_config,
-		disk_encryption=disk_encryption,
 		kernels=config.kernels,
 	) as installation:
 		# Strap in the base system, add a boot loader and configure
@@ -64,13 +61,7 @@ def perform_installation(mountpoint: Path) -> None:
 def _minimal() -> None:
 	with Tui():
 		disk_config = DiskLayoutConfigurationMenu(disk_layout_config=None).run()
-
-		disk_encryption = None
-		if disk_config:
-			disk_encryption = DiskEncryptionMenu(disk_config).run()
-
 		arch_config_handler.config.disk_config = disk_config
-		arch_config_handler.config.disk_encryption = disk_encryption
 
 	config = ConfigurationOutput(arch_config_handler.config)
 	config.write_debug()
@@ -86,11 +77,7 @@ def _minimal() -> None:
 				_minimal()
 
 	if arch_config_handler.config.disk_config:
-		fs_handler = FilesystemHandler(
-			arch_config_handler.config.disk_config,
-			arch_config_handler.config.disk_encryption,
-		)
-
+		fs_handler = FilesystemHandler(arch_config_handler.config.disk_config)
 		fs_handler.perform_filesystem_operations()
 
 	perform_installation(arch_config_handler.args.mountpoint)

--- a/archinstall/scripts/only_hd.py
+++ b/archinstall/scripts/only_hd.py
@@ -17,7 +17,6 @@ def ask_user_questions() -> None:
 
 		global_menu.set_enabled('archinstall_language', True)
 		global_menu.set_enabled('disk_config', True)
-		global_menu.set_enabled('disk_encryption', True)
 		global_menu.set_enabled('swap', True)
 		global_menu.set_enabled('__config__', True)
 
@@ -37,13 +36,11 @@ def perform_installation(mountpoint: Path) -> None:
 		return
 
 	disk_config = config.disk_config
-	disk_encryption = config.disk_encryption
 	mountpoint = disk_config.mountpoint if disk_config.mountpoint else mountpoint
 
 	with Installer(
 		mountpoint,
 		disk_config,
-		disk_encryption=disk_encryption,
 		kernels=config.kernels,
 	) as installation:
 		# Mount all the drives to the desired mountpoint
@@ -78,11 +75,7 @@ def _only_hd() -> None:
 				_only_hd()
 
 	if arch_config_handler.config.disk_config:
-		fs_handler = FilesystemHandler(
-			arch_config_handler.config.disk_config,
-			arch_config_handler.config.disk_encryption,
-		)
-
+		fs_handler = FilesystemHandler(arch_config_handler.config.disk_config)
 		fs_handler.perform_filesystem_operations()
 
 	perform_installation(arch_config_handler.args.mountpoint)

--- a/examples/full_automated_installation.py
+++ b/examples/full_automated_installation.py
@@ -87,8 +87,10 @@ disk_encryption = DiskEncryption(
 	hsm_device=None,
 )
 
+disk_config.disk_encryption = disk_encryption
+
 # initiate file handler with the disk config and the optional disk encryption config
-fs_handler = FilesystemHandler(disk_config, disk_encryption)
+fs_handler = FilesystemHandler(disk_config)
 
 # perform all file operations
 # WARNING: this will potentially format the filesystem and delete all data
@@ -99,7 +101,6 @@ mountpoint = Path('/tmp')
 with Installer(
 	mountpoint,
 	disk_config,
-	disk_encryption=disk_encryption,
 	kernels=['linux'],
 ) as installation:
 	installation.mount_ordered_layout()

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -211,7 +211,6 @@ def test_config_file_parsing(
 				groups=['wheel'],
 			),
 		],
-		disk_encryption=None,
 		services=['service_1', 'service_2'],
 		root_enc_password=Password(enc_password='password_hash'),
 		custom_commands=["echo 'Hello, World!'"],


### PR DESCRIPTION
This will move the disk encryption menu from the main menu into the disk configuration menu as it makes more sense to group it in there with the other disk related configurations. 

The configuration file has also changed to reflect it and the `disk_encryption` is now inside the `disk_config` block. This change is backwards compatible though, so existing configuration files will still be parsed correctly. 