### PR TITLE
Move get_parent_device_path() to disk.utils

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -187,10 +187,6 @@ class DeviceHandler:
 				return part
 		return None
 
-	def get_parent_device_path(self, dev_path: Path) -> Path:
-		lsblk = get_lsblk_info(dev_path)
-		return Path(f'/dev/{lsblk.pkname}')
-
 	def get_uuid_for_path(self, path: Path) -> str | None:
 		partition = self.find_partition(path)
 		return partition.partuuid if partition else None

--- a/archinstall/lib/disk/utils.py
+++ b/archinstall/lib/disk/utils.py
@@ -110,6 +110,11 @@ def disk_layouts() -> str:
 	return lsblk_output.model_dump_json(indent=4)
 
 
+def get_parent_device_path(dev_path: Path) -> Path:
+	lsblk = get_lsblk_info(dev_path)
+	return Path(f'/dev/{lsblk.pkname}')
+
+
 def get_unique_path_for_device(dev_path: Path) -> Path | None:
 	paths = Path('/dev/disk/by-id').glob('*')
 	linked_targets = {p.resolve(): p for p in paths}

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -19,6 +19,7 @@ from archinstall.lib.disk.fido import Fido2
 from archinstall.lib.disk.utils import (
 	get_lsblk_by_mountpoint,
 	get_lsblk_info,
+	get_parent_device_path,
 	get_unique_path_for_device,
 	mount,
 	swapon,
@@ -1381,7 +1382,7 @@ class Installer:
 		else:
 			info(f'GRUB boot partition: {boot_partition.dev_path}')
 
-			parent_dev_path = device_handler.get_parent_device_path(boot_partition.safe_dev_path)
+			parent_dev_path = get_parent_device_path(boot_partition.safe_dev_path)
 
 			add_options = [
 				'--target=i386-pc',
@@ -1475,7 +1476,7 @@ class Installer:
 
 			info(f'Limine EFI partition: {efi_partition.dev_path}')
 
-			parent_dev_path = device_handler.get_parent_device_path(efi_partition.safe_dev_path)
+			parent_dev_path = get_parent_device_path(efi_partition.safe_dev_path)
 
 			try:
 				efi_dir_path = self.target / efi_partition.mountpoint.relative_to('/') / 'EFI'
@@ -1538,7 +1539,7 @@ class Installer:
 
 			config_path = boot_limine_path / 'limine.conf'
 
-			parent_dev_path = device_handler.get_parent_device_path(boot_partition.safe_dev_path)
+			parent_dev_path = get_parent_device_path(boot_partition.safe_dev_path)
 
 			if unique_path := get_unique_path_for_device(parent_dev_path):
 				parent_dev_path = unique_path
@@ -1635,7 +1636,7 @@ class Installer:
 			loader = '/EFI/Linux/arch-{kernel}.efi'
 			cmdline = []
 
-		parent_dev_path = device_handler.get_parent_device_path(boot_partition.safe_dev_path)
+		parent_dev_path = get_parent_device_path(boot_partition.safe_dev_path)
 
 		cmd_template = (
 			'efibootmgr',


### PR DESCRIPTION
Part of #4149, continuing #4232
