### PR TITLE
gracefully return "undefined" if DMI is not in sysfs

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -239,7 +239,7 @@ class SysInfo:
 		return _sys_info.cpu_info.get('model name', None)
 
 	@staticmethod
-	def sys_vendor() -> str:
+	def sys_vendor() -> str | None:
 		try:
 			with open('/sys/devices/virtual/dmi/id/sys_vendor') as vendor:
 				return vendor.read().strip()
@@ -247,7 +247,7 @@ class SysInfo:
 			return None
 
 	@staticmethod
-	def product_name() -> str:
+	def product_name() -> str | None:
 		try:
 			with open('/sys/devices/virtual/dmi/id/product_name') as product:
 				return product.read().strip()

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -244,7 +244,7 @@ class SysInfo:
 			with open('/sys/devices/virtual/dmi/id/sys_vendor') as vendor:
 				return vendor.read().strip()
 		except FileNotFoundError:
-			return "undefined"
+			return None
 
 	@staticmethod
 	def product_name() -> str:
@@ -252,7 +252,7 @@ class SysInfo:
 			with open('/sys/devices/virtual/dmi/id/product_name') as product:
 				return product.read().strip()
 		except FileNotFoundError:
-			return "undefined"
+			return None
 
 	@staticmethod
 	def mem_available() -> int:

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -240,13 +240,19 @@ class SysInfo:
 
 	@staticmethod
 	def sys_vendor() -> str:
-		with open('/sys/devices/virtual/dmi/id/sys_vendor') as vendor:
-			return vendor.read().strip()
+		try:
+			with open('/sys/devices/virtual/dmi/id/sys_vendor') as vendor:
+				return vendor.read().strip()
+		except FileNotFoundError:
+			return "undefined"
 
 	@staticmethod
 	def product_name() -> str:
-		with open('/sys/devices/virtual/dmi/id/product_name') as product:
-			return product.read().strip()
+		try:
+			with open('/sys/devices/virtual/dmi/id/product_name') as product:
+				return product.read().strip()
+		except FileNotFoundError:
+			return "undefined"
 
 	@staticmethod
 	def mem_available() -> int:


### PR DESCRIPTION
- This (should) fix issue: #3770

## PR Description:

Wraps access to the virtual DMI device in a try/except statement to not crash if it doesn't exist.

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
