### PR TITLE
Fix useless-return warnings reported by Pylint

### DIFF
--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -68,4 +68,3 @@ class HyprlandProfile(XorgProfile):
 	@override
 	def do_on_select(self) -> None:
 		self._ask_seat_access()
-		return None

--- a/archinstall/default_profiles/desktops/labwc.py
+++ b/archinstall/default_profiles/desktops/labwc.py
@@ -65,4 +65,3 @@ class LabwcProfile(XorgProfile):
 	@override
 	def do_on_select(self) -> None:
 		self._ask_seat_access()
-		return None

--- a/archinstall/default_profiles/desktops/niri.py
+++ b/archinstall/default_profiles/desktops/niri.py
@@ -73,4 +73,3 @@ class NiriProfile(XorgProfile):
 	@override
 	def do_on_select(self) -> None:
 		self._ask_seat_access()
-		return None

--- a/archinstall/default_profiles/desktops/sway.py
+++ b/archinstall/default_profiles/desktops/sway.py
@@ -75,4 +75,3 @@ class SwayProfile(XorgProfile):
 	@override
 	def do_on_select(self) -> None:
 		self._ask_seat_access()
-		return None

--- a/archinstall/tui/ui/components.py
+++ b/archinstall/tui/ui/components.py
@@ -1205,7 +1205,6 @@ class TApp:
 	def exit(self, result: Result[ValueT]) -> None:
 		assert TApp.app
 		TApp.app.exit(result)
-		return
 
 
 tui = TApp()


### PR DESCRIPTION
## PR Description:

This PR fixes the following warnings (the `R`-level Pylint warnings are currently disabled in `pyproject.toml`):

```
************* Module archinstall.default_profiles.desktops.labwc
archinstall/default_profiles/desktops/labwc.py:66:1: R1711: Useless return at end of function or method (useless-return)
************* Module archinstall.default_profiles.desktops.sway
archinstall/default_profiles/desktops/sway.py:76:1: R1711: Useless return at end of function or method (useless-return)
************* Module archinstall.default_profiles.desktops.niri
archinstall/default_profiles/desktops/niri.py:74:1: R1711: Useless return at end of function or method (useless-return)
************* Module archinstall.default_profiles.desktops.hyprland
archinstall/default_profiles/desktops/hyprland.py:69:1: R1711: Useless return at end of function or method (useless-return)
************* Module archinstall.tui.ui.components
archinstall/tui/ui/components.py:1205:1: R1711: Useless return at end of function or method (useless-return)
```