### PR TITLE
Disable the non-empty-init-module ruff rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ ignore = [
     "RUF015",   # unnecessary-iterable-allocation-for-first-element
     "RUF039",   # unraw-re-pattern
     "RUF051",   # if-key-in-dict-del
+    "RUF067",   # non-empty-init-module
     "UP037",    # quoted-annotation
     "W191",     # tab-indentation
 ]


### PR DESCRIPTION
## PR Description:

This allows `ruff check --preview` to pass again.

Rule docs:
- https://docs.astral.sh/ruff/rules/non-empty-init-module/