### PR TITLE
Fix a reportUnnecessaryIsInstance Pyright warning

### DIFF
--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -317,10 +317,6 @@ class Size:
 	unit: Unit
 	sector_size: SectorSize
 
-	def __post_init__(self) -> None:
-		if not isinstance(self.sector_size, SectorSize):
-			raise ValueError('sector size must be of type SectorSize')
-
 	def json(self) -> _SizeSerialization:
 		return {
 			'value': self.value,


### PR DESCRIPTION
## PR Description:

This PR fixes the following warning:

```
archinstall/archinstall/lib/models/device.py:321:10 - error: Unnecessary isinstance call; "SectorSize" is always an instance of "SectorSize" (reportUnnecessaryIsInstance)
```