### PR TITLE
Fix parsing of systemd package version

### DIFF
--- a/archinstall/lib/models/packages.py
+++ b/archinstall/lib/models/packages.py
@@ -103,27 +103,12 @@ class PackageSearch:
 
 class LocalPackage(BaseModel):
 	name: str
-	repository: str
 	version: str
 	description: str
 	architecture: str
 	url: str
 	licenses: str
 	groups: str
-	depends_on: str
-	optional_deps: str
-	required_by: str
-	optional_for: str
-	conflicts_with: str
-	replaces: str
-	installed_size: str
-	packager: str
-	build_date: str
-	install_date: str
-	install_reason: str
-	install_script: str
-	validated_by: str
-	provides: str
 
 	@override
 	def __eq__(self, other: object) -> bool:

--- a/archinstall/lib/packages/packages.py
+++ b/archinstall/lib/packages/packages.py
@@ -106,7 +106,10 @@ def validate_package_list(packages: list[str]) -> tuple[list[str], list[str]]:
 
 def installed_package(package: str) -> LocalPackage | None:
 	try:
-		package_info = Pacman.run(f'-Q --info {package}').decode().split('\n')
+		package_info = []
+		for line in Pacman.run(f'-Q --info {package}'):
+			package_info.append(line.decode().strip())
+
 		return _parse_package_output(package_info, LocalPackage)
 	except SysCallError:
 		pass


### PR DESCRIPTION
Fixes #3729 

* Parse the pacman output as dataclass
* Handle edge case where systemd version is something like `257.1-0` as that is not a int