### PR TITLE
fix efistub bootloader to use backslashes

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1620,7 +1620,7 @@ class Installer:
 			loader = '/vmlinuz-{kernel}'
 			# EFI standards stipulate backslashes
 			entries = (
-				'initrd=\\initramfs-{kernel}.img',
+				r'initrd=\initramfs-{kernel}.img',
 				*self._get_kernel_params(root),
 			)
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1618,8 +1618,7 @@ class Installer:
 
 		if not uki_enabled:
 			loader = '/vmlinuz-{kernel}'
-			# python escaping for a single backslash
-			# according to wiki EFISTUB when passed to --unicode
+			# EFI standards stipulate backslashes
 			entries = (
 				'initrd=\\initramfs-{kernel}.img',
 				*self._get_kernel_params(root),

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1618,7 +1618,7 @@ class Installer:
 
 		if not uki_enabled:
 			loader = '/vmlinuz-{kernel}'
-			# python escaping for a single forward slash
+			# python escaping for a single backslash
 			# according to wiki EFISTUB when passed to --unicode
 			entries = (
 				'initrd=\\initramfs-{kernel}.img',

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1618,9 +1618,10 @@ class Installer:
 
 		if not uki_enabled:
 			loader = '/vmlinuz-{kernel}'
-
+			# python escaping for a single forward slash
+			# according to wiki EFISTUB when passed to --unicode
 			entries = (
-				'initrd=/initramfs-{kernel}.img',
+				'initrd=\\initramfs-{kernel}.img',
 				*self._get_kernel_params(root),
 			)
 


### PR DESCRIPTION
As seen in wiki example: 
https://wiki.archlinux.org/title/EFI_boot_stub#efibootmgr

```shell 
efibootmgr --create --disk /dev/sdX --part Y --label "Arch Linux" --loader /vmlinuz-linux \
--unicode 'root=block_device_identifier rw initrd=\initramfs-linux.img'
```

Was just wondering why `EFIstub` never worked to boot and found this :)

#1431 #2684 
