### PR TITLE
Change from grub-btrfs.service to grub-btrfsd.service

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -952,7 +952,7 @@ class Installer:
 
 			if bootloader and bootloader == Bootloader.Grub:
 				self.pacman.strap('grub-btrfs')
-				self.enable_service('grub-btrfs.service')
+				self.enable_service('grub-btrfsd.service')
 
 	def setup_swap(self, kind: str = 'zram') -> None:
 		if kind == 'zram':


### PR DESCRIPTION
Fix the bug of installation failure caused by incorrect service name

- This fix issue: IDK

## PR Description:

change "grub-btrfs.service" to "grub-btrfsd.service"
