### PR TITLE
Improved regex removes unneeded '|' symbol and allows white-space when validating user input for partition value, unit.

### DIFF
--- a/archinstall/lib/disk/partitioning_menu.py
+++ b/archinstall/lib/disk/partitioning_menu.py
@@ -437,7 +437,7 @@ class PartitioningList(ListManager[DiskSegment]):
 		max_size: Size,
 		text: str,
 	) -> Size | None:
-		match = re.match(r'([0-9]+)([a-zA-Z|%]*)', text, re.I)
+		match = re.match(r'^\s*([0-9]+)\s*([a-zA-Z%]*)\s*$', text, re.I)
 
 		if not match:
 			return None


### PR DESCRIPTION

## PR Description:
### Small enhancement to size parsing for partition input.
Allows users to enter sizes with or without whitespace between the numeric value and the unit (e.g. 120 GiB). Previously only inputs such as '120GiB' _(value,unit)_ were accepted, while inputs such as '120 GiB' were rejected.
 
<img width="1032" height="332" alt="screenshot-2025-11-26_11-52-14" src="https://github.com/user-attachments/assets/31008d74-2eff-4895-9e41-ef91ab249be5" />

This change improves UX consistency and better aligns with input behavior and displayed examples. 

This change is made by updating the regex used for parsing size strings:
-` match = re.match(r'([0-9]+)([a-zA-Z|%]*)', text, re.I)`
+`match = re.match(r'^\s*([0-9]+)\s*([a-zA-Z%]*)\s*$', text, re.I)`

- Users no longer need to merge value and unit (120GiB) if they used spaced input
- Accepts flexable white-space
- Removes literal '|' from unit-matching, improving correctness of regex intent

### Regex Explanations

#### Previous Regex - '([0-9]+)([a-zA-Z|%]*)'

- **(')** matches the character ' with index 3910 (2716 or 478) literally (case sensitive)

##### 1st Capturing Group ([0-9]+)
- Match a single character present in the list below **[0-9]**
- **(+)** matches the previous token between one and unlimited times, as many times as possible, giving back as needed (greedy)
- **0-9** matches a single character in the range between 0 (index 48) and 9 (index 57) (case sensitive)

##### 2nd Capturing Group **([a-zA-Z|%]*)**
- Match a single character present in the list below **[a-zA-Z|%]**
- **(*)** matches the previous token between zero and unlimited times, as many times as possible, giving back as needed (greedy)
- **a-z** matches a single character in the range between a (index 97) and z (index 122) (case sensitive)
- **A-Z** matches a single character in the range between A (index 65) and Z (index 90) (case sensitive)
- **(|%)** matches a single character in the list |% (case sensitive)
- **(')** matches the character ' with index 3910 (2716 or 478) literally (case sensitive)

##### Global pattern flags 
- **g** **modifier:** global. All matches (don't return after first match)
- **m** **modifier:** multi line. Causes ^ and $ to match the begin/end of each line (not only begin/end of string)
 
#### New Regex - '^\s*([0-9]+)\s*([a-zA-Z%]*)\s*$'


- **(')** matches the character ' with index 3910 (2716 or 478) literally (case sensitive)
- **(^)** asserts position at start of a line
- **\s** matches any whitespace character (equivalent to [\r\n\t\f\v ])
- **(*)** matches the previous token between zero and unlimited times, as many times as possible, giving back as needed (greedy)

##### 1st Capturing Group ([0-9]+)

- Match a single character present in the list below [0-9]
- **(+)** matches the previous token between one and unlimited times, as many times as possible, giving back as needed (greedy)
- **0-9** matches a single character in the range between 0 (index 48) and 9 (index 57) (case sensitive)
- **\s** matches any white- space character (equivalent to [\r\n\t\f\v ])
- **(*)** matches the previous token between zero and unlimited times, as many times as possible, giving back as needed (greedy)

##### 2nd Capturing Group ([a-zA-Z%]*)
- Match a single character present in the list below [a-zA-Z%]
- **(*)** matches the previous token between zero and unlimited times, as many times as possible, giving back as needed (greedy)
- **a-z** matches a single character in the range between a (index 97) and z (index 122) (case sensitive)
- **A-Z** matches a single character in the range between A (index 65) and Z (index 90) (case sensitive)
- **%** matches the character % with index 3710 (2516 or 458) literally (case sensitive)
- **\s** matches any white-space character (equivalent to [\r\n\t\f\v ])
- **(*)** matches the previous token between zero and unlimited times, as many times as possible, giving back as needed (greedy)
- **($)** asserts position at the end of a line
- **(')** matches the character ' with index 3910 (2716 or 478) literally (case sensitive)

##### Global pattern flags 
**g** **modifier:** global. All matches (don't return after first match)
**m** **modifier:** multi line. Causes ^ and $ to match the begin/end of each line (not only begin/end of string)

## Tests and Checks
- [x] Manual check of both spaced and unspaced strings
- [x] Confirmed no regressions to existing units or number forms
- [x] ISO test after build  
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
