### PR TITLE
Remove some unnecessary None checks from desktop profile code

### DIFF
--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -66,8 +66,7 @@ class HyprlandProfile(XorgProfile):
 		).run()
 
 		if result.type_ == ResultType.Selection:
-			if result.item() is not None:
-				self.custom_settings['seat_access'] = result.get_value().value
+			self.custom_settings['seat_access'] = result.get_value().value
 
 	@override
 	def do_on_select(self) -> None:

--- a/archinstall/default_profiles/desktops/labwc.py
+++ b/archinstall/default_profiles/desktops/labwc.py
@@ -63,8 +63,7 @@ class LabwcProfile(XorgProfile):
 		).run()
 
 		if result.type_ == ResultType.Selection:
-			if result.item() is not None:
-				self.custom_settings['seat_access'] = result.get_value().value
+			self.custom_settings['seat_access'] = result.get_value().value
 
 	@override
 	def do_on_select(self) -> None:

--- a/archinstall/default_profiles/desktops/niri.py
+++ b/archinstall/default_profiles/desktops/niri.py
@@ -71,8 +71,7 @@ class NiriProfile(XorgProfile):
 		).run()
 
 		if result.type_ == ResultType.Selection:
-			if result.item() is not None:
-				self.custom_settings['seat_access'] = result.get_value().value
+			self.custom_settings['seat_access'] = result.get_value().value
 
 	@override
 	def do_on_select(self) -> None:

--- a/archinstall/default_profiles/desktops/sway.py
+++ b/archinstall/default_profiles/desktops/sway.py
@@ -73,8 +73,7 @@ class SwayProfile(XorgProfile):
 		).run()
 
 		if result.type_ == ResultType.Selection:
-			if result.item() is not None:
-				self.custom_settings['seat_access'] = result.get_value().value
+			self.custom_settings['seat_access'] = result.get_value().value
 
 	@override
 	def do_on_select(self) -> None:


### PR DESCRIPTION
## PR Description:

This commit fixes some warnings reported by Pyright's reportUnnecessaryComparison checker:

```
archinstall/archinstall/default_profiles/desktops/hyprland.py:69:7 - error: Condition will always evaluate to True since the types "MenuItem" and "None" have no overlap (reportUnnecessaryComparison)
archinstall/archinstall/default_profiles/desktops/labwc.py:66:7 - error: Condition will always evaluate to True since the types "MenuItem" and "None" have no overlap (reportUnnecessaryComparison)
archinstall/archinstall/default_profiles/desktops/niri.py:74:7 - error: Condition will always evaluate to True since the types "MenuItem" and "None" have no overlap (reportUnnecessaryComparison)
archinstall/archinstall/default_profiles/desktops/sway.py:76:7 - error: Condition will always evaluate to True since the types "MenuItem" and "None" have no overlap (reportUnnecessaryComparison)
```

## Tests and Checks
- [x] I have tested the code!