### PR TITLE
Add sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # These are supported funding model platforms
 
 github: [archlinux]
-custom: [https://archlinux.org/donate/]
+custom: ['https://archlinux.org/donate/']


### PR DESCRIPTION
Just thought since this is one of archlinux's most popular project, perhaps this would be useful.

Just redirects to either archlinux github sponsors or /donate link. 

For obvious reasons I cannot test this on my private repo, has to be added to settings (if we can also add a social preview in the repo settings that would be cool too :) 