### PR TITLE
Mount partitions in minimal script before starting installation

### DIFF
--- a/archinstall/scripts/minimal.py
+++ b/archinstall/scripts/minimal.py
@@ -31,6 +31,7 @@ def perform_installation(mountpoint: Path) -> None:
 	) as installation:
 		# Strap in the base system, add a boot loader and configure
 		# some other minor details as specified by this profile and user.
+		installation.mount_ordered_layout()
 		installation.minimal_installation()
 		installation.set_hostname('minimal-arch')
 		installation.add_bootloader(Bootloader.Systemd)


### PR DESCRIPTION
FIxed minimal installation script based on @correctmost suggested fix https://github.com/archlinux/archinstall/issues/3553#issuecomment-2934568888