### PR TITLE
--needed prevent re-installs & fix #issues/3599

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -554,7 +554,7 @@ class Installer:
 		info(f'Updating {fstab_path}')
 
 		try:
-			gen_fstab = SysCommand(f'genfstab {flags} {self.target}').output()
+			gen_fstab = SysCommand(f'genfstab {flags} -f {self.target} {self.target}').output()
 		except SysCallError as err:
 			raise RequirementError(f'Could not generate fstab, strapping in packages most likely failed (disk out of space?)\n Error: {err}')
 

--- a/archinstall/lib/pacman/__init__.py
+++ b/archinstall/lib/pacman/__init__.py
@@ -78,7 +78,7 @@ class Pacman:
 			'Could not strap in packages',
 			'Pacstrap failed. See /var/log/archinstall/install.log or above message for error details',
 			SysCommand,
-			f'pacstrap -C /etc/pacman.conf -K {self.target} {" ".join(packages)} --noconfirm',
+			f'pacstrap -C /etc/pacman.conf -K {self.target} {" ".join(packages)} --noconfirm --needed',
 			peek_output=True,
 		)
 


### PR DESCRIPTION
- Fix host-to-target installs using `-f` in genfstab
- Fix overlapping meta package vs drivers installs using `--needed` grep install logs for `re-installing`
- Fix Snapper-Grub integration similar to how `timeshift` is handled
- Fix mkinitcpio v40 `vconsole.conf` hook 

- Added support for hybrid laptops to conditionally add `nvidia-prime` 
- Added VM fix as many apps need software render fallback `vulkan-swrast`

Tested many times using full-disk best effort: on `MSI GP72 6QE` Nvidia 950M + Intel iGPU

This would notably effect positively: Both amd/intel iGPU + NVIDIA dGPU setups:
- Acer Predator/Nitro series 
- Asus ROG/TUF series
- HP Omen/Envy/Zbook
- Most MSI laptops
- ...

Allowing for `prime-run <intensive-app>`


EDIT: Readme fix because I see many logs(mostly on reddit) using outdated version since it's not mentioned you need to update archinstall and then some people recpmmend -Syu archinstall on ISO which isn't great.

I have also added documentation at each step so that if you don't use the full PR it might still help =) 