### PR TITLE
chore: missing dep libfido2

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -35,6 +35,7 @@ depends=(
   'lvm2'
   'f2fs-tools'
   'ntfs-3g'
+  'libfido2'
 )
 makedepends=(
   'python-build'


### PR DESCRIPTION
Fixes an issue with the menu

`^[[31mfailed to read fido2 devices: Binary fido2-token does not exist.^[[0m`

I'm not sure if this should be declared somewhere else too?