### PR TITLE
Remove unneeded None annotation from Bootloader.get_default

### DIFF
--- a/archinstall/lib/models/bootloader.py
+++ b/archinstall/lib/models/bootloader.py
@@ -31,7 +31,7 @@ class Bootloader(Enum):
 		return [e.value for e in Bootloader if e != Bootloader.NO_BOOTLOADER or arch_config_handler.args.skip_boot is True]
 
 	@classmethod
-	def get_default(cls) -> None | Bootloader:
+	def get_default(cls) -> Bootloader:
 		from ..args import arch_config_handler
 
 		if arch_config_handler.args.skip_boot:


### PR DESCRIPTION
## PR Description:

This commit fixes a warning reported by `ruff check --preview`:

```
archinstall/archinstall/lib/models/bootloader.py:34:26: RUF036 `None` not at the end of the type annotation.
```