### PR TITLE
Fix GRUB fallback-from-removable logic introduced in c095eb56d8

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1321,11 +1321,15 @@ class Installer:
 
 			try:
 				SysCommand(command, peek_output=True)
-			except SysCallError:
-				try:
-					SysCommand(command, peek_output=True)
-				except SysCallError as err:
-					raise DiskError(f'Could not install GRUB to {self.target}{efi_partition.mountpoint}: {err}')
+			except SysCallError as err:
+				if not bootloader_removable:
+					command.append('--removable')
+					try:
+						SysCommand(command, peek_output=True)
+					except SysCallError:
+						pass
+
+				raise DiskError(f'Could not install GRUB to {self.target}{efi_partition.mountpoint}: {err}') from err
 		else:
 			info(f'GRUB boot partition: {boot_partition.dev_path}')
 


### PR DESCRIPTION
Commit c095eb56d878b51a80d49cdef3c82950bcfcdecd was supposed to introduce logic
such that if the `grub-install` command failed with a `--removable` flag, then
another attempt would be made with such flag removed.

This was broken because the `--removable` flag was kept in both cases (likely a
copy-paste mistake). This has been an issue since, in all future iterations of
the code.

What this commit does is fix this logic, but also invert the cases tested:
first test without `--removable`, then add it should that case fail, as this is
the most sensible thing to do.
