### PR TITLE
Fix disk encryption menu

### DIFF
--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -312,15 +312,15 @@ class GlobalMenu(AbstractMenu[None]):
 				output += tr('Mountpoint') + ': ' + str(disk_layout_conf.mountpoint)
 
 			if disk_layout_conf.lvm_config:
-				output += '{}: {}'.format(tr('LVM configuration type'), disk_layout_conf.lvm_config.config_type.display_msg())
+				output += '{}: {}'.format(tr('LVM configuration type'), disk_layout_conf.lvm_config.config_type.display_msg()) + '\n'
 
 			if disk_layout_conf.disk_encryption:
-				output += tr('Disk encryption') + ': ' + EncryptionType.type_to_text(disk_layout_conf.disk_encryption.encryption_type)
+				output += tr('Disk encryption') + ': ' + EncryptionType.type_to_text(disk_layout_conf.disk_encryption.encryption_type) + '\n'
 
 			if disk_layout_conf.btrfs_options:
 				btrfs_options = disk_layout_conf.btrfs_options
 				if btrfs_options.snapshot_config:
-					output += tr('Btrfs snapshot type: {}').format(btrfs_options.snapshot_config.snapshot_type.value)
+					output += tr('Btrfs snapshot type: {}').format(btrfs_options.snapshot_config.snapshot_type.value) + '\n'
 
 			return output
 

--- a/archinstall/lib/models/device_model.py
+++ b/archinstall/lib/models/device_model.py
@@ -1505,15 +1505,19 @@ class DiskEncryption:
 		return obj
 
 	@classmethod
-	def validate_enc(cls, disk_config: DiskLayoutConfiguration) -> bool:
+	def validate_enc(
+		cls,
+		modifications: list[DeviceModification],
+		lvm_config: LvmConfiguration | None = None,
+	) -> bool:
 		partitions = []
 
-		for mod in disk_config.device_modifications:
+		for mod in modifications:
 			for part in mod.partitions:
 				partitions.append(part)
 
 		if len(partitions) > 2:  # assume one boot and at least 2 additional
-			if disk_config.lvm_config:
+			if lvm_config:
 				return False
 
 		return True
@@ -1525,7 +1529,7 @@ class DiskEncryption:
 		disk_encryption: _DiskEncryptionSerialization,
 		password: Password | None = None,
 	) -> 'DiskEncryption | None':
-		if not cls.validate_enc(disk_config):
+		if not cls.validate_enc(disk_config.device_modifications, disk_config.lvm_config):
 			return None
 
 		if not password:


### PR DESCRIPTION
Followup fix for https://github.com/archlinux/archinstall/pull/3502 the menu entries some more updates with the move under the new submenu. 

I've tried reproducing the issue https://github.com/archlinux/archinstall/issues/3499 but I can't find what triggered it. However, with these changes all menu entries should be reset correctly now if partitioning or lvm config change. 