### PR TITLE
Cache property of graphics_devices

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -35,7 +35,6 @@ def _log_sys_info() -> None:
 	debug(f'Memory statistics: {SysInfo.mem_available()} available out of {SysInfo.mem_total()} total installed')
 	debug(f'Virtualization detected: {SysInfo.virtualization()}; is VM: {SysInfo.is_vm()}')
 	debug(f'Graphics devices detected: {SysInfo._graphics_devices().keys()}')
-	from archinstall.lib.hardware import _sys_info
 
 	# For support reasons, we'll log the disk layout pre installation to match against post-installation layout
 	debug(f'Disk states before installing:\n{disk_layouts()}')

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -193,6 +193,18 @@ class _SysInfo:
 
 		return modules
 
+	@cached_property
+	def graphics_devices(self) -> dict[str, str]:
+		"""
+		Returns detected graphics devices (cached)
+		"""
+		cards: dict[str, str] = {}
+		for line in SysCommand('lspci'):
+			if b' VGA ' in line or b' 3D ' in line:
+				_, identifier = line.split(b': ', 1)
+				cards[identifier.strip().decode('UTF-8')] = str(line)
+		return cards
+
 
 _sys_info = _SysInfo()
 
@@ -209,24 +221,19 @@ class SysInfo:
 
 	@staticmethod
 	def _graphics_devices() -> dict[str, str]:
-		cards: dict[str, str] = {}
-		for line in SysCommand('lspci'):
-			if b' VGA ' in line or b' 3D ' in line:
-				_, identifier = line.split(b': ', 1)
-				cards[identifier.strip().decode('UTF-8')] = str(line)
-		return cards
+		return _sys_info.graphics_devices
 
 	@staticmethod
 	def has_nvidia_graphics() -> bool:
-		return any('nvidia' in x.lower() for x in SysInfo._graphics_devices())
+		return any('nvidia' in x.lower() for x in _sys_info.graphics_devices)
 
 	@staticmethod
 	def has_amd_graphics() -> bool:
-		return any('amd' in x.lower() for x in SysInfo._graphics_devices())
+		return any('amd' in x.lower() for x in _sys_info.graphics_devices)
 
 	@staticmethod
 	def has_intel_graphics() -> bool:
-		return any('intel' in x.lower() for x in SysInfo._graphics_devices())
+		return any('intel' in x.lower() for x in _sys_info.graphics_devices)
 
 	@staticmethod
 	def cpu_vendor() -> CpuVendor | None:


### PR DESCRIPTION
Basically was testing on laptop from 2010 and the `Graphics Drivers` section in TUI took about 2-3 seconds to load, which I found odd since it's initialized in `__init__`

(Think because the headers for hint text used to call `lspci` 3-4x) So this what I could come up with to fix just that, using the same structure as existing. `@cached_property` and then update the calls to use this


