### PR TITLE
Optimized the speed of retrieving mirrorlist

### DIFF
--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -418,12 +418,12 @@ class MirrorListHandler:
 
 		for attempt_nr in range(attempts):
 			try:
-				mirrorlist = fetch_data_from_url(url)
+				mirrorlist = fetch_data_from_url(url, timeout=1)
 				self._status_mappings = self._parse_remote_mirror_list(mirrorlist)
 				return True
 			except Exception as e:
 				debug(f'Error while fetching mirror list: {e}')
-				time.sleep(attempt_nr + 1)
+				time.sleep(0.5)
 
 		debug('Unable to fetch mirror list remotely, falling back to local mirror list')
 		return False


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:
The waiting time and request timeout were limited based on the original code.
```python
	try:
        #Added timeout period
		mirrorlist = fetch_data_from_url(url, timeout=1)
		self._status_mappings = self._parse_remote_mirror_list(mirrorlist)
		return True
	except Exception as e:
		debug(f'Error while fetching mirror list: {e}')
		#The original wait was deleted.
		time.sleep(0.5)
```
<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
