### PR TITLE
replace 'leafpad' with 'l3afpad'

### DIFF
--- a/archinstall/default_profiles/desktops/lxqt.py
+++ b/archinstall/default_profiles/desktops/lxqt.py
@@ -20,7 +20,7 @@ class LxqtProfile(XorgProfile):
 			'oxygen-icons',
 			'xdg-utils',
 			'ttf-freefont',
-			'leafpad',
+			'l3afpad',
 			'slock',
 		]
 


### PR DESCRIPTION
fixes issue #3886 

`leafpad` is no longer in the Arch package repository, so the LXQt profile breaks midway through installation.

this PR simply replaces it with `l3afpad`, which seems like the most obvious replacement, but maybe another one would be better? (`gedit`, `mousepad`, `pluma`, `featherpad`, etc.)