### PR TITLE
Add support for rEFInd boot manager

### DIFF
--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -456,6 +456,10 @@ class GlobalMenu(AbstractMenu[None]):
 			if boot_partition.fs_type not in [FilesystemType.Fat12, FilesystemType.Fat16, FilesystemType.Fat32]:
 				return 'Limine does not support booting with a non-FAT boot partition'
 
+		elif bootloader == Bootloader.Refind:
+			if not SysInfo.has_uefi():
+				return 'rEFInd can only be used on UEFI systems'
+
 		return None
 
 	def _prev_install_invalid_config(self, item: MenuItem) -> str | None:

--- a/archinstall/lib/models/bootloader.py
+++ b/archinstall/lib/models/bootloader.py
@@ -13,10 +13,11 @@ class Bootloader(Enum):
 	Grub = 'Grub'
 	Efistub = 'Efistub'
 	Limine = 'Limine'
+	Refind = 'rEFInd'
 
 	def has_uki_support(self) -> bool:
 		match self:
-			case Bootloader.Efistub | Bootloader.Limine | Bootloader.Systemd:
+			case Bootloader.Efistub | Bootloader.Limine | Bootloader.Systemd | Bootloader.Refind:
 				return True
 			case _:
 				return False


### PR DESCRIPTION
This fixes #1951.

## PR Description:

This PR simply adds support for rEFInd boot manager. I've checked all the places where the boot managers are called to make sure I didn't miss anything.
I've also followed the [Arch Wiki page about rEFInd](https://wiki.archlinux.org/title/REFInd) to make sure I made the installation function correct.
Before accepting the PR, I'd like an opinion about a small issue I noticed. I didn't know this but per the Arch Wiki, [rEFInd is supposed to use the distro logo](https://wiki.archlinux.org/title/REFInd#Not_using_the_distribution_logo) but after the installation is finished, it uses the Tux logo. After checking the partitions, it's as it says there, `the root partition is of type Linux x86-64 root (/) instead of Linux filesystem`. But the installation guide suggests using `Linux x86-64 root (/)`. The Wiki also shows two other fixes, but I don't know if the label can be changed in the rEFInd installation step and copying the distro image seems easy, tho I don't know if it's the best solution
Is this and issue that can be fixed?

Just a note for the future, I'd also like to include [refind-btrfs](https://github.com/Venom1991/refind-btrfs), like grub includes [grub-btrfs](https://github.com/Antynea/grub-btrfs), to show BTRFS snapshots as boot options, but refind-btrfs isn't in the extra repository.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
