### PR TITLE
Fix install gfx before DE/WM/Server

### DIFF
--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -235,10 +235,10 @@ class ProfileHandler:
 		if not profile:
 			return
 
-		profile.install(install_session)
-
 		if profile_config.gfx_driver and (profile.is_xorg_type_profile() or profile.is_desktop_profile()):
 			self.install_gfx_driver(install_session, profile_config.gfx_driver)
+
+		profile.install(install_session)
 
 		if profile_config.greeter:
 			self.install_greeter(install_session, profile_config.greeter)


### PR DESCRIPTION
This fixes a case where `vulkan-driver` virtual package is not met and installs `nvidia-utils`  (`default=1` prompt, regardless of actual drivers selected) when selecting `cosmic` profile. This could be the case for other desktops that have this dependency #4226