### PR TITLE
Fix ruff format for local builds

### DIFF
--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -171,10 +171,7 @@ class Logger:
 			# Fallback to creating the log file in the current folder
 			logger._path = Path('./').absolute()
 
-			warn(
-				f'Not enough permission to place log file at {log_file},',
-				'creating it in {logger.path} instead'
-			)
+			warn(f'Not enough permission to place log file at {log_file}, creating it in {logger.path} instead')
 
 	def log(self, level: int, content: str) -> None:
 		self._check_permissions()


### PR DESCRIPTION
## PR Description:

`ruff format --diff` reports one difference on master:

```
$ ruff format --diff
--- archinstall/lib/output.py
+++ archinstall/lib/output.py
@@ -171,10 +171,7 @@
 			# Fallback to creating the log file in the current folder
 			logger._path = Path('./').absolute()
 
-			warn(
-				f'Not enough permission to place log file at {log_file},',
-				'creating it in {logger.path} instead'
-			)
+			warn(f'Not enough permission to place log file at {log_file},', 'creating it in {logger.path} instead')
 
 	def log(self, level: int, content: str) -> None:
 		self._check_permissions()

1 file would be reformatted, 130 files already formatted
```

The CI checks pass because `ruff check --select=COM812 --fix` is run before checking for differences: https://github.com/archlinux/archinstall/blob/9f110849e6dd72b2ee7990739159ed84cd072ffc/.github/workflows/ruff-format.yaml#L11-L12

I think the COM812 line can be removed now that the initial reformat has been performed.