### PR TITLE
Fix: Resolve fuzzy strings and add note for 'Seat access translation'

### DIFF
--- a/archinstall/locales/es/LC_MESSAGES/base.po
+++ b/archinstall/locales/es/LC_MESSAGES/base.po
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.8\n"
 
 msgid "[!] A log file has been created here: {} {}"
 msgstr "[!] Se ha creado un archivo de registro aquí: {} {}"
@@ -259,7 +259,7 @@ msgstr "Codificación local"
 msgid "Drive(s)"
 msgstr "Disco(s)"
 
-# not sure about this one... we've been saying distribución instead of diseño up to now...  
+# not sure about this one... we've been saying distribución instead of diseño up to now...
 msgid "Disk layout"
 msgstr "Diseño del disco"
 
@@ -1358,7 +1358,7 @@ msgstr "Presione Ctrl+h para obtener ayuda"
 msgid "Choose an option to give Sway access to your hardware"
 msgstr "Elija una opción para darle a Sway acceso a su hardware"
 
-#, fuzzy
+# maybe "Acceso a la estación"  or "Gestión de puestos (seats)" could be better?
 msgid "Seat access"
 msgstr "Acceso al asiento"
 
@@ -1716,7 +1716,6 @@ msgstr "Contraseña para descifrar el archivo de credenciales"
 msgid "Do you want to encrypt the user_credentials.json file?"
 msgstr "¿Desea encriptar el archivo user_credentials.json?"
 
-#, fuzzy
 msgid "Credentials file encryption password"
 msgstr "Contraseña para cifrar el archivo de credenciales"
 
@@ -1747,17 +1746,6 @@ msgstr "¿Desea configurar el servicio de impresión?"
 
 msgid "Power management"
 msgstr "Administración de energía"
-
-msgid "Authentication"
-msgstr "Autenticación"
-
-#, fuzzy
-msgid "Would you like to configure the print service?"
-msgstr "¿Quiere continuar?"
-
-#, fuzzy
-msgid "Power management"
-msgstr "Gestión de particiones: {}"
 
 msgid "Authentication"
 msgstr "Autenticación"
@@ -1865,7 +1853,7 @@ msgid "Firmware that does not properly support NVRAM boot entries."
 msgstr "Firmware que no soporta entradas arrancables NVRAM."
 
 msgid "Will install to /EFI/BOOT/ (removable location, safe default)"
-msgstr "Instalará a /EFI/BOOT/ (ubicación desmontable, segura por defecto)" 
+msgstr "Instalará a /EFI/BOOT/ (ubicación desmontable, segura por defecto)"
 
 msgid "Will install to custom location with NVRAM entry"
 msgstr "Instalará a ubicación personalizada con entrada NVRAM"


### PR DESCRIPTION
This PR fixes duplicate entries in the Spanish (es) translation file and reviews the two fuzzy strings, adding a translator note for the term 'Seat access'.

**Fixed compilation errors (duplicate entries)**
- "Would you like to configure the print service?" (1755)
- "Power management" (1759) 
- "Authentication" (1762)

**Reviewed fuzzy translations**
- "Credentials file encryption password" (1719)
- "Seat access" (1362) - added translator note with alternative suggestions

The file now compiles cleanly with `msgfmt --statistics` showing 0 fuzzy.
