### PR TITLE
Disable btrfs snapshots when no subvolumes defined

### DIFF
--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -118,7 +118,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 		disk_layout_conf: DiskLayoutConfiguration | None = self._menu_item_group.find_by_key('disk_config').value
 
 		if disk_layout_conf:
-			return disk_layout_conf.is_default_btrfs()
+			return disk_layout_conf.has_default_btrfs_vols()
 
 		return False
 

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -193,19 +193,20 @@ class DiskLayoutConfiguration:
 		if (enc_config := disk_config.get('disk_encryption', None)) is not None:
 			config.disk_encryption = DiskEncryption.parse_arg(config, enc_config, enc_password)
 
-		if config.is_default_btrfs():
+		if config.has_default_btrfs_vols():
 			if (btrfs_arg := disk_config.get('btrfs_options', None)) is not None:
 				config.btrfs_options = BtrfsOptions.parse_arg(btrfs_arg)
 
 		return config
 
-	def is_default_btrfs(self) -> bool:
+	def has_default_btrfs_vols(self) -> bool:
 		if self.config_type == DiskLayoutType.Default:
 			for mod in self.device_modifications:
 				for part in mod.partitions:
 					if part.is_create_or_modify():
 						if part.fs_type == FilesystemType.Btrfs:
-							return True
+							if len(part.btrfs_subvols) > 0:
+								return True
 
 		return False
 

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -150,7 +150,7 @@ def perform_installation(mountpoint: Path) -> None:
 		if servies := config.services:
 			installation.enable_service(servies)
 
-		if disk_config.is_default_btrfs():
+		if disk_config.has_default_btrfs_vols():
 			btrfs_options = disk_config.btrfs_options
 			snapshot_config = btrfs_options.snapshot_config if btrfs_options else None
 			snapshot_type = snapshot_config.snapshot_type if snapshot_config else None


### PR DESCRIPTION
Fixes #https://github.com/archlinux/archinstall/issues/3700