### PR TITLE
Fix pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,12 +44,9 @@ repos:
         - pytest-mock
         - cryptography
         - textual
-  - repo: local
+  - repo: https://github.com/pycqa/pylint
+    rev: v4.0.4
     hooks:
-      - id: pylint
-        name: pylint
-        entry: pylint
-        language: system
-        types: [python]
-        fail_fast: true
-        require_serial: true
+    - id: pylint
+      fail_fast: true
+      require_serial: true


### PR DESCRIPTION
just used latest version from GH so you don't have to go through manual pip installation, was giving me errors today. Perhaps can help other new contributors