### PR TITLE
Avoid a reportPossiblyUnboundVariable warning with Pyright

### DIFF
--- a/archinstall/lib/interactions/system_conf.py
+++ b/archinstall/lib/interactions/system_conf.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import assert_never
+
 from archinstall.lib.models.application import ZramAlgorithm, ZramConfiguration
 from archinstall.lib.translationhandler import tr
 from archinstall.tui.curses_menu import SelectMenu
@@ -126,12 +128,15 @@ def ask_for_swap(preset: ZramConfiguration = ZramConfiguration(enabled=True)) ->
 				allow_skip=True,
 			).run()
 
-			algo: ZramAlgorithm
 			match algo_result.type_:
 				case ResultType.Skip:
 					algo = preset.algorithm
 				case ResultType.Selection:
 					algo = algo_result.get_value()
+				case ResultType.Reset:
+					raise ValueError('Unhandled result type')
+				case _:
+					assert_never(algo_result.type_)
 
 			return ZramConfiguration(enabled=True, algorithm=algo)
 		case ResultType.Reset:


### PR DESCRIPTION
## PR Description:

Pyright was reporting this false positive:
```
archinstall/lib/interactions/system_conf.py:136:53 - error: "algo" is possibly unbound (reportPossiblyUnboundVariable)
```