### PR TITLE
Do not create BLS and Limine entries for fallback initramfs

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1160,19 +1160,18 @@ class Installer:
 			f"""\
 			# Created by: archinstall
 			# Created on: {self.init_time}
-			title   Arch Linux ({{kernel}}{{variant}})
+			title   Arch Linux ({{kernel}})
 			linux   /vmlinuz-{{kernel}}
-			initrd  /initramfs-{{kernel}}{{variant}}.img
+			initrd  /initramfs-{{kernel}}.img
 			options {' '.join(self._get_kernel_params(root))}
 			""",
 		)
 
 		for kernel in self.kernels:
-			for variant in ('',):
-				# Setup the loader entry
-				name = entry_name.format(kernel=kernel, variant=variant)
-				entry_conf = entries_dir / name
-				entry_conf.write_text(entry_template.format(kernel=kernel, variant=variant))
+			# Setup the loader entry
+			name = entry_name.format(kernel=kernel)
+			entry_conf = entries_dir / name
+			entry_conf.write_text(entry_template.format(kernel=kernel))
 
 	def _add_systemd_bootloader(
 		self,
@@ -1237,8 +1236,8 @@ class Installer:
 		if uki_enabled:
 			default_entry = f'arch-{default_kernel}.efi'
 		else:
-			entry_name = self.init_time + '_{kernel}{variant}.conf'
-			default_entry = entry_name.format(kernel=default_kernel, variant='')
+			entry_name = self.init_time + '_{kernel}.conf'
+			default_entry = entry_name.format(kernel=default_kernel)
 			self._create_bls_entries(boot_partition, root, entry_name)
 
 		default = f'default {default_entry}'
@@ -1496,15 +1495,14 @@ class Installer:
 				config_contents += f'\n/Arch Linux ({kernel})\n'
 				config_contents += '\n'.join([f'    {it}' for it in entry]) + '\n'
 			else:
-				for variant in ('',):
-					entry = [
-						'protocol: linux',
-						f'path: {path_root}:/vmlinuz-{kernel}',
-						f'cmdline: {kernel_params}',
-						f'module_path: {path_root}:/initramfs-{kernel}{variant}.img',
-					]
-					config_contents += f'\n/Arch Linux ({kernel}{variant})\n'
-					config_contents += '\n'.join([f'    {it}' for it in entry]) + '\n'
+				entry = [
+					'protocol: linux',
+					f'path: {path_root}:/vmlinuz-{kernel}',
+					f'cmdline: {kernel_params}',
+					f'module_path: {path_root}:/initramfs-{kernel}.img',
+				]
+				config_contents += f'\n/Arch Linux ({kernel})\n'
+				config_contents += '\n'.join([f'    {it}' for it in entry]) + '\n'
 
 		config_path.write_text(config_contents)
 


### PR DESCRIPTION
Fallback initramfs seem to no longer be built by default.
