### PR TITLE
Remove unused pytest-mock dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
       additional_dependencies:
         - pydantic
         - pytest
-        - pytest-mock
         - cryptography
         - textual
   - repo: https://github.com/pycqa/pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "pydantic==2.12.5",
     "cryptography>=45.0.7",
     "textual>=5.3.0",
-    "pytest-mock>=3.15.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
## PR Description:

The dependency was added in 76ab9482e, but it doesn't seem to be used anywhere.