### PR TITLE
Do not install Btrfs module and binary in mkinitcpio

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -802,10 +802,6 @@ class Installer:
 	) -> None:
 		if (pkg := fs_type.installation_pkg) is not None:
 			self._base_packages.append(pkg)
-		if (module := fs_type.installation_module) is not None:
-			self._modules.append(module)
-		if (binary := fs_type.installation_binary) is not None:
-			self._binaries.append(binary)
 
 		# https://github.com/archlinux/archinstall/issues/1837
 		if fs_type.fs_type_mount == 'btrfs':

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -823,18 +823,6 @@ class FilesystemType(Enum):
 				return None
 
 	@property
-	def installation_module(self) -> str | None:
-		match self:
-			case _:
-				return None
-
-	@property
-	def installation_binary(self) -> str | None:
-		match self:
-			case _:
-				return None
-
-	@property
 	def installation_hooks(self) -> str | None:
 		match self:
 			case FilesystemType.Btrfs:


### PR DESCRIPTION
This is what btrfs hook already does.

- This fix issue: None <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

This is what btrfs hook from btrfs-progs already does: https://gitlab.archlinux.org/archlinux/packaging/packages/btrfs-progs/-/blob/main/initcpio-install-btrfs

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
