### PR TITLE
Fix dismiss() called from worker thread without event loop

### DIFF
--- a/archinstall/tui/ui/components.py
+++ b/archinstall/tui/ui/components.py
@@ -110,7 +110,7 @@ class LoadingScreen(BaseScreen[None]):
 	def _exec_callback(self) -> None:
 		assert self._data_callback
 		result = self._data_callback()
-		_ = self.dismiss(Result(ResultType.Selection, _data=result))
+		self.app.call_from_thread(self.dismiss, Result(ResultType.Selection, _data=result))
 
 	def action_pop_screen(self) -> None:
 		_ = self.dismiss()


### PR DESCRIPTION
Steps to reproduce: 

- Press `exit` (instead of `reboot`, `chroot`) at the end of `archinstall`

<img width="1920" height="1080" alt="Screenshot 2026-02-16 15-57-00" src="https://github.com/user-attachments/assets/f2480870-005b-4125-8b30-c980054116f6" />

