### PR TITLE
Fixed mkinitcpio.conf some times containing a trailing 'o"' causing syntax issues

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -779,6 +779,7 @@ class Installer:
 
 			content = re.sub('\nHOOKS=(.*)', f'\nHOOKS=({" ".join(self._hooks)})', content)
 			mkinit.seek(0)
+			mkinit.truncate()
 			mkinit.write(content)
 
 		try:


### PR DESCRIPTION
Fixes an issue where re-writing a smaller mkinitcpio.conf than previously existed, made the `#MODULES_DECOMPRESS="no"` part at the end can become a trailing `o"` causing syntax issues.

- This fix issue: #3901

