### PR TITLE
Fix an invalid-type-form error reported by ty

### DIFF
--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import math
 import uuid
 from dataclasses import dataclass, field
@@ -772,7 +773,7 @@ class PartitionGUID(Enum):
 	LINUX_ROOT_X86_64 = '4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709'
 
 	@property
-	def bytes(self) -> bytes:
+	def bytes(self) -> builtins.bytes:
 		return uuid.UUID(self.value).bytes
 
 


### PR DESCRIPTION
## PR Description:

The 'bytes' annotation for the 'bytes' property was actually a forward reference to the property instead of builtins.bytes: https://github.com/astral-sh/ty/issues/1747#issuecomment-3609042917

ty was reporting this error:
```
archinstall/lib/models/device.py:775:21: error[invalid-type-form] Variable of type `property` is not allowed in a type expression
```