### PR TITLE
Honor the sort_items parameter on MenuItemGroup.from_enum

### DIFF
--- a/archinstall/tui/menu_item.py
+++ b/archinstall/tui/menu_item.py
@@ -127,7 +127,7 @@ class MenuItemGroup:
 		preset: Enum | None = None,
 	) -> 'MenuItemGroup':
 		items = [MenuItem(elem.value, value=elem) for elem in enum_cls]
-		group = MenuItemGroup(items, sort_items=False)
+		group = MenuItemGroup(items, sort_items=sort_items)
 
 		if preset is not None:
 			group.set_selected_by_value(preset)


### PR DESCRIPTION
## PR Description:
This code is only used for the Btrfs snapshot menu.  The menu items were already sorted, so the unused parameter didn't cause any UI issues.

## Tests and Checks
- [x] I have tested the code!