### PR TITLE
feat: add `plasma-login-manager` option and set it as default for Plasma

### DIFF
--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -23,4 +23,4 @@ class PlasmaProfile(XorgProfile):
 	@property
 	@override
 	def default_greeter_type(self) -> GreeterType:
-		return GreeterType.Sddm
+		return GreeterType.PlasmaLoginManager

--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -32,6 +32,7 @@ class GreeterType(Enum):
 	Gdm = 'gdm'
 	Ly = 'ly'
 	CosmicSession = 'cosmic-greeter'
+	PlasmaLoginManager = 'plasma-login-manager'
 
 
 class SelectResult(Enum):

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -198,6 +198,9 @@ class ProfileHandler:
 			case GreeterType.CosmicSession:
 				packages = ['cosmic-greeter']
 				service = ['cosmic-greeter']
+			case GreeterType.PlasmaLoginManager:
+				packages = ['plasma-login-manager']
+				service = ['plasmalogin']
 
 		if packages:
 			install_session.add_additional_packages(packages)


### PR DESCRIPTION
Resolves: #4189 

## PR Description:

Add the `plasma-login-manager` option as a new greeter and set it as default for `plasma`.

## Tests and Checks
- [x] I have tested the code!<br>
