### PR TITLE
h2t: protect host cfg

### DIFF
--- a/archinstall/lib/pacman/config.py
+++ b/archinstall/lib/pacman/config.py
@@ -1,3 +1,4 @@
+import atexit
 import re
 from pathlib import Path
 from shutil import copy2
@@ -47,10 +48,12 @@ class PacmanConfig:
 				if row + 1 < len(content) and content[row + 1].lstrip().startswith('#'):
 					content[row + 1] = re.sub(r'^#\s*', '', content[row + 1])
 
-		# Modify file only in ISO env
+		# Apply temp using backup then revert on exit handler
 		if running_from_host():
-			pass
-		else:
+			temp_copy = self._config_path.with_suffix('.bak')
+			copy2(self._config_path, temp_copy)
+			atexit.register(lambda: copy2(temp_copy, self._config_path))
+		else:  # Apply directly
 			with open(self._config_path, 'w') as f:
 				f.writelines(content)
 


### PR DESCRIPTION
Still on my spree of testing directly from one install to another.

This a simple patch to not write into a host `pacman.conf` prevents from accidentally modifying the host's `/etc` when using `Custom Repositories` section in the menu but persists on target regardless