### PR TITLE
Remove an unused milliseconds member from Installer

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -80,7 +80,6 @@ class Installer:
 		self.target: Path = target
 
 		self.init_time = time.strftime('%Y-%m-%d_%H-%M-%S')
-		self.milliseconds = int(str(time.time()).split('.')[1])
 		self._helper_flags: dict[str, str | bool | None] = {
 			'base': False,
 			'bootloader': None,


### PR DESCRIPTION
## PR Description:

I noticed this unused variable while looking at #4198 and other `time.time()` usages.