### PR TITLE
Fix plural form in device selection message

### DIFF
--- a/archinstall/locales/de/LC_MESSAGES/base.po
+++ b/archinstall/locales/de/LC_MESSAGES/base.po
@@ -854,7 +854,7 @@ msgid "Profiles must have unique name, but profile definitions with duplicate na
 msgstr "Profile müssen einen eindeutige Namen haben, aber Profildefinition mit gleichem Namen gefunden: {}"
 
 msgid "Select one or more devices to use and configure"
-msgstr "Wählen Sie ein oder mehrere Geräte aus, die konfiguriert und verwendet werden sollen"
+msgstr "Wählen Sie ein oder mehrere Gerät(e) aus, die konfiguriert und verwendet werden sollen"
 
 msgid "If you reset the device selection this will also reset the current disk layout. Are you sure?"
 msgstr "Wenn Sie die Laufwerksauswahl zurücksetzen, dann wird das auch das Laufwerkslayout zurückgesetzt. Sind Sie sicher?"


### PR DESCRIPTION
Corrected the plural form in the German translation for device selection.

- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
