### PR TITLE
fix: prevent IndexError in focus_index with invalid input

### DIFF
--- a/archinstall/tui/menu_item.py
+++ b/archinstall/tui/menu_item.py
@@ -316,7 +316,9 @@ class MenuItemGroup:
 
 	def focus_index(self, index: int) -> None:
 		enabled = self.get_enabled_items()
-		self.focus_item = enabled[index]
+		if not (0 <= index < len(enabled)):
+			return
+		self.focus_item = enabled[index]]
 
 	def focus_first(self) -> None:
 		if len(self.items) == 0:


### PR DESCRIPTION
this PR fixes a crash encountered during the installation process when interacting with the TUI menus (specifically in the disk configuration).

**the bug:**
the `focus_index` method in `menu_item.py` currently attempts to access the `enabled` list using a raw index provided by the key press logic. if a user presses a number key (e.g '3') that corresponds to an index larger than the current list size (e.g. in a menu with only 2 items), it raises an `IndexError` and crashes the installer.

**the fix:**
i have added a guard clause to `focus_index` that checks if the requested index is within valid bounds `(0 <= index < len(enabled))`. this matches the safety behavior already present in `focus_first` and `focus_last`.

```
def focus_index(self, index: int) -> None:
        enabled = self.get_enabled_items()

        # fix: this prevents crashing on invalid key presses
        if not (0 <= index < len(enabled)):
            return

        self.focus_item = enabled[index]
```

**verification:**
i reproduced this crash on the latest ISO. i manually patched the file in `/usr/lib/python3.13/site-packages/archinstall/tui/menu_item.py` with this fix, verified that the crash no longer occurs, and successfully completed an installation.

### Traceback
```text
[2026-01-30 13:28:29] - ERROR - Traceback (most recent call last):
...
  File "/usr/lib/python3.13/site-packages/archinstall/tui/curses_menu.py", line 1216, in _process_input_key
    self._item_group.focus_index(key - 49)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/archinstall/tui/menu_item.py", line 284, in focus_index
    self.focus_item = enabled[index]
                      ~~~~~~~^^^^^^^
IndexError: list index out of range