### PR TITLE
Remove strict_bytes from the mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ enable_error_code = [
 ]
 show_traceback = true
 strict = true
-strict_bytes = true
 warn_unreachable = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
## PR Description:

In mypy 1.16.0, strict mode automatically enables strict_bytes checks: https://github.com/python/mypy/pull/19049