### PR TITLE
Fix a type annotation for list_available_packages

### DIFF
--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -127,7 +127,7 @@ def check_package_upgrade(package: str) -> str | None:
 
 @lru_cache
 def list_available_packages(
-	repositories: tuple[Repository],
+	repositories: tuple[Repository, ...],
 ) -> dict[str, AvailablePackage]:
 	"""
 	Returns a list of all available packages in the database


### PR DESCRIPTION
## PR Description:

The `repositories` parameter is a variable-length tuple instead of a one-element tuple.

mypy will start to flag these errors if https://github.com/python/mypy/pull/19432 is merged.