### PR TITLE
Add support for exFAT filesystem

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -35,6 +35,7 @@ depends=(
   'lvm2'
   'f2fs-tools'
   'ntfs-3g'
+  'exfatprogs'
 )
 makedepends=(
   'python-build'

--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -284,6 +284,8 @@ class DeviceHandler:
 				mkfs_type = 'fat'
 				# Set FAT size
 				options.extend(('-F', fs_type.value.removeprefix(mkfs_type)))
+			case FilesystemType.Exfat:
+				pass
 			case FilesystemType.Ntfs:
 				# Skip zeroing and bad sector check
 				options.append('--fast')
@@ -567,12 +569,12 @@ class DeviceHandler:
 		)
 
 		fs_value = part_mod.safe_fs_type.parted_value
-		filesystem = FileSystem(type=fs_value, geometry=geometry)
 
 		partition = Partition(
 			disk=disk,
 			type=part_mod.type.get_partition_code(),
-			fs=filesystem,
+			# exfat is not supported by parted
+			fs=FileSystem(type=fs_value, geometry=geometry) if fs_value != 'exfat' else None,
 			geometry=geometry,
 		)
 

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -785,6 +785,7 @@ class FilesystemType(Enum):
 	Fat12 = 'fat12'
 	Fat16 = 'fat16'
 	Fat32 = 'fat32'
+	Exfat = 'exfat'
 	Ntfs = 'ntfs'
 	Xfs = 'xfs'
 	LinuxSwap = 'linux-swap'


### PR DESCRIPTION
## PR Description:

Introduce support for the exFAT file system, which is commonly used for exchanging data between different operating systems.

Since exFAT is not supported by [GNU Parted](https://www.gnu.org/software/parted/parted.html), the `fs` argument is omitted when creating an exFAT partition.

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
