### PR TITLE
Add interface to change LUKS iteration time

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -14,6 +14,7 @@ from ..exceptions import DiskError, SysCallError, UnknownFilesystemFormat
 from ..general import SysCommand, SysCommandWorker
 from ..luks import Luks2
 from ..models.device_model import (
+	DEFAULT_ITER_TIME,
 	BDevice,
 	BtrfsMountOption,
 	DeviceModification,
@@ -308,6 +309,7 @@ class DeviceHandler:
 		mapper_name: str | None,
 		enc_password: Password | None,
 		lock_after_create: bool = True,
+		iter_time: int = DEFAULT_ITER_TIME,
 	) -> Luks2:
 		luks_handler = Luks2(
 			dev_path,
@@ -315,7 +317,7 @@ class DeviceHandler:
 			password=enc_password,
 		)
 
-		key_file = luks_handler.encrypt()
+		key_file = luks_handler.encrypt(iter_time=iter_time)
 
 		self.udev_sync()
 
@@ -346,7 +348,7 @@ class DeviceHandler:
 			password=enc_conf.encryption_password,
 		)
 
-		key_file = luks_handler.encrypt()
+		key_file = luks_handler.encrypt(iter_time=enc_conf.iter_time)
 
 		self.udev_sync()
 

--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -256,8 +256,8 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 			return tr('LVM disk encryption with more than 2 partitions is currently not supported')
 
 		if enc_config:
-			enc_type = EncryptionType.type_to_text(enc_config.encryption_type)
-			output = tr('Encryption type') + f': {enc_type}\n'
+			enc_type = enc_config.encryption_type
+			output = tr('Encryption type') + f': {EncryptionType.type_to_text(enc_type)}\n'
 
 			if enc_config.encryption_password:
 				output += tr('Password') + f': {enc_config.encryption_password.hidden()}\n'

--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -3,6 +3,7 @@ from typing import override
 
 from archinstall.lib.disk.encryption_menu import DiskEncryptionMenu
 from archinstall.lib.models.device_model import (
+	DEFAULT_ITER_TIME,
 	BtrfsOptions,
 	DiskEncryption,
 	DiskLayoutConfiguration,
@@ -260,6 +261,9 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 
 			if enc_config.encryption_password:
 				output += tr('Password') + f': {enc_config.encryption_password.hidden()}\n'
+
+			if enc_type != EncryptionType.NoEncryption:
+				output += tr('Iteration time') + f': {enc_config.iter_time or DEFAULT_ITER_TIME}ms\n'
 
 			if enc_config.partitions:
 				output += f'Partitions: {len(enc_config.partitions)} selected\n'

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -398,7 +398,7 @@ def select_iteration_time(preset: int | None = None) -> int | None:
 			return tr('Please enter a valid number')
 
 	result = EditMenu(
-		tr('Iteration time (ms)'),
+		tr('Iteration time'),
 		header=header,
 		alignment=Alignment.CENTER,
 		allow_skip=True,

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -230,7 +230,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 	def _prev_iter_time(self) -> str | None:
 		iter_time = self._item_group.find_by_key('iter_time').value
 
-		if iter_time and iter_time != DEFAULT_ITER_TIME:
+		if iter_time:
 			return f'{tr("Iteration time")}: {iter_time}ms'
 
 		return None

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -67,7 +67,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 			),
 			MenuItem(
 				text=tr('Iteration time'),
-				action=lambda x: select_iteration_time(x),
+				action=select_iteration_time,
 				value=self._enc_config.iter_time,
 				dependencies=[self._check_dep_enc_type],
 				preview_action=self._preview,

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -163,7 +163,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		if (enc_pwd := self._prev_password()) is not None:
 			output += f'\n{enc_pwd}'
 
-		if (iter_time := self._prev_iter_time()) is not None:
+		if (enc_type := self._prev_type()) is not None and enc_type != EncryptionType.NoEncryption and (iter_time := self._prev_iter_time()) is not None:
 			output += f'\n{iter_time}'
 
 		if (fido_device := self._prev_hsm()) is not None:

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -163,7 +163,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		if (enc_pwd := self._prev_password()) is not None:
 			output += f'\n{enc_pwd}'
 
-		if (enc_type := self._prev_type()) is not None and enc_type != EncryptionType.NoEncryption and (iter_time := self._prev_iter_time()) is not None:
+		if (iter_time := self._prev_iter_time()) is not None:
 			output += f'\n{iter_time}'
 
 		if (fido_device := self._prev_hsm()) is not None:
@@ -229,8 +229,9 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 	def _prev_iter_time(self) -> str | None:
 		iter_time = self._item_group.find_by_key('iter_time').value
+		enc_type = self._item_group.find_by_key('encryption_type').value
 
-		if iter_time:
+		if iter_time and enc_type != EncryptionType.NoEncryption:
 			return f'{tr("Iteration time")}: {iter_time}ms'
 
 		return None

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -11,7 +11,7 @@ from archinstall.lib.models.device_model import (
 	PartitionModification,
 )
 from archinstall.lib.translationhandler import tr
-from archinstall.tui.curses_menu import SelectMenu
+from archinstall.tui.curses_menu import EditMenu, SelectMenu
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
 from archinstall.tui.result import ResultType
 from archinstall.tui.types import Alignment, FrameProperties
@@ -396,29 +396,21 @@ def select_iteration_time(preset: int | None = None) -> int | None:
 		except ValueError:
 			return tr('Please enter a valid number')
 
-	try:
-		from archinstall.tui.curses_menu import EditMenu
-		from archinstall.tui.result import ResultType
-		from archinstall.tui.types import Alignment
-		
-		result = EditMenu(
-			tr('Iteration time (ms)'),
-			header=header,
-			alignment=Alignment.CENTER,
-			allow_skip=True,
-			default_text=str(preset) if preset else str(DEFAULT_ITER_TIME),
-			validator=validate_iter_time,
-		).input()
-		
-		match result.type_:
-			case ResultType.Skip:
+	result = EditMenu(
+		tr('Iteration time (ms)'),
+		header=header,
+		alignment=Alignment.CENTER,
+		allow_skip=True,
+		default_text=str(preset) if preset else str(DEFAULT_ITER_TIME),
+		validator=validate_iter_time,
+	).input()
+	
+	match result.type_:
+		case ResultType.Skip:
+			return preset
+		case ResultType.Selection:
+			if not result.text():
 				return preset
-			case ResultType.Selection:
-				if not result.text():
-					return preset
-				return int(result.text())
-			case ResultType.Reset:
-				return None
-	except ImportError:
-		# Fallback for non-interactive mode
-		return preset or DEFAULT_ITER_TIME
+			return int(result.text())
+		case ResultType.Reset:
+			return None

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -384,8 +384,8 @@ def select_iteration_time(preset: int | None = None) -> int | None:
 
 	def validate_iter_time(value: str | None) -> str | None:
 		if not value:
-			return tr('Iteration time cannot be empty')
-		
+			return None
+
 		try:
 			iter_time = int(value)
 			if iter_time < 100:
@@ -404,7 +404,7 @@ def select_iteration_time(preset: int | None = None) -> int | None:
 		default_text=str(preset) if preset else str(DEFAULT_ITER_TIME),
 		validator=validate_iter_time,
 	).input()
-	
+
 	match result.type_:
 		case ResultType.Skip:
 			return preset

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -287,6 +287,7 @@ class FilesystemHandler:
 					vol.mapper_name,
 					enc_config.encryption_password,
 					lock_after_create,
+					iter_time=enc_config.iter_time,
 				)
 
 				enc_vols[vol] = luks_handler
