### PR TITLE
user: add required birth date field to non-root user creation

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1,4 +1,5 @@
 import glob
+import json
 import os
 import platform
 import re
@@ -1942,6 +1943,20 @@ class Installer:
 
 		if user.sudo:
 			self.enable_sudo(user)
+
+		if user.birth_date:
+			self._write_userdb_dropin(user)
+
+	def _write_userdb_dropin(self, user: User) -> None:
+		userdb_dir = self.target / 'etc' / 'userdb'
+		userdb_dir.mkdir(parents=True, exist_ok=True)
+
+		dropin = userdb_dir / f'{user.username}.user'
+		record = {'userName': user.username, 'birthDate': user.birth_date}
+		dropin.write_text(json.dumps(record))
+		dropin.chmod(0o644)
+
+		info(f'Wrote userdb drop-in for {user.username} with birth date')
 
 	def set_user_password(self, user: User) -> bool:
 		info(f'Setting password for {user.username}')

--- a/archinstall/lib/models/users.py
+++ b/archinstall/lib/models/users.py
@@ -107,6 +107,7 @@ UserSerialization = TypedDict(
 		'sudo': bool,
 		'groups': list[str],
 		'enc_password': str | None,
+		'birth_date': NotRequired[str],
 	},
 )
 
@@ -158,6 +159,7 @@ class User:
 	password: Password
 	sudo: bool
 	groups: list[str] = field(default_factory=list)
+	birth_date: str = ''
 
 	@override
 	def __str__(self) -> str:
@@ -170,15 +172,21 @@ class User:
 			'password': self.password.hidden(),
 			'sudo': self.sudo,
 			'groups': self.groups,
+			'birth_date': self.birth_date,
 		}
 
 	def json(self) -> UserSerialization:
-		return {
+		data: UserSerialization = {
 			'username': self.username,
 			'enc_password': self.password.enc_password,
 			'sudo': self.sudo,
 			'groups': self.groups,
 		}
+
+		if self.birth_date:
+			data['birth_date'] = self.birth_date
+
+		return data
 
 	@classmethod
 	def parse_arguments(
@@ -208,6 +216,7 @@ class User:
 				password=password,
 				sudo=entry.get('sudo', False) is True,
 				groups=groups,
+				birth_date=entry.get('birth_date', ''),
 			)
 
 			users.append(user)

--- a/archinstall/lib/user/user_menu.py
+++ b/archinstall/lib/user/user_menu.py
@@ -1,4 +1,5 @@
 import re
+from datetime import UTC, date, datetime
 from typing import override
 
 from archinstall.lib.menu.helpers import Confirmation, Input
@@ -91,6 +92,12 @@ class UserList(ListManager[User]):
 			return None
 
 		header += f'{tr("Password")}: {password.hidden()}\n'
+
+		birth_date = self._ask_birth_date(header)
+
+		if birth_date:
+			header += f'{tr("Birth date")}: {birth_date}\n'
+
 		prompt = f'{header}\n' + tr('Should "{}" be a superuser (sudo)?\n').format(username)
 
 		result = Confirmation(
@@ -105,7 +112,35 @@ class UserList(ListManager[User]):
 			case _:
 				raise ValueError('Unhandled result type')
 
-		return User(username, password, sudo)
+		return User(username, password, sudo, birth_date=birth_date)
+
+	def _validate_birth_date(self, value: str | None) -> str | None:
+		if not value:
+			return tr('Birth date is required')
+		try:
+			dt = date.fromisoformat(value)
+		except ValueError:
+			return tr('Invalid date format. Use YYYY-MM-DD')
+		if dt > datetime.now(tz=UTC).date():
+			return tr('Birth date cannot be in the future')
+		if dt.year < 1900:
+			return tr('Birth date year must be 1900 or later')
+		return None
+
+	def _ask_birth_date(self, header: str) -> str:
+		prompt = f'{header}\n' + tr('Enter birth date (YYYY-MM-DD, e.g. 2000-01-01)')
+
+		result = Input(
+			prompt,
+			allow_skip=False,
+			validator_callback=self._validate_birth_date,
+		).show()
+
+		match result.type_:
+			case ResultType.Selection:
+				return result.get_value() or ''
+			case _:
+				raise ValueError('Unhandled result type')
 
 
 def select_users(prompt: str = '', preset: list[User] = []) -> list[User]:


### PR DESCRIPTION
Add a required birth date prompt (YYYY-MM-DD) to the user creation flow, stored as a systemd userdb JSON drop-in at `/etc/userdb/<user>.user` on the target system.

## Motivation

Recent age verification laws in California (AB-1043), Colorado (SB26-051), Brazil (Lei 15.211/2025), etc. require platforms to verify user age. Collecting birth date at install time ensures Arch Linux is compliant with these regulations.

## Changes

- `users.py` — add `birth_date` field to `User` dataclass, serialization, and config parsing
- `user_menu.py` — add required birth date prompt with validation after the password step
- `installer.py` — write userdb JSON drop-in with `userName` and `birthDate` after user creation

## Integration

This integrates with [systemd PR #40954](https://github.com/systemd/systemd/pull/40954) which adds `birthDate` support to JSON user records. The drop-in is read by systemd's `io.systemd.DropIn` service and displayed by `userdbctl`.