### PR TITLE
Install inotify-tools along with grub-btrfs when using grub with btrfs config

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -956,6 +956,7 @@ class Installer:
 
 			if bootloader and bootloader == Bootloader.Grub:
 				self.pacman.strap('grub-btrfs')
+				self.pacman.strap('inotify-tools')
 				self.enable_service('grub-btrfsd.service')
 
 	def setup_swap(self, kind: str = 'zram') -> None:


### PR DESCRIPTION
- This fixes the first issue mentioned [here](https://github.com/archlinux/archinstall/issues/3655)

## PR Description:

archinstall currently only installs timeshift and grub-btrfs when btrfs+grub configurations are detected. But grub-btrfs require inotify-tools to work and the systemd service fails to start without it. This commit just adds the inotify-tools package.

```
if bootloader and bootloader == Bootloader.Grub:
				self.pacman.strap('grub-btrfs')
                                self.pacman.strap('inotify-tools')
				self.enable_service('grub-btrfsd.service')

```

## Tests and Checks
- [x] I have tested the code!<br>
