### PR TITLE
Update documentation to also mention the --config-url option

### DIFF
--- a/docs/installing/guided.rst
+++ b/docs/installing/guided.rst
@@ -36,7 +36,12 @@ There are two configuration files, both are optional.
 ``--config``
 ------------
 
-This parameter takes a local or remote :code:`.json` file as argument and contains the overall configuration and menu answers for the guided installer.
+This parameter takes a local :code:`.json` file as argument and contains the overall configuration and menu answers for the guided installer.
+
+``--config-url``
+------------
+
+This parameter takes a remote :code:`.json` file as argument and contains the overall configuration and menu answers for the guided installer.
 
 .. note::
 

--- a/docs/installing/guided.rst
+++ b/docs/installing/guided.rst
@@ -52,7 +52,11 @@ Example usage
 
 .. code-block:: sh
 
-    archinstall --config https://domain.lan/config.json
+    archinstall --config config.json
+
+.. code-block:: sh
+
+    archinstall --config-url https://domain.lan/config.json
 
 The contents of :code:`https://domain.lan/config.json`:
 


### PR DESCRIPTION
# This fix updates the documentation

Using `archinstall` version `3.0.8`

## PR Description

I wanted to use a remote configuration file with `archinstall --config <url>` as described at https://archinstall.archlinux.page/installing/guided.html#example-usage

Unfortunately it failed.

By accident I took a look at the output of `archinstall --help` and discovered `archinstall --config-url`.

With `archinstall --config-url <url>` it works like expected.

This PR updates the documentation so others don't need to try the wrong option as I did. 😄 

## Tests and Checks
- Did not touch tests as I only updated the documentation
