### PR TITLE
Fix root partition device mapper name

### DIFF
--- a/archinstall/lib/models/device_model.py
+++ b/archinstall/lib/models/device_model.py
@@ -1010,6 +1010,8 @@ class PartitionModification:
 
 	@property
 	def mapper_name(self) -> str | None:
+		if self.is_root():
+			return 'root'
 		if self.is_home():
 			return 'home'
 		if self.dev_path:


### PR DESCRIPTION
Use the root device mapper name `root` as it appears in the [ArchWiki](https://wiki.archlinux.org/title/Dm-crypt/Encrypting_an_entire_system#LUKS_on_a_partition). With this change, the device comment column will correctly appear as `/dev/mapper/root` in the fstab file, as produced by `genfstab`.

Follow-up to #3516
