### PR TITLE
Added explicit drivers defined by the empty package linux-firmware

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -51,7 +51,7 @@ from .plugins import plugins
 from .storage import storage
 
 # Any package that the Installer() is responsible for (optional and the default ones)
-__packages__ = ['base', 'base-devel', 'linux-firmware', 'linux', 'linux-lts', 'linux-zen', 'linux-hardened']
+__packages__ = ['base', 'base-devel', 'linux-firmware-amdgpu', 'linux-firmware-atheros', 'linux-firmware-broadcom', 'linux-firmware-intel', 'linux-firmware-mediatek', 'linux-firmware-nvidia', 'linux-firmware-other', 'linux-firmware-radeon', 'linux-firmware-realtek', 'linux', 'linux-lts', 'linux-zen', 'linux-hardened']
 
 # Additional packages that are installed if the user is running the Live ISO with accessibility tools enabled
 __accessibility_packages__ = ['brltty', 'espeakup', 'alsa-utils']

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -161,7 +161,7 @@ def ask_additional_packages_to_install(
 	package_groups = PackageGroup.from_available_packages(packages)
 
 	# Additional packages (with some light weight error handling for invalid package names)
-	header = tr('Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed.') + '\n'
+	header = tr('Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed.') + '\n'
 	header += tr('Select any packages from the below list that should be installed additionally') + '\n'
 
 	# there are over 15k packages so this needs to be quick

--- a/archinstall/locales/ar/LC_MESSAGES/base.po
+++ b/archinstall/locales/ar/LC_MESSAGES/base.po
@@ -55,8 +55,8 @@ msgstr "اختر مُحمّل الإقلاع"
 msgid "Choose an audio server"
 msgstr "اختر خادِم صوتيات"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "فقط الحزم مثل base وbase-devel وlinux وlinux-firmware وefibootmgr و حِزم مِلف اختيارية سوف تُثَبَّت."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "فقط الحزم مثل base وbase-devel وlinux وlinux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other وefibootmgr و حِزم مِلف اختيارية سوف تُثَبَّت."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "إذا كنت ترغب في متصفح الويب ، مثل Firefox أو chromium، فيمكنك تحديده في موضِع الكتابة التالي."

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -46,7 +46,7 @@ msgid "Choose an audio server"
 msgstr ""
 
 msgid ""
-"Only packages such as base, base-devel, linux, linux-firmware, efibootmgr "
+"Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr "
 "and optional profile packages are installed."
 msgstr ""
 

--- a/archinstall/locales/ca/LC_MESSAGES/base.po
+++ b/archinstall/locales/ca/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Trieu un gestor d'arranc"
 msgid "Choose an audio server"
 msgstr "Trieu un servidor d'àudio"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Només s'instal·laran paquets com base, base-devel, linux, linux-firmware, efibootmgr i altres paquets de perfil opcionals."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Només s'instal·laran paquets com base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr i altres paquets de perfil opcionals."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Si desitgeu un navegador web, com ara firefox o chromium, ho podeu especificar al proper missatge."

--- a/archinstall/locales/cs/LC_MESSAGES/base.po
+++ b/archinstall/locales/cs/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Zvolte zavaděč"
 msgid "Choose an audio server"
 msgstr "Zvolte audio server"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Budou nainstalovány pouze balíčky jako base, base-devel, linux, linux-firmware, efibootmgr a volitelné balíčky profilu."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Budou nainstalovány pouze balíčky jako base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr a volitelné balíčky profilu."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Pokud si přejete nainstalovat webový prohlížeč, jako je například Firefox nebo Chromium, můžete jej zadat do následujícího pole."

--- a/archinstall/locales/de/LC_MESSAGES/base.po
+++ b/archinstall/locales/de/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Bitte wählen Sie einen Bootloader aus"
 msgid "Choose an audio server"
 msgstr "Bitte wählen Sie einen Audioserver aus"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Nur Pakete wie base, base-devel, linux, linux-firmware, efibootmgr und optionale Profilpakete werden installiert."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Nur Pakete wie base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr und optionale Profilpakete werden installiert."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Wenn Sie einen Webbrowser installieren möchten, wie z.B. Firefox oder Chromium, können Sie diese nun eingeben."

--- a/archinstall/locales/el/LC_MESSAGES/base.po
+++ b/archinstall/locales/el/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Επιλέξτε έναν bootloader"
 msgid "Choose an audio server"
 msgstr "Επιλέξτε έναν διακομιστή ήχου"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Εγκαθίστανται μόνο πακέτα όπως το base, base-devel, linux, linux-firmware, efibootmgr και προαιρετικά πακέτα προφίλ."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Εγκαθίστανται μόνο πακέτα όπως το base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr και προαιρετικά πακέτα προφίλ."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Εάν επιθυμείτε έναν περιηγητή διαδικτύου, όπως ο firefox ή ο chromium, πρέπει να το καθορίσετε στο επακόλουθο prompt."

--- a/archinstall/locales/en/LC_MESSAGES/base.po
+++ b/archinstall/locales/en/LC_MESSAGES/base.po
@@ -50,7 +50,7 @@ msgstr ""
 msgid "Choose an audio server"
 msgstr ""
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
 msgstr ""
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."

--- a/archinstall/locales/es/LC_MESSAGES/base.po
+++ b/archinstall/locales/es/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Elija un gestor de arranque"
 msgid "Choose an audio server"
 msgstr "Elija un servidor de audio"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Solo paquetes como base, base-devel, linux, linux-firmware, efibootmgr y paquetes opcionales de perfil se instalan."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Solo paquetes como base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr y paquetes opcionales de perfil se instalan."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Si desea un navegador web, como firefox o chromium, puede especificarlo en el siguiente mensaje."

--- a/archinstall/locales/et/LC_MESSAGES/base.po
+++ b/archinstall/locales/et/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Vali buudilaadija"
 msgid "Choose an audio server"
 msgstr "Vali audio server"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Paigaldatakse ainult sellised paketid nagu base, base-devel, linux, linux-firmware, efibootmgr ja valikulised profiilipaketid."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Paigaldatakse ainult sellised paketid nagu base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr ja valikulised profiilipaketid."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Kui soovite veebibrauserit, näiteks firefox või chromium, saate selle määrata järgmises viipas."

--- a/archinstall/locales/fi/LC_MESSAGES/base.po
+++ b/archinstall/locales/fi/LC_MESSAGES/base.po
@@ -51,8 +51,8 @@ msgstr "Valitse käynnistyslatain"
 msgid "Choose an audio server"
 msgstr "Valitse audiopalvelin"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Vain paketit, kuten base, base-devel, linux, linux-firmware, efibootmgr ja valinnaiset profiili-paketit, asennetaan."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Vain paketit, kuten base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr ja valinnaiset profiili-paketit, asennetaan."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Jos haluat selaimen, kuten firefox tai chromium, voit valita sen seuraavassa kohdassa."

--- a/archinstall/locales/fr/LC_MESSAGES/base.po
+++ b/archinstall/locales/fr/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Choisir un chargeur de démarrage"
 msgid "Choose an audio server"
 msgstr "Choisir un serveur audio"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Seuls les paquets tels que base, base-devel, linux, linux-firmware, efibootmgr et les paquets de profil optionnels sont installés."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Seuls les paquets tels que base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr et les paquets de profil optionnels sont installés."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Si vous désirez un navigateur Web, tel que firefox ou chrome, vous pouvez le spécifier dans l'invite suivante."

--- a/archinstall/locales/ga/LC_MESSAGES/base.po
+++ b/archinstall/locales/ga/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Roghnaigh lódálaí tosaithe"
 msgid "Choose an audio server"
 msgstr "Roghnaigh freastalaí fuaime"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Ní shuiteáiltear ach pacáistí cosúil le pacáistí bonn, base-devel, linux, linux-firmware, efibootmgr agus próifíl roghnach."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Ní shuiteáiltear ach pacáistí cosúil le pacáistí bonn, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr agus próifíl roghnach."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Más mian leat brabhsálaí gréasáin, mar firefox nó cróimiam, is féidir leat é a shonrú sa leid seo a leanas."

--- a/archinstall/locales/he/LC_MESSAGES/base.po
+++ b/archinstall/locales/he/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "נא לבחור מנהל טעינה"
 msgid "Choose an audio server"
 msgstr "נא לבחור שרת שמע"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "רק חבילות כגוןbase,‏ base-devel,‏ linux,‏ linux-firmware,‏ efibootmgr וחבילות פרופיל כרשות מותקנות."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "רק חבילות כגוןbase,‏ base-devel,‏ linux,‏ linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other,‏ efibootmgr וחבילות פרופיל כרשות מותקנות."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "כדי שיותקן דפדפן כגון firefox או chromium אפשר לציין זאת בבקשה הבאה."

--- a/archinstall/locales/hi/LC_MESSAGES/base.po
+++ b/archinstall/locales/hi/LC_MESSAGES/base.po
@@ -50,7 +50,7 @@ msgstr "एक bootloader चुनें"
 msgid "Choose an audio server"
 msgstr "एक audio server चुनें"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
 msgstr ""
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."

--- a/archinstall/locales/hu/LC_MESSAGES/base.po
+++ b/archinstall/locales/hu/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Válasszon ki egy rendszerbetöltőt"
 msgid "Choose an audio server"
 msgstr "Válasszon ki egy hangkiszolgálót"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Csak az olyan csomagok mint a base, base-devel, linux, linux-firmware, efibootmgr és a nem kötelező profilcsomagok lesznek telepítve."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Csak az olyan csomagok mint a base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr és a nem kötelező profilcsomagok lesznek telepítve."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Ha olyan böngészőre vágyik, mint például a Firefox vagy a Chromium, akkor azt a következő promptban adhatja meg."

--- a/archinstall/locales/id/LC_MESSAGES/base.po
+++ b/archinstall/locales/id/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Pilih bootloader"
 msgid "Choose an audio server"
 msgstr "Pilih server audio"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Hanya paket seperti base, base-devel, linux, linux-firmware, efibootmgr dan paket profil opsional yang diinstal."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Hanya paket seperti base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr dan paket profil opsional yang diinstal."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Jika Anda menginginkan web browser, seperti firefox atau chromium, Anda dapat menentukannya di prompt berikut."

--- a/archinstall/locales/it/LC_MESSAGES/base.po
+++ b/archinstall/locales/it/LC_MESSAGES/base.po
@@ -53,8 +53,8 @@ msgstr "Scegli un bootloader"
 msgid "Choose an audio server"
 msgstr "Scegli un server audio"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Vengono installati solo pacchetti come base, base-devel, linux, linux-firmware, efibootmgr e pacchetti di profilo opzionali."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Vengono installati solo pacchetti come base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr e pacchetti di profilo opzionali."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Se desideri un browser web, come firefox o chromium, puoi specificarlo nel seguente prompt."

--- a/archinstall/locales/ja/LC_MESSAGES/base.po
+++ b/archinstall/locales/ja/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "ブートローダーを選択"
 msgid "Choose an audio server"
 msgstr "オーディオサーバーを選択"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "base, base-devel, linux, linux-firmware, efibootmgr などのパッケージとオプションのプロファイルパッケージのみがインストールされます。"
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr などのパッケージとオプションのプロファイルパッケージのみがインストールされます。"
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "firefox や chromium などのウェブブラウザーをインストールする場合は、次のプロンプトで指定できます。"

--- a/archinstall/locales/ka/LC_MESSAGES/base.po
+++ b/archinstall/locales/ka/LC_MESSAGES/base.po
@@ -51,8 +51,8 @@ msgstr "აირჩიეთ ჩამტვირთავი"
 msgid "Choose an audio server"
 msgstr "აირჩიეთ აუდიოსერვერი"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "მოხდება მხოლოდ ისეთი პაკეტების დაყენება, როგორებიცაა base, base-devel, linux, linux-firmware, efibootmgr და არასავალდებულო პროფილის პაკეტი."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "მოხდება მხოლოდ ისეთი პაკეტების დაყენება, როგორებიცაა base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr და არასავალდებულო პროფილის პაკეტი."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "თუ გნებავთ ბრაუზერის, როგორებიცაა firefox ან chromium, ქონა, შემდეგი რამ უნდა მიუთითოთ."

--- a/archinstall/locales/ko/LC_MESSAGES/base.po
+++ b/archinstall/locales/ko/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "부트로더를 선택하세요"
 msgid "Choose an audio server"
 msgstr "오디오 서버를 선택하세요"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "base, base-devel, linux, linux-firmware, efibootmgr 및 선택적 프로파일 패키지와 같은 패키지만 설치됩니다."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr 및 선택적 프로파일 패키지와 같은 패키지만 설치됩니다."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "만약 파이어폭스나 크로미움같은 웹브라우저를 희망하실 경우 다음 프롬프트에서 지정하실 수 있습니다."

--- a/archinstall/locales/lt/LC_MESSAGES/base.po
+++ b/archinstall/locales/lt/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Išrinkite paleidyklė"
 msgid "Choose an audio server"
 msgstr "Išrinkite garso serverį"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Tiktai paketai tokie kaip: base, base-devel, linux, linux-firmware, efibootmgr ir neprivalomi paketai bus įdegtį."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Tiktai paketai tokie kaip: base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr ir neprivalomi paketai bus įdegtį."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr ""

--- a/archinstall/locales/nl/LC_MESSAGES/base.po
+++ b/archinstall/locales/nl/LC_MESSAGES/base.po
@@ -51,8 +51,8 @@ msgstr "Kies een opstartlader"
 msgid "Choose an audio server"
 msgstr "Kies een audioserver"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Er worden alleen basispakketten geïnstalleerd, zoals base, base-devel, linux, linux-firmware, efibootmgr en profielpakketten (optioneel)."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Er worden alleen basispakketten geïnstalleerd, zoals base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr en profielpakketten (optioneel)."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Als u een webbrowser wenst, zoals Firefox of Chromium, dan kunt u dit handmatig aangeven."

--- a/archinstall/locales/pl/LC_MESSAGES/base.po
+++ b/archinstall/locales/pl/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Wybierz program rozruchowy"
 msgid "Choose an audio server"
 msgstr "Wybierz serwer dźwięku"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Instalowane są tylko pakiety takie jak base, base-devel, linux, linux-firmware, efibootmgr i opcjonalne pakiety profili."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Instalowane są tylko pakiety takie jak base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr i opcjonalne pakiety profili."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Jeśli potrzebujesz przeglądarki internetowej, takiej jak firefox lub chromium, możesz ją określić w następującym oknie dialogowym."

--- a/archinstall/locales/pt/LC_MESSAGES/base.po
+++ b/archinstall/locales/pt/LC_MESSAGES/base.po
@@ -54,8 +54,8 @@ msgstr "Escolha um carregador de arranque"
 msgid "Choose an audio server"
 msgstr "Escolha um servidor de áudio"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Apenas pacotes como base, base-devel, linux, linux-firmware, efibootmgr e pacotes opcionais de perfil são instalados."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Apenas pacotes como base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr e pacotes opcionais de perfil são instalados."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Se quer um navegador web, como firefox ou chromium, deve especificá-lo na pergunta seguinte."

--- a/archinstall/locales/pt_BR/LC_MESSAGES/base.po
+++ b/archinstall/locales/pt_BR/LC_MESSAGES/base.po
@@ -60,8 +60,8 @@ msgstr "Escolha um bootloader"
 msgid "Choose an audio server"
 msgstr "Escolha um servidor de áudio"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Apenas pacotes como base, base-devel, linux, linux-firmware, efibootmgr e pacotes opcionais de perfil são instalados."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Apenas pacotes como base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr e pacotes opcionais de perfil são instalados."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Se deseja um navegador web, como firefox ou chromium, pode especificá-lo no próximo prompt."

--- a/archinstall/locales/ro/LC_MESSAGES/base.po
+++ b/archinstall/locales/ro/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Selectați un bootloader"
 msgid "Choose an audio server"
 msgstr "Selectați un server audio"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Doar pachetele precum base, base-devel, linux, linux-firmware, egibootmgr și cele opționale de profil sunt instalate."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Doar pachetele precum base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, egibootmgr și cele opționale de profil sunt instalate."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Dacă doriți un browser, precum firefox sau chromium, puteți să-l specificați în promptul următor."

--- a/archinstall/locales/ru/LC_MESSAGES/base.po
+++ b/archinstall/locales/ru/LC_MESSAGES/base.po
@@ -51,8 +51,8 @@ msgstr "Выберите загрузчик"
 msgid "Choose an audio server"
 msgstr "Выберите звуковой сервер"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Устанавливаются только такие пакеты, как base, base-devel, linux, linux-firmware, efibootmgr и дополнительные пакеты профиля."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Устанавливаются только такие пакеты, как base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr и дополнительные пакеты профиля."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Если вы хотите использовать веб-браузер, например, firefox или chromium, вы можете указать его в следующем запросе."

--- a/archinstall/locales/sv/LC_MESSAGES/base.po
+++ b/archinstall/locales/sv/LC_MESSAGES/base.po
@@ -51,8 +51,8 @@ msgstr "Välj en boot-loader"
 msgid "Choose an audio server"
 msgstr "Välj en ljud-server"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Enbart paket som base, base-devel, linux, linux-firmware, efibootmgr och självvalda paket är installerade."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Enbart paket som base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr och självvalda paket är installerade."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Om du önskar en webbläsare, exempelvis firefox eller chromium, bör du skriva in dom i följande fält."

--- a/archinstall/locales/ta/LC_MESSAGES/base.po
+++ b/archinstall/locales/ta/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "துவக்க ஏற்றியைத் தேர்ந்தெ�
 msgid "Choose an audio server"
 msgstr "ஆடியோ சர்வரை தேர்வு செய்யவும்"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "தொகுப்பு Base, base-devel, linux, linux-firmware, efibootmgr மற்றும் விருப்ப சுயவிவர தொகுப்புகள் போன்ற தொகுப்புகள் மட்டுமே நிறுவப்பட்டுள்ளன."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "தொகுப்பு Base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr மற்றும் விருப்ப சுயவிவர தொகுப்புகள் போன்ற தொகுப்புகள் மட்டுமே நிறுவப்பட்டுள்ளன."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "நீங்கள் பயர்பாக்ஸ் அல்லது குரோமியம் போன்ற இணைய உலாவியை விரும்பினால், அதை பின்வரும் வரியில் குறிப்பிடலாம்."

--- a/archinstall/locales/tr/LC_MESSAGES/base.po
+++ b/archinstall/locales/tr/LC_MESSAGES/base.po
@@ -51,8 +51,8 @@ msgstr "Bir ön yükleyici seç"
 msgid "Choose an audio server"
 msgstr "Bir ses sunucusu seç"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Yalnızca base, base-devel, linux, linux-firmware, efibootmgr ve isteğe bağlı profil paketleri gibi paketler yüklenir."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Yalnızca base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr ve isteğe bağlı profil paketleri gibi paketler yüklenir."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Firefox veya Chromium gibi bir web tarayıcısı isterseniz, sıradaki ekranda belirtebilirsiniz."

--- a/archinstall/locales/uk/LC_MESSAGES/base.po
+++ b/archinstall/locales/uk/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "Оберіть завантажувач"
 msgid "Choose an audio server"
 msgstr "Оберіть звуковий сервер"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Встановлюються лише такі пакети, як base, base-devel, linux, linux-firmware, efibootmgr і додаткові пакети профілів."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Встановлюються лише такі пакети, як base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr і додаткові пакети профілів."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Якщо вам потрібен веб-браузер, наприклад firefox або chromium, ви можете вказати його в наступному запиті."

--- a/archinstall/locales/ur/LC_MESSAGES/base.po
+++ b/archinstall/locales/ur/LC_MESSAGES/base.po
@@ -37,8 +37,8 @@ msgstr "Bootloader ka intkhab"
 msgid "Choose an audio server"
 msgstr "Audio server ka intkhab"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "Sirf packages jaisa ke'h base, base-devel, linux, linux-firmware, efibootmgr aur ikhti'ari profile packages hi install hein."
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "Sirf packages jaisa ke'h base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr aur ikhti'ari profile packages hi install hein."
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "Agar aap web browser chahtay hein, jaise firefox ya chromium, to aap foori taur par kar saktay hein."

--- a/archinstall/locales/zh-CN/LC_MESSAGES/base.po
+++ b/archinstall/locales/zh-CN/LC_MESSAGES/base.po
@@ -50,8 +50,8 @@ msgstr "选择引导加载程序"
 msgid "Choose an audio server"
 msgstr "请选择一个音频服务器（audio server）"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "仅安装基本软件包（base）、基本开发软件包（base-devel）、Linux 内核（linux）、Linux 固件（linux-firmware）、efibootmgr 和可选的配置文件软件包（profile packages）。"
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "仅安装基本软件包（base）、基本开发软件包（base-devel）、Linux 内核（linux）、Linux 固件（linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other）、efibootmgr 和可选的配置文件软件包（profile packages）。"
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "如果您需要一个网络浏览器，例如 firefox 或 chromium，您可以在下面的提示中指定它。"

--- a/archinstall/locales/zh-TW/LC_MESSAGES/base.po
+++ b/archinstall/locales/zh-TW/LC_MESSAGES/base.po
@@ -51,8 +51,8 @@ msgstr "選擇開機引導程式"
 msgid "Choose an audio server"
 msgstr "請選擇音效伺服器"
 
-msgid "Only packages such as base, base-devel, linux, linux-firmware, efibootmgr and optional profile packages are installed."
-msgstr "僅安裝基本套件，如 base、base-devel、linux、linux-firmware、efibootmgr 和選擇性的軟體設定套件包。"
+msgid "Only packages such as base, base-devel, linux, linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other, efibootmgr and optional profile packages are installed."
+msgstr "僅安裝基本套件，如 base、base-devel、linux、linux-firmware-amdgpu, linux-firmware-atheros, linux-firmware-broadcom, linux-firmware-intel, linux-firmware-mediatek, linux-firmware-nvidia, linux-firmware-other、efibootmgr 和選擇性的軟體設定套件包。"
 
 msgid "If you desire a web browser, such as firefox or chromium, you may specify it in the following prompt."
 msgstr "如果您需要網頁瀏覽器，例如 firefox 或 chromium，你可以在下面的提示字元中進行指定。"


### PR DESCRIPTION
As of [linux-firmware 20250613.12fe085f-5](https://archlinux.org/news/linux-firmware-2025061312fe085f-5-upgrade-requires-manual-intervention/), `linux-firmware` will become an empty package with dependencies pulling in different firmwares.

This allows us to have more fine grained control of which firmwares are installed by `archinstall`. This PR will add the default ones as of writing this.

In the future, we can detect and install only the required once perhaps. This adds a slight overhead in order to making sure any future additions/removals of package requirements in `linux-firmware` gets adopted.
