### PR TITLE
Modify archinstall language display to be handled like other sections.

### DIFF
--- a/archinstall/tui/types.py
+++ b/archinstall/tui/types.py
@@ -115,7 +115,7 @@ class Chars:
 	Block = '█'
 	Triangle_up = '▲'
 	Triangle_down = '▼'
-	Check = '✓'
+	Check = '+'
 	Cross = 'x'
 	Right_arrow = '←'
 


### PR DESCRIPTION
<img width="1298" height="922" alt="Screenshot_20251229_113905" src="https://github.com/user-attachments/assets/7e29f15e-0fa0-4a7a-86ae-6cdaf7188461" /> NEW FORMAT


<img width="1298" height="922" alt="Screenshot_20251229_113941" src="https://github.com/user-attachments/assets/0a9a868f-242f-4ff2-b5e7-51bfe1c6ad7c" /> OLD FORMAT

Basically the value of `lang.display_name` was breaking the menu when too long. So just changed it to be handled like other sections. 
