### PR TITLE
quick fix to run archinstall and enable systemd services

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -667,7 +667,7 @@ class Installer:
 			info(f'Enabling service {service}')
 
 			try:
-				self.arch_chroot(f'systemctl enable {service}')
+				SysCommand(f'systemctl --root={self.target} enable {service}')
 			except SysCallError as err:
 				raise ServiceException(f'Unable to start service {service}: {err}')
 


### PR DESCRIPTION
- This fix issue: #3800

## PR Description:

Just inserted a direct call to SysCommand instead of self.arch_chroot, with the flag --root={self.target}.
This fixed the issue, at least for me.

## Tests and Checks
- [ X ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
