### PR TITLE
chore: pre-commit hook pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,5 +47,6 @@ repos:
     rev: v4.0.4
     hooks:
     - id: pylint
+      args: ['--init-hook', 'import sys; sys.path.insert(0, ".")']
       fail_fast: true
       require_serial: true


### PR DESCRIPTION
This makes it so that it can find local `archinstall` module properly, was giving me more errors today and end-up using `uninstall` temporarily 