### PR TITLE
Remove beta label from LVM

### DIFF
--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -70,7 +70,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 				key='disk_config',
 			),
 			MenuItem(
-				text='LVM (BETA)',
+				text='LVM',
 				action=self._select_lvm_config,
 				value=self._disk_menu_config.lvm_config,
 				preview_action=self._prev_lvm_config,


### PR DESCRIPTION
I think this has been soaking long enough to remove the `(Beta)` from the LVM menu entry