### PR TITLE
Change plasma-meta -> -desktop.

### DIFF
--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -12,7 +12,7 @@ class PlasmaProfile(XorgProfile):
 	@override
 	def packages(self) -> list[str]:
 		return [
-			'plasma-meta',
+			'plasma-desktop',
 			'konsole',
 			'kate',
 			'dolphin',


### PR DESCRIPTION
Second time I open up this subject, instead of creating a separate profile we should use this option directly:

First of all it installs `flatpak` related libs which should be up to the user as to which containerization tech he wants to use. 

Second of all it also pulls in `sddm-kcm` which isn't needed if user selected another login manager through `archinstall`. 

This still results in a fully functional system and aligns closer to arch philosophy (plus 1GiB saved in bandwidth)