### PR TITLE
Add missing --script option in documentation for pre-programmed scripts

### DIFF
--- a/docs/installing/guided.rst
+++ b/docs/installing/guided.rst
@@ -7,7 +7,7 @@ Archinstall ships with a pre-programmed `Guided Installer`_ guiding you through 
 
 .. note::
 
-   Other pre-programmed scripts can be invoked by executing :code:`archinstall <script>` *(without .py)*. To see a complete list of scripts, run :code:`archinstall --script list` or check the source code `scripts`_ directory.
+   Other pre-programmed scripts can be invoked by executing :code:`archinstall --script <script>` *(without .py)*. To see a complete list of scripts, run :code:`archinstall --script list` or check the source code `scripts`_ directory.
 
 .. note::
 


### PR DESCRIPTION
## PR Description:

This fixes a small inconsistency in the guided installation docs, which does not mention the `--script` option for invoking a given script.

## Tests and Checks

I ran `make html` inside the `docs` directory and inspected the resulting output by pointing Firefox to `archinstall/docs/_build/html/installing/guided.html`. Some warnings were emitted as part of the build, but this did not seem to affect the output:

```console
> make html
Running Sphinx v8.2.3
loading translations [en]... done
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 12 source files that are out of date
updating environment: [new config] 12 added, 0 changed, 0 removed
reading sources... [100%] installing/python
WARNING: autodoc: failed to import function 'Installer' from module 'archinstall'; the module executes module level statement and it might call sys.exit(). [autodoc.import_object]
/path/to/archinstall/docs/help/known_issues.rst:23: WARNING: Title underline too short.

Waiting for Arch Linux keyring sync (archlinux-keyring-wkd-sync) to complete. `#2679`_
------------------------------ [docutils]
/path/to/archinstall/docs/help/known_issues.rst:23: WARNING: Title underline too short.

Waiting for Arch Linux keyring sync (archlinux-keyring-wkd-sync) to complete. `#2679`_
------------------------------ [docutils]
/path/to/archinstall/docs/installing/guided.rst:42: WARNING: Title underline too short.

``--config-url``
------------ [docutils]
/path/to/archinstall/docs/installing/guided.rst:42: WARNING: Title underline too short.

``--config-url``
------------ [docutils]
/path/to/archinstall/docs/installing/guided.rst:294: ERROR: Content block expected for the "note" directive; none found. [docutils]
looking for now-outdated files... none found
pickling environment... done
checking consistency... /path/to/archinstall/docs/cli_parameters/config/custom_commands.rst: WARNING: document isn't included in any toctree [toc.not_included]
/path/to/archinstall/docs/cli_parameters/config/disk_config.rst: WARNING: document isn't included in any toctree [toc.not_included]
/path/to/archinstall/docs/cli_parameters/config/disk_encryption.rst: WARNING: document isn't included in any toctree [toc.not_included]
done
preparing documents... done
copying assets...
copying static files...
Writing evaluated template result to /path/to/archinstall/docs/_build/html/_static/basic.css
Writing evaluated template result to /path/to/archinstall/docs/_build/html/_static/documentation_options.js
Writing evaluated template result to /path/to/archinstall/docs/_build/html/_static/language_data.js
Writing evaluated template result to /path/to/archinstall/docs/_build/html/_static/js/versions.js
copying static files: done
copying extra files...
copying extra files: done
copying assets: done
writing output... [100%] installing/python
generating indices... genindex done
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 9 warnings.

The HTML pages are in _build/html.
```