### PR TITLE
Added temporary hold on bootctl's --variables=BOOL usage, as it's notin systemd main yet

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1174,7 +1174,11 @@ class Installer:
 
 		# TODO: This is a temporary workaround to deal with https://github.com/archlinux/archinstall/pull/3396#issuecomment-2996862019
 		# the systemd_version check can be removed once `--variables=BOOL` is merged into systemd.
-		systemd_version = int(self.pacman.run('-Q systemd').trace_log.split(b' ')[1][:3].decode())
+		if pacman_q_systemd := self.pacman.run('-Q systemd').trace_log:
+			pacman_version = int(pacman_q_systemd.split(b' ')[1][:3].decode())
+		else:
+			pacman_version = 257 # This works as a safety workaround for this hot-fix
+
 		# Install the boot loader
 		try:
 			# Force EFI variables since bootctl detects arch-chroot

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1174,7 +1174,7 @@ class Installer:
 
 		# TODO: This is a temporary workaround to deal with https://github.com/archlinux/archinstall/pull/3396#issuecomment-2996862019
 		# the systemd_version check can be removed once `--variables=BOOL` is merged into systemd.
-		systemd_version = int(self.pacman.run("-Q systemd").trace_log.split(b" ")[1][:3].decode())
+		systemd_version = int(self.pacman.run('-Q systemd').trace_log.split(b' ')[1][:3].decode())
 		# Install the boot loader
 		try:
 			# Force EFI variables since bootctl detects arch-chroot

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1172,15 +1172,24 @@ class Installer:
 			bootctl_options.append(f'--esp-path={efi_partition.mountpoint}')
 			bootctl_options.append(f'--boot-path={boot_partition.mountpoint}')
 
+		# TODO: This is a temporary workaround to deal with https://github.com/archlinux/archinstall/pull/3396#issuecomment-2996862019
+		# the systemd_version check can be removed once `--variables=BOOL` is merged into systemd.
+		systemd_version = int(self.pacman.run("-Q systemd").trace_log.split(b" ")[1][:3].decode())
 		# Install the boot loader
 		try:
 			# Force EFI variables since bootctl detects arch-chroot
 			# as a container environemnt since v257 and skips them silently.
 			# https://github.com/systemd/systemd/issues/36174
-			SysCommand(f'arch-chroot {self.target} bootctl --variables=yes {" ".join(bootctl_options)} install')
+			if systemd_version >= 258:
+				SysCommand(f'arch-chroot {self.target} bootctl --variables=yes {" ".join(bootctl_options)} install')
+			else:
+				SysCommand(f'arch-chroot {self.target} bootctl {" ".join(bootctl_options)} install')
 		except SysCallError:
-			# Fallback, try creating the boot loader without touching the EFI variables
-			SysCommand(f'arch-chroot {self.target} bootctl --variables=no {" ".join(bootctl_options)} install')
+			if systemd_version >= 258:
+				# Fallback, try creating the boot loader without touching the EFI variables
+				SysCommand(f'arch-chroot {self.target} bootctl --variables=no {" ".join(bootctl_options)} install')
+			else:
+				SysCommand(f'arch-chroot {self.target} bootctl --no-variables {" ".join(bootctl_options)} install')
 
 		# Loader configuration is stored in ESP/loader:
 		# https://man.archlinux.org/man/loader.conf.5

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1175,9 +1175,9 @@ class Installer:
 		# TODO: This is a temporary workaround to deal with https://github.com/archlinux/archinstall/pull/3396#issuecomment-2996862019
 		# the systemd_version check can be removed once `--variables=BOOL` is merged into systemd.
 		if pacman_q_systemd := self.pacman.run('-Q systemd').trace_log:
-			pacman_version = int(pacman_q_systemd.split(b' ')[1][:3].decode())
+			systemd_version = int(pacman_q_systemd.split(b' ')[1][:3].decode())
 		else:
-			pacman_version = 257 # This works as a safety workaround for this hot-fix
+			systemd_version = 257 # This works as a safety workaround for this hot-fix
 
 		# Install the boot loader
 		try:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1177,7 +1177,7 @@ class Installer:
 		if pacman_q_systemd := self.pacman.run('-Q systemd').trace_log:
 			systemd_version = int(pacman_q_systemd.split(b' ')[1][:3].decode())
 		else:
-			systemd_version = 257 # This works as a safety workaround for this hot-fix
+			systemd_version = 257  # This works as a safety workaround for this hot-fix
 
 		# Install the boot loader
 		try:


### PR DESCRIPTION
This will deal with: https://github.com/archlinux/archinstall/pull/3396#issuecomment-2996862019

And once we're satisfied that it works, we can remove the check and revert to the above PR's original code.