@@ -317,6 +318,7 @@ class FilesystemHandler:
 						part_mod.mapper_name,
 						enc_config.encryption_password,
 						lock_after_create=lock_after_create,
+						iter_time=enc_config.iter_time,
 					)
 
 					enc_mods[part_mod] = luks_handler

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -61,6 +61,7 @@ def ask_hostname(preset: str | None = None) -> str | None:
 		alignment=Alignment.CENTER,
 		allow_skip=True,
 		default_text=preset,
+		validator=lambda x: x if len(x) > 0 else tr('Hostname cannot be empty'),
 	).input()
 
 	match result.type_:

--- a/archinstall/lib/interactions/general_conf.py
+++ b/archinstall/lib/interactions/general_conf.py
@@ -61,7 +61,6 @@ def ask_hostname(preset: str | None = None) -> str | None:
 		alignment=Alignment.CENTER,
 		allow_skip=True,
 		default_text=preset,
-		validator=lambda x: x if len(x) > 0 else tr('Hostname cannot be empty'),
 	).input()
 
 	match result.type_:

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -7,6 +7,7 @@ from subprocess import CalledProcessError
 from types import TracebackType
 
 from archinstall.lib.disk.utils import get_lsblk_info, umount
+from archinstall.lib.models.device_model import DEFAULT_ITER_TIME
 
 from .exceptions import DiskError, SysCallError
 from .general import SysCommand, SysCommandWorker, generate_password, run
@@ -76,7 +77,7 @@ class Luks2:
 		self,
 		key_size: int = 512,
 		hash_type: str = 'sha512',
-		iter_time: int = 10000,
+		iter_time: int = DEFAULT_ITER_TIME,
 		key_file: Path | None = None,
 	) -> Path | None:
 		debug(f'Luks2 encrypting: {self.luks_dev_path}')

--- a/archinstall/lib/models/device_model.py
+++ b/archinstall/lib/models/device_model.py
@@ -19,7 +19,7 @@ from ..models.users import Password
 from ..output import debug
 
 ENC_IDENTIFIER = 'ainst'
-
+DEFAULT_ITER_TIME = 10000
 
 class DiskLayoutType(Enum):
 	Default = 'default_layout'
