### PR TITLE
Migrate pytest configs to native TOML and enable strict mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,9 +128,12 @@ ignore_missing_imports = true
 targets = ["archinstall"]
 exclude = ["/tests"]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 pythonpath = ["."]
-addopts = "-s"
+addopts = [
+    "-s",
+    "--strict",
+]
 testpaths = ["tests"]
 
 [tool.pylint.main]


### PR DESCRIPTION
## PR Description:

Native TOML configs and strict mode were added in pytest 9.0:
- https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05
- https://docs.pytest.org/en/stable/explanation/goodpractices.html#strict-mode