### PR TITLE
Remove /tmp/archlive before building

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -18,6 +18,9 @@ packages=(
 	python-textual
 )
 
+if [ -d "/tmp/archlive" ]; then
+    rm -rf "/tmp/archlive"
+fi
 mkdir -p /tmp/archlive/airootfs/root/archinstall-git
 cp -r . /tmp/archlive/airootfs/root/archinstall-git
 


### PR DESCRIPTION
## PR Description:

Remove `/tmp/archlive` before building ISO. Otherwise latest changes are not built.

<img width="382" height="43" alt="image" src="https://github.com/user-attachments/assets/142c2761-2ee7-4408-8418-24c35ac410fa" />  

&nbsp;
vs
&nbsp;

<img width="382" height="43" alt="image" src="https://github.com/user-attachments/assets/410b8ef5-0455-445b-836d-3270990fbec2" />


## Tests and Checks
- [x] I have tested the code!<br>