### PR TITLE
Fix boot detection to use PartitionFlag.BOOT instead of mountpoint

### DIFF
--- a/archinstall/lib/models/device_model.py
+++ b/archinstall/lib/models/device_model.py
@@ -967,9 +967,7 @@ class PartitionModification:
 		return PartitionFlag.ESP in self.flags
 
 	def is_boot(self) -> bool:
-		if self.mountpoint is not None:
-			return self.mountpoint == Path('/boot')
-		return False
+		return PartitionFlag.BOOT in self.flags
 
 	def is_root(self) -> bool:
 		if self.mountpoint is not None:


### PR DESCRIPTION
## PR Description:

This PR updates the boot partition detection logic to use `PartitionFlag.BOOT` instead of relying solely on the mountpoint being `/boot`. This resolves an issue introduced in #3336 where users attempting to mount the ESP to `/efi` encountered a "Boot partition not found" error during installation.

I tested the installation script in 3 different situations and everything worked as expected.