### PR TITLE
Remove return value check for Installer.minimal_installation

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -824,7 +824,7 @@ class Installer:
 		mkinitcpio: bool = True,
 		hostname: str | None = None,
 		locale_config: LocaleConfiguration | None = LocaleConfiguration.default(),
-	):
+	) -> None:
 		if self._disk_config.lvm_config:
 			lvm = 'lvm2'
 			self.add_additional_packages(lvm)

--- a/archinstall/scripts/minimal.py
+++ b/archinstall/scripts/minimal.py
@@ -31,25 +31,25 @@ def perform_installation(mountpoint: Path) -> None:
 	) as installation:
 		# Strap in the base system, add a boot loader and configure
 		# some other minor details as specified by this profile and user.
-		if installation.minimal_installation():
-			installation.set_hostname('minimal-arch')
-			installation.add_bootloader(Bootloader.Systemd)
+		installation.minimal_installation()
+		installation.set_hostname('minimal-arch')
+		installation.add_bootloader(Bootloader.Systemd)
 
-			network_config = config.network_config
+		network_config = config.network_config
 
-			if network_config:
-				network_config.install_network_config(
-					installation,
-					config.profile_config,
-				)
+		if network_config:
+			network_config.install_network_config(
+				installation,
+				config.profile_config,
+			)
 
-			installation.add_additional_packages(['nano', 'wget', 'git'])
+		installation.add_additional_packages(['nano', 'wget', 'git'])
 
-			profile_config = ProfileConfiguration(MinimalProfile())
-			profile_handler.install_profile_config(installation, profile_config)
+		profile_config = ProfileConfiguration(MinimalProfile())
+		profile_handler.install_profile_config(installation, profile_config)
 
-			user = User('devel', Password(plaintext='devel'), False)
-			installation.create_users(user)
+		user = User('devel', Password(plaintext='devel'), False)
+		installation.create_users(user)
 
 	# Once this is done, we output some useful information to the user
 	# And the installation is complete.


### PR DESCRIPTION
## PR Description:

The `minimal_installation` method always returns `None`.

## Tests and Checks
The script cannot be fully tested because of #3553.