### PR TITLE
lib/network: adds symlink to configure systemd-resovled properly

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -754,8 +754,13 @@ class Installer:
 				for psk in psk_files:
 					shutil.copy2(psk, f'{self.target}/var/lib/iwd/{os.path.basename(psk)}')
 
-		# Add symlink to enable systemd-resolved
-		os.symlink('/run/systemd/resolve/stub-resolv.conf', f'{self.target}/etc/resolv.conf')
+		# Enable systemd-resolved by (forcefully) setting a symlink
+		# For further details see  https://wiki.archlinux.org/title/Systemd-resolved#DNS
+		resolv_config_path = Path(f'{self.target}/etc/resolv.conf')
+		if resolv_config_path.exists():
+			os.unlink(resolv_config_path)
+		os.symlink('/run/systemd/resolve/stub-resolv.conf', resolv_config_path)
+
 		# Copy (if any) systemd-networkd config files
 		if netconfigurations := glob.glob('/etc/systemd/network/*'):
 			if not os.path.isdir(f'{self.target}/etc/systemd/network/'):


### PR DESCRIPTION
When "Copy network config from ISO" is selected, it sets up `systemd-resolved` and `systemd-networkd`, however, `systemd-resolved` requires `resolve.conf` to be a [stub](https://wiki.archlinux.org/title/Systemd-resolved#DNS) in order to work properly.

This PR addresses the issue that it's currently not a stub, but a core filesystem file meant for other types of resolvers.