### PR TITLE
Remove GRUB removable fallback path

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1321,14 +1321,7 @@ class Installer:
 			try:
 				SysCommand(command, peek_output=True)
 			except SysCallError as err:
-				if not bootloader_removable:
-					command.append('--removable')
-					try:
-						SysCommand(command, peek_output=True)
-					except SysCallError:
-						pass
-
-				raise DiskError(f'Could not install GRUB to {self.target}{efi_partition.mountpoint}: {err}') from err
+				raise DiskError(f'Could not install GRUB to {self.target}{efi_partition.mountpoint}: {err}')
 		else:
 			info(f'GRUB boot partition: {boot_partition.dev_path}')
 


### PR DESCRIPTION
As mentioned by @svartkanin on #3950, given we now have a way for the user to
explicitly specify if they want to install to the removable location, having a
fallback like this seems undesirable.

On top of that, as mentioned by @correctmost on the same PR, the code that said
PR introduced was bugged and would always raise an exception anyways.
