### PR TITLE
Skip bootloader config check when 'No Bootloader' is selected as bootloader

### DIFF
--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -425,7 +425,8 @@ class GlobalMenu(AbstractMenu[None]):
 
 		bootloader = self._item_group.find_by_key('bootloader').value
 
-		if bootloader == Bootloader.NO_BOOTLOADER: return None
+		if bootloader == Bootloader.NO_BOOTLOADER:
+			return None
 
 		if disk_config := self._item_group.find_by_key('disk_config').value:
 			for layout in disk_config.device_modifications:


### PR DESCRIPTION
## PR Description:

When using `archinstall --skip-boot`  (no bootloader), the installation can get blocked with a message like `Root partition not found` in the TUI for certain setups such as
- pre_mounted_config to `/mnt` with a setup like this
<details>
<summary>disk layout like this caused it for me</summary>

```
root@archiso ~ # lsblk
NAME              MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
loop0               7:0    0 957.1M  1 loop  /run/archiso/airootfs
sda                 8:0    0    20G  0 disk  
├─sda1              8:1    0     1M  0 part  
├─sda2              8:2    0   550M  0 part  /mnt/efi
└─sda3              8:3    0  19.5G  0 part  
  └─cryptroot     253:0    0  19.4G  0 crypt 
    ├─system-boot 253:1    0     1G  0 lvm   /mnt/boot
    ├─system-swap 253:2    0     1G  0 lvm   [SWAP]
    └─system-pool 253:3    0  17.4G  0 lvm   /mnt/home
                                             /mnt/var/tmp
                                             /mnt/var/spool
                                             /mnt/var/log
                                             /mnt/var/cache
                                             /mnt/srv
                                             /mnt/root
                                             /mnt/.snapshots
                                             /mnt
```

Where `system-pool` is a BTRFS pool with these mount points

```
[root@archiso /]# findmnt
TARGET                        SOURCE                                 FSTYPE   OPTIONS
/                             /dev/mapper/system-pool[/@]            btrfs    rw,relatime,space_cache=v2,subvolid=257,subvol=/@
├─/.snapshots                 /dev/mapper/system-pool[/snapshots/@]  btrfs    rw,noatime,space_cache=v2,subvolid=256,subvol=/snapshots/@
├─/efi                        /dev/sda2                              vfat     rw,relatime,fmask=0777,dmask=0777,codepage=437,iocharset=iso8859-1,sho
├─/boot                       /dev/mapper/system-boot                ext4     rw,relatime
├─/root                       /dev/mapper/system-pool[/root]         btrfs    rw,relatime,space_cache=v2,subvolid=258,subvol=/root
├─/srv                        /dev/mapper/system-pool[/srv]          btrfs    rw,relatime,space_cache=v2,subvolid=259,subvol=/srv
├─/var/cache                  /dev/mapper/system-pool[/var/cache]    btrfs    rw,noatime,space_cache=v2,subvolid=260,subvol=/var/cache
├─/var/log                    /dev/mapper/system-pool[/var/log]      btrfs    rw,noatime,space_cache=v2,subvolid=261,subvol=/var/log
├─/var/spool                  /dev/mapper/system-pool[/var/spool]    btrfs    rw,noatime,space_cache=v2,subvolid=262,subvol=/var/spool
├─/var/tmp                    /dev/mapper/system-pool[/var/tmp]      btrfs    rw,nosuid,nodev,noexec,noatime,space_cache=v2,subvolid=263,subvol=/var
├─/home                       /dev/mapper/system-pool[/home]         btrfs    rw,noatime,space_cache=v2,subvolid=264,subvol=/home
├─/tmp                        tmpfs                                  tmpfs    rw,nosuid,nodev,noexec,relatime,mode=1700,inode64
│ └─/tmp                      tmp                                    tmpfs    rw,nosuid,nodev,inode64
├─/etc/resolv.conf            run[/systemd/resolve/stub-resolv.conf] tmpfs    rw,nosuid,nodev,relatime,mode=755,inode64
├─/proc                       proc                                   proc     rw,nosuid,nodev,noexec,relatime
├─/sys                        sys                                    sysfs    ro,nosuid,nodev,noexec,relatime
│ └─/sys/firmware/efi/efivars efivarfs                               efivarfs rw,nosuid,nodev,noexec,relatime
├─/dev                        udev                                   devtmpfs rw,nosuid,relatime,size=3933220k,nr_inodes=983305,mode=755,inode64
│ ├─/dev/pts                  devpts                                 devpts   rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000
│ └─/dev/shm                  shm                                    tmpfs    rw,nosuid,nodev,relatime,inode64
└─/run                        run                                    tmpfs    rw,nosuid,nodev,relatime,mode=755,inode64
```

</details>

The message is caused by `archinstall.lib.global_menu._validate_bootloader` still performing validity checks for the bootloader configuration, even when no bootloader shall be installed. This PR simply skips the check, if no bootloader shall be installed.

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