@@ -1471,6 +1471,7 @@ class _DiskEncryptionSerialization(TypedDict):
 	partitions: list[str]
 	lvm_volumes: list[str]
 	hsm_device: NotRequired[_Fido2DeviceSerialization]
+	iter_time: NotRequired[int]
 
 
 @dataclass
@@ -1480,6 +1481,7 @@ class DiskEncryption:
 	partitions: list[PartitionModification] = field(default_factory=list)
 	lvm_volumes: list[LvmVolume] = field(default_factory=list)
 	hsm_device: Fido2Device | None = None
+	iter_time: int = DEFAULT_ITER_TIME
 
 	def __post_init__(self) -> None:
 		if self.encryption_type in [EncryptionType.Luks, EncryptionType.LvmOnLuks] and not self.partitions:
@@ -1503,6 +1505,9 @@ class DiskEncryption:
 
 		if self.hsm_device:
 			obj['hsm_device'] = self.hsm_device.json()
+
+		if self.iter_time != DEFAULT_ITER_TIME:  # Only include if not default
+			obj['iter_time'] = self.iter_time
 
 		return obj
 
@@ -1558,6 +1563,9 @@ class DiskEncryption:
 
 		if hsm := disk_encryption.get('hsm_device', None):
 			enc.hsm_device = Fido2Device.parse_arg(hsm)
+
+		if iter_time := disk_encryption.get('iter_time', None):
+			enc.iter_time = iter_time
 
 		return enc
 

--- a/archinstall/lib/models/device_model.py
+++ b/archinstall/lib/models/device_model.py
@@ -21,6 +21,7 @@ from ..output import debug
 ENC_IDENTIFIER = 'ainst'
 DEFAULT_ITER_TIME = 10000
 
+
 class DiskLayoutType(Enum):
 	Default = 'default_layout'
 	Manual = 'manual_partitioning'

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -959,6 +959,33 @@ msgstr ""
 msgid "Encryption type"
 msgstr ""
 
+msgid "Iteration time"
+msgstr ""
+
+msgid "Enter iteration time for LUKS encryption (in milliseconds)"
+msgstr ""
+
+msgid "Higher values increase security but slow down boot time"
+msgstr ""
+
+msgid "Default: 10000ms, Recommended range: 1000-60000"
+msgstr ""
+
+msgid "Iteration time (ms)"
+msgstr ""
+
+msgid "Iteration time cannot be empty"
+msgstr ""
+
+msgid "Iteration time must be at least 100ms"
+msgstr ""
+
+msgid "Iteration time must be at most 120000ms"
+msgstr ""
+
+msgid "Please enter a valid number"
+msgstr ""
+
 msgid "Partitions"
 msgstr ""
 

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Default: 10000ms, Recommended range: 1000-60000"
 msgstr ""
 
-msgid "Iteration time (ms)"
+msgid "Iteration time"
 msgstr ""
 
 msgid "Iteration time cannot be empty"

--- a/archinstall/tui/curses_menu.py
+++ b/archinstall/tui/curses_menu.py
@@ -566,7 +566,10 @@ class EditMenu(AbstractCurses[str]):
 				entry = ViewportEntry(err, 0, 0, STYLE.ERROR)
 				self._info_vp.update([entry], 0)
 				self._set_default_info = False
-				self._real_input = ''
+
+				if self._hide_input:
+					self._real_input = ''
+
 				return None
 
 		return text
@@ -586,7 +589,7 @@ class EditMenu(AbstractCurses[str]):
 			if self._set_default_info and self._info_vp:
 				self._info_vp.update([self._only_ascii_text], 0)
 
-			self._input_vp.edit(default_text=self._current_text)
+			self._input_vp.edit(default_text=self._real_input)
 
 	@override
 	def kickoff(self, win: curses.window) -> Result[str]:


### PR DESCRIPTION
## PR Description:
Added a user interface to configure the LUKS encryption iteration time through the interactive menu system.


### Why:
I found myself always changing this value after performing archinstall. 
because i can't bother to wait 10 seconds for my disk to decrypt. 
i would much prefer if its 1-3 seconds.
i know this can be a security issue for some people out there.
so i opted into adding an interface for users to change it instead.


### Changes:
- Added "Iteration time" option in the encryption menu
- Added input validation (100-120000ms range)
- Added translation support for the new interface (just the base.pot)
- Updated encryption configuration to pass iteration time to LUKS

### Affects:
- LUKS encryption on partitions
- LVM on LUKS encryption
- LUKS on LVM encryption

Default: 10000ms (10 seconds). 

**Note**: This PR follows the existing code patterns and maintains consistency with the current architecture. All changes are properly typed, documented, and include appropriate error handling. 

## Tests and Checks
- [x] I have tested the code!<br>
- [x] Tested everything default value(10000ms), seems to slowly decrypt (expected behavior)
- [x] Tested changing iteration time to 100ms, it seems to quickly decrypt
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
