### PR TITLE
Add node_modules to .gitignore and Pylint's ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ requirements.txt
 /.gitconfig
 /actions-runner
 /cmd_output.txt
+node_modules/
 uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ testpaths = ["tests"]
 ignore-paths = [
     "^build/",
     "^docs/",
+    "^node_modules/",
 ]
 persistent = false
 py-version = "3.12"


### PR DESCRIPTION
## PR Description:

This makes it easier to use Pyright locally.