### PR TITLE
Measure install time with monotonic clock instead of system clock

### DIFF
--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -57,7 +57,7 @@ def perform_installation(
 	Only requirement is that the block devices are
 	formatted and setup prior to entering this function.
 	"""
-	start_time = time.time()
+	start_time = time.monotonic()
 	info('Starting installation...')
 
 	config = arch_config_handler.config
@@ -169,7 +169,7 @@ def perform_installation(
 		debug(f'Disk states after installing:\n{disk_layouts()}')
 
 		if not arch_config_handler.args.silent:
-			elapsed_time = time.time() - start_time
+			elapsed_time = time.monotonic() - start_time
 			action = select_post_installation(elapsed_time)
 
 			match action:


### PR DESCRIPTION
## PR Description:

Using `time.time()` can be inaccurate if the system clock gets updated in between calls.

Docs
- https://docs.python.org/3/library/time.html#time.monotonic
- https://docs.python.org/3/library/time.html#time.time