### PR TITLE
Enable the bad-exit-annotation ruff rule and fix related warnings

### DIFF
--- a/archinstall/lib/boot.py
+++ b/archinstall/lib/boot.py
@@ -1,5 +1,6 @@
 import time
 from collections.abc import Iterator
+from types import TracebackType
 
 from .exceptions import SysCallError
 from .general import SysCommand, SysCommandWorker, locate_binary
@@ -47,13 +48,13 @@ class Boot:
 		storage['active_boot'] = self
 		return self
 
-	def __exit__(self, *args: str, **kwargs: str) -> None:
+	def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> None:
 		# b''.join(sys_command('sync')) # No need to, since the underlying fs() object will call sync.
 		# TODO: https://stackoverflow.com/questions/28157929/how-to-safely-handle-an-exception-inside-a-context-manager
 
-		if len(args) >= 2 and args[1]:
+		if exc_type is not None:
 			error(
-				args[1],
+				str(exc_value),
 				f'The error above occurred in a temporary boot-up of the installation {self.instance}',
 			)
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -124,9 +124,9 @@ class Installer:
 	def __enter__(self) -> 'Installer':
 		return self
 
-	def __exit__(self, exc_type: type[BaseException] | None, exc_val, exc_tb: TracebackType | None) -> bool:
+	def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> bool | None:
 		if exc_type is not None:
-			error(exc_val)
+			error(str(exc_value))
 
 			self.sync_log_to_install_medium()
 
@@ -134,7 +134,9 @@ class Installer:
 			# and then reboot, and a identical log file will be found in the ISO medium anyway.
 			Tui.print(str(tr('[!] A log file has been created here: {}').format(logger.path)))
 			Tui.print(tr('Please submit this issue (and file) to https://github.com/archlinux/archinstall/issues'))
-			raise exc_val
+
+			# Return None to propagate the exception
+			return None
 
 		if not (missing_steps := self.post_install_check()):
 			msg = f'Installation completed without any errors.\nLog files temporarily available at {logger.directory}.\nYou may reboot when ready.\n'

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -4,6 +4,7 @@ import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CalledProcessError
+from types import TracebackType
 
 from archinstall.lib.disk.utils import get_lsblk_info, umount
 
@@ -47,7 +48,7 @@ class Luks2:
 	def __enter__(self) -> None:
 		self.unlock(self.key_file)
 
-	def __exit__(self, *args: str, **kwargs: str) -> None:
+	def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> None:
 		if self.auto_unmount:
 			self.lock()
 

--- a/archinstall/lib/menu/abstract_menu.py
+++ b/archinstall/lib/menu/abstract_menu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import TracebackType
 from typing import Any, Self
 
 from archinstall.lib.translationhandler import tr
@@ -36,13 +37,15 @@ class AbstractMenu[ValueT]:
 		self.is_context_mgr = True
 		return self
 
-	def __exit__(self, *args: Any, **kwargs: Any) -> None:
+	def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> None:
 		# TODO: https://stackoverflow.com/questions/28157929/how-to-safely-handle-an-exception-inside-a-context-manager
 		# TODO: skip processing when it comes from a planified exit
-		if len(args) >= 2 and args[1]:
-			error(args[1])
+		if exc_type is not None:
+			error(str(exc_value))
 			Tui.print('Please submit this issue (and file) to https://github.com/archlinux/archinstall/issues')
-			raise args[1]
+
+			# Return None to propagate the exception
+			return None
 
 		self.sync_all_to_config()
 

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -49,7 +49,7 @@ class DownloadTimer:
 		self.start_time = time.time()
 		return self
 
-	def __exit__(self, typ: type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None) -> None:
+	def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> None:
 		if self.start_time:
 			time_delta = time.time() - self.start_time
 			signal.alarm(0)

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -1225,7 +1225,7 @@ class Tui:
 			tui = self.init()
 			Tui._t = tui
 
-	def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, tb: TracebackType | None) -> None:
+	def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> None:
 		self.stop()
 
 	@property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,6 @@ ignore = [
     "PLW1514",  # unspecified-encoding
     "PLW1641",  # eq-without-hash
     "PLW2901",  # redefined-loop-name
-    "PYI036",   # bad-exit-annotation
     "RUF005",   # collection-literal-concatenation
     "RUF015",   # unnecessary-iterable-allocation-for-first-element
     "RUF039",   # unraw-re-pattern


### PR DESCRIPTION
## PR Description:

This commit is a backwards compatible alternative to https://github.com/archlinux/archinstall/pull/3562.

## References:

### Typeshed definition for \_\_exit\_\_
https://github.com/python/typeshed/blob/8a6bfb06981a9bab7c74472f62d6132f501c4a0e/stdlib/contextlib.pyi#L52-L54

### \_\_exit\_\_ docs
> If an exception is supplied, and the method wishes to suppress the exception (i.e., prevent it from being propagated), it should return a true value. Otherwise, the exception will be processed normally upon exit from this method.

-- [Python docs](https://docs.python.org/3/reference/datamodel.html#object.__exit__)

## Tests and Checks
- [x] I have tested the code!