### PR TITLE
Do not re-order amdgpu and radeon modules in mkinitcpio

### DIFF
--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -228,13 +228,6 @@ class ProfileHandler:
 			headers = [f'{kernel}-headers' for kernel in install_session.kernels]
 			# Fixes https://github.com/archlinux/archinstall/issues/585
 			install_session.add_additional_packages(headers)
-		elif driver in [GfxDriver.AllOpenSource, GfxDriver.AmdOpenSource]:
-			# The order of these two are important if amdgpu is installed #808
-			install_session.remove_mod('amdgpu')
-			install_session.remove_mod('radeon')
-
-			install_session.append_mod('amdgpu')
-			install_session.append_mod('radeon')
 
 		driver_pkgs = driver.gfx_packages()
 		pkg_names = [p.value for p in driver_pkgs]


### PR DESCRIPTION
This is not necessary as kms hook for mkinitcpio already takes care of adding amdgpu and radeon modules.

- This fix issue: None <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

Relevant issue (https://github.com/archlinux/archinstall/issues/808) was created in 2021, but in 2022 mkinitcpio had added `kms` hook (https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/7bfe4861eacb3bf6cb70d9a17a0262542733a8ed), which already takes care of adding amdgpu and radeon modules and it used by default.

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
