### PR TITLE
Fix 3863

### DIFF
--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -338,7 +338,7 @@ class FilesystemHandler:
 	def _final_warning(self) -> bool:
 		# Issue a final warning before we continue with something un-revertable.
 		# We mention the drive one last time, and count from 5 to 0.
-		out = tr('Starting device operations in ')
+		out = tr('Starting device modifications in ')
 		Tui.print(out, row=0, endl='', clear_screen=True)
 
 		try:


### PR DESCRIPTION
Fixes #3863 and #2776 

Change the final warning message from 
```Formatting in 1...2...3```

to something more generic as it's difficult to determine what each configuration may entail 

```Starting device modifications in 1...2...3```