### PR TITLE
Avoid union syntax in an isinstance check

### DIFF
--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -100,7 +100,7 @@ class FormattedOutput:
 				if '!' in key:
 					value = '*' * len(value)
 
-				if isinstance(value, int | float) or (isinstance(value, str) and value.isnumeric()):
+				if isinstance(value, (int, float)) or (isinstance(value, str) and value.isnumeric()):
 					obj_data.append(unicode_rjust(str(value), width))
 				else:
 					obj_data.append(unicode_ljust(str(value), width))


### PR DESCRIPTION
## PR Description:

This is a partial revert of commit 44f4bc86. The UP038 ruff rule was removed and using union syntax is no longer recommended.

The remaining instances will be removed by #4183.

Docs:
- https://docs.astral.sh/ruff/rules/non-pep604-isinstance/#removed