### PR TITLE
Upgrade Pylint to 4.0.0

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -14,7 +14,7 @@ jobs:
                 pacman --noconfirm -Syyu
                 pacman --noconfirm -Sy python-pip python-pyparted pkgconfig gcc
             - run: pip install --break-system-packages --upgrade pip
-            - name: Install Pylint and Pylint plug-ins
+            - name: Install Pylint
               run: pip install --break-system-packages .[dev]
             - run: python --version
             - run: pylint --version

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -43,7 +43,6 @@ makedepends=(
   'python-wheel'
   'python-sphinx_rtd_theme'
   'python-pylint'
-  'python-pylint-pydantic'
   'ruff'
 )
 optdepends=(

--- a/archinstall/lib/models/users.py
+++ b/archinstall/lib/models/users.py
@@ -45,6 +45,8 @@ class PasswordStrength(Enum):
 		symbol = any(not character.isalnum() for character in password)
 		return cls._check_password_strength(digit, upper, lower, symbol, len(password))
 
+	# TODO: Remove the disable line when https://github.com/pylint-dev/pylint/issues/10647 is fixed
+	# pylint: disable=bare-name-capture-pattern
 	@classmethod
 	def _check_password_strength(
 		cls,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ dev = [
     "flake8==7.3.0",
     "pre-commit==4.3.0",
     "ruff==0.14.0",
-    "pylint==3.3.9",
-    "pylint-pydantic==0.3.5",
+    "pylint==4.0.0",
     "pytest==8.4.2",
 ]
 doc = ["sphinx"]
@@ -137,7 +136,6 @@ ignore-paths = [
     "^build/",
     "^docs/",
 ]
-load-plugins = ["pylint_pydantic"]
 persistent = false
 py-version = "3.12"
 recursive = true


### PR DESCRIPTION
## PR Description:

This commit also removes the pylint-pydantic plug-in, which is not yet compatible with Pylint v4.

Related Pylint bug report:
- https://github.com/pylint-dev/pylint/issues/10647