### PR TITLE
Enable mypy's show_traceback option in pyproject.toml

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -20,4 +20,4 @@ jobs:
             - run: python --version
             - run: mypy --version
             - name: run mypy
-              run: mypy --show-traceback --config-file pyproject.toml
+              run: mypy --config-file pyproject.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,6 @@ repos:
     hooks:
     - id: mypy
       args: [
-        '--show-traceback',
         '--config-file=pyproject.toml'
       ]
       fail_fast: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ enable_error_code = [
     "unimported-reveal",
     "unused-awaitable",
 ]
+show_traceback = true
 strict = true
 strict_bytes = true
 warn_unreachable = true


### PR DESCRIPTION
## PR Description:

This makes it easier to debug mypy crashes when running `mypy` in the project directory.

This is a follow-up to https://github.com/archlinux/archinstall/pull/3425.