### PR TITLE
Default `partuuid` parameter of `_get_kernel_params_partition()` to false

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1115,7 +1115,7 @@ class Installer:
 		self,
 		root: PartitionModification | LvmVolume,
 		id_root: bool = True,
-		partuuid: bool = True,
+		partuuid: bool = False,
 	) -> list[str]:
 		kernel_parameters = []
 


### PR DESCRIPTION
There isn't a reason I could think of for preferring PARTUUIDs to UUIDs, since as far as I know that should work fine with all supported filesystems (and GRUB already forces this to false). This is especially important when using MBR instead of GPT, as that doesn't have proper UUIDs, and it will instead use the kernel's own conversion that is based on the MBR ID and more prone to collisions.