### PR TITLE
feat: make bug report URL configurable

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -143,9 +143,9 @@ def run_as_a_module() -> None:
 			error(err)
 
 			text = (
-				'Archinstall experienced the above error. If you think this is a bug, please report it to\n'
-				'https://github.com/archlinux/archinstall and include the log file "/var/log/archinstall/install.log".\n\n'
-				"Hint: To extract the log from a live ISO \ncurl -F 'file=@/var/log/archinstall/install.log' https://0x0.st\n"
+				f'Archinstall experienced the above error. If you think this is a bug, please report it to\n'
+				f'{arch_config_handler.config.bug_report_url} and include the log file "/var/log/archinstall/install.log".\n\n'
+				f"Hint: To extract the log from a live ISO \ncurl -F 'file=@/var/log/archinstall/install.log' https://0x0.st\n"
 			)
 
 			warn(text)

--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -76,6 +76,7 @@ class ArchConfig:
 	timezone: str = 'UTC'
 	services: list[str] = field(default_factory=list)
 	custom_commands: list[str] = field(default_factory=list)
+	bug_report_url: str = 'https://github.com/archlinux/archinstall'
 
 	def unsafe_json(self) -> dict[str, Any]:
 		config: dict[str, list[UserSerialization] | str | None] = {}
@@ -108,6 +109,7 @@ class ArchConfig:
 			'timezone': self.timezone,
 			'services': self.services,
 			'custom_commands': self.custom_commands,
+			'bug_report_url': self.bug_report_url,
 			'bootloader_config': self.bootloader_config.json() if self.bootloader_config else None,
 			'app_config': self.app_config.json() if self.app_config else None,
 			'auth_config': self.auth_config.json() if self.auth_config else None,
@@ -249,6 +251,9 @@ class ArchConfig:
 
 		if custom_commands := args_config.get('custom_commands', []):
 			arch_config.custom_commands = custom_commands
+
+		if bug_report_url := args_config.get('bug_report_url', None):
+			arch_config.bug_report_url = bug_report_url
 
 		return arch_config
 

--- a/examples/config-sample.json
+++ b/examples/config-sample.json
@@ -151,5 +151,6 @@
     "algorithm": "zstd"
   },
   "timezone": "UTC",
-  "version": "2.8.6"
+  "version": "2.8.6",
+  "bug_report_url": "https://github.com/archlinux/archinstall"
 }


### PR DESCRIPTION
This would notably allow for forks to provide their own URL for bug reports (especially since they might be frozen behind or use very modified configs). 

Less false-positives for us and more critical bug reports for everyone (:
