### PR TITLE
Add nepali translation

### DIFF
--- a/archinstall/locales/ne/LC_MESSAGES/base.po
+++ b/archinstall/locales/ne/LC_MESSAGES/base.po
@@ -512,212 +512,217 @@ msgid "Choose which configuration to save"
 msgstr "कुन कन्फिगरेसन बचत गर्ने रोज्नुहोस्"
 
 msgid "Enter a directory for the configuration(s) to be saved: "
-msgstr "कन्फिगरेसन बचत गर्नको लागि एउटा डाइरेक्टरी प्रविष्ट गर्नुहोस्: "
-
+msgstr "कन्फिगरेसन बचत गर्नको लागि एउटा डाइरेक्टरी प्रविष्ट गर्नुहोस्: "ok
 msgid "Not a valid directory: {}"
-msgstr ""
+msgstr "मान्य डाइरेक्टरी होइन: {}"
 
 msgid "The password you are using seems to be weak,"
-msgstr ""
+msgstr "तपाईंले प्रयोग गरिरहनुभएको पासवर्ड कमजोर देखिन्छ,"
 
 msgid "are you sure you want to use it?"
-msgstr ""
+msgstr "के तपाईं निश्चित रूपमा यसलाई प्रयोग गर्न चाहनुहुन्छ?"
 
 msgid "Optional repositories"
-msgstr ""
+msgstr "वैकल्पिक रिपोजिटरीहरू (Optional repositories)"
 
 msgid "Save configuration"
-msgstr ""
+msgstr "कन्फिगरेसन बचत गर्नुहोस्"
 
 msgid "Missing configurations:\n"
-msgstr ""
+msgstr "छुटिरहेका कन्फिगरेसनहरू:\n"
 
 msgid "Either root-password or at least 1 superuser must be specified"
-msgstr ""
+msgstr "कि त रूट-पासवर्ड वा कम्तिमा १ सुपर-युजर (superuser) उल्लेख गर्नुपर्छ"
 
 msgid "Manage superuser accounts: "
-msgstr ""
+msgstr "सुपर-युजर खाताहरू व्यवस्थापन गर्नुहोस्: "
 
 msgid "Manage ordinary user accounts: "
-msgstr ""
+msgstr "साधारण प्रयोगकर्ता खाताहरू व्यवस्थापन गर्नुहोस्: "
 
 msgid " Subvolume :{:16}"
-msgstr ""
+msgstr " उप-भोल्युम :{:16}"
 
 msgid " mounted at {:16}"
-msgstr ""
+msgstr " {:16} मा माउन्ट गरिएको"
 
 msgid " with option {}"
-msgstr ""
+msgstr " विकल्प {} सँग"
 
 msgid ""
 "\n"
 " Fill the desired values for a new subvolume \n"
 msgstr ""
+"\n"
+" नयाँ उप-भोल्युमको लागि इच्छाएको मानहरू भर्नुहोस् \n"
 
 msgid "Subvolume name "
-msgstr ""
+msgstr "उप-भोल्युमको नाम "
 
 msgid "Subvolume mountpoint"
-msgstr ""
+msgstr "उप-भोल्युम माउन्ट-पोइन्ट"
 
 msgid "Subvolume options"
-msgstr ""
+msgstr "उप-भोल्युम विकल्पहरू"
 
 msgid "Save"
-msgstr ""
+msgstr "बचत गर्नुहोस्"
 
 msgid "Subvolume name :"
-msgstr ""
+msgstr "उप-भोल्युमको नाम :"
 
 msgid "Select a mount point :"
-msgstr ""
+msgstr "माउन्ट पोइन्ट चयन गर्नुहोस् :"
 
 msgid "Select the desired subvolume options "
-msgstr ""
+msgstr "इच्छाएको उप-भोल्युम विकल्पहरू चयन गर्नुहोस् "
 
 msgid "Define users with sudo privilege, by username: "
-msgstr ""
+msgstr "प्रयोगकर्ता-नाम मार्फत sudo विशेषाधिकार भएका प्रयोगकर्ताहरू परिभाषित गर्नुहोस्: "
 
 #, python-brace-format
 msgid "[!] A log file has been created here: {}"
-msgstr ""
+msgstr "[!] यहाँ एउटा लग फाइल सिर्जना गरिएको छ: {}"
 
 msgid "Would you like to use BTRFS subvolumes with a default structure?"
-msgstr ""
+msgstr "के तपाईं पूर्वनिर्धारित ढाँचामा BTRFS उप-भोल्युमहरू प्रयोग गर्न चाहनुहुन्छ?"
 
 msgid "Would you like to use BTRFS compression?"
-msgstr ""
+msgstr "के तपाईं BTRFS कम्प्रेसन (compression) प्रयोग गर्न चाहनुहुन्छ?"
 
 msgid "Would you like to create a separate partition for /home?"
-msgstr ""
+msgstr "के तपाईं /home को लागि छुट्टै पार्टिसन सिर्जना गर्न चाहनुहुन्छ?"
 
 msgid "The selected drives do not have the minimum capacity required for an automatic suggestion\n"
-msgstr ""
+msgstr "चयन गरिएका ड्राइभहरूमा स्वचालित सुझावको लागि आवश्यक न्यूनतम क्षमता छैन\n"
 
 msgid "Minimum capacity for /home partition: {}GB\n"
-msgstr ""
+msgstr "/home पार्टिसनको लागि न्यूनतम क्षमता: {}GB\n"
 
 msgid "Minimum capacity for Arch Linux partition: {}GB"
-msgstr ""
+msgstr "Arch Linux पार्टिसनको लागि न्यूनतम क्षमता: {}GB"
 
 msgid "Continue"
-msgstr ""
+msgstr "जारी राख्नुहोस्"
 
 msgid "yes"
 msgstr "हो"
 
 msgid "no"
-msgstr ""
+msgstr "होइन"
 
 msgid "set: {}"
-msgstr ""
+msgstr "सेट: {}"
 
 msgid "Manual configuration setting must be a list"
-msgstr ""
+msgstr "म्यानुअल कन्फिगरेसन सेटिङ एउटा सूची (list) हुनुपर्छ"
 
 msgid "No iface specified for manual configuration"
-msgstr ""
+msgstr "म्यानुअल कन्फिगरेसनको लागि कुनै iface उल्लेख गरिएको छैन"
 
 msgid "Manual nic configuration with no auto DHCP requires an IP address"
-msgstr ""
+msgstr "स्वचालित DHCP बिनाको म्यानुअल nic कन्फिगरेसनको लागि IP ठेगाना आवश्यक पर्छ"
 
 msgid "Add interface"
-msgstr ""
+msgstr "इन्टरफेस थप्नुहोस्"
 
 msgid "Edit interface"
-msgstr ""
+msgstr "इन्टरफेस सम्पादन गर्नुहोस्"
 
 msgid "Delete interface"
-msgstr ""
+msgstr "इन्टरफेस मेटाउनुहोस्"
 
 msgid "Select interface to add"
-msgstr ""
+msgstr "थप्नको लागि इन्टरफेस चयन गर्नुहोस्"
 
 msgid "Manual configuration"
-msgstr ""
+msgstr "म्यानुअल कन्फिगरेसन"
 
 msgid "Mark/Unmark a partition as compressed (btrfs only)"
-msgstr ""
+msgstr "पार्टिसनलाई कम्प्रेस्ड (compressed) को रूपमा चिन्ह लगाउनुहोस् वा हटाउनुहोस् (btrfs को लागि मात्र)"
 
 msgid "The password you are using seems to be weak, are you sure you want to use it?"
-msgstr ""
+msgstr "तपाईंले प्रयोग गरिरहनुभएको पासवर्ड कमजोर देखिन्छ, के तपाईं निश्चित रूपमा यसलाई प्रयोग गर्न चाहनुहुन्छ?"
 
 msgid "Provides a selection of desktop environments and tiling window managers, e.g. gnome, kde, sway"
-msgstr ""
+msgstr "डेस्कटप वातावरण र टाइलिङ विन्डो प्रबन्धकहरूको छनोट प्रदान गर्दछ, जस्तै: gnome, kde, sway"
 
 msgid "Select your desired desktop environment"
-msgstr ""
+msgstr "आफ्नो इच्छाएको डेस्कटप वातावरण चयन गर्नुहोस्"
 
 msgid "A very basic installation that allows you to customize Arch Linux as you see fit."
-msgstr ""
+msgstr "एकदमै आधारभूत स्थापना जसले तपाईंलाई आफ्नो आवश्यकता अनुसार Arch Linux कस्टमाइज गर्न अनुमति दिन्छ।"
 
 msgid "Provides a selection of various server packages to install and enable, e.g. httpd, nginx, mariadb"
-msgstr ""
+msgstr "स्थापना र सक्षम गर्नका लागि विभिन्न सर्भर प्याकेजहरूको छनोट प्रदान गर्दछ, जस्तै: httpd, nginx, mariadb"
 
 msgid "Choose which servers to install, if none then a minimal installation will be done"
-msgstr ""
+msgstr "कुन सर्भरहरू स्थापना गर्ने रोज्नुहोस्, यदि कुनै पनि रोजिएन भने न्यूनतम (minimal) स्थापना गरिनेछ"
 
 msgid "Installs a minimal system as well as xorg and graphics drivers."
-msgstr ""
+msgstr "न्यूनतम प्रणालीको साथै xorg र ग्राफिक्स ड्राइभरहरू स्थापना गर्दछ।"
 
 msgid "Press Enter to continue."
-msgstr ""
+msgstr "अगाडि बढ्नको लागि Enter थिच्नुहोस्।"
 
 msgid "Would you like to chroot into the newly created installation and perform post-installation configuration?"
-msgstr ""
+msgstr "के तपाईं भर्खरै सिर्जना गरिएको स्थापनामा chroot गरेर स्थापना-पश्चातको कन्फिगरेसन गर्न चाहनुहुन्छ?"
 
 msgid "Are you sure you want to reset this setting?"
-msgstr ""
+msgstr "के तपाईं पक्का यो सेटिङ रिसेट गर्न चाहनुहुन्छ?"
 
 msgid "Select one or more hard drives to use and configure\n"
-msgstr ""
+msgstr "प्रयोग र कन्फिगर गर्नको लागि एक वा बढी हार्ड ड्राइभहरू चयन गर्नुहोस्\n"
 
 msgid "Any modifications to the existing setting will reset the disk layout!"
-msgstr ""
+msgstr "अवस्थित सेटिङमा कुनै पनि परिमार्जनले डिस्क लेआउटलाई रिसेट गर्नेछ!"
 
 msgid "If you reset the harddrive selection this will also reset the current disk layout. Are you sure?"
-msgstr ""
+msgstr "यदि तपाईंले हार्ड-ड्राइभ चयन रिसेट गर्नुभयो भने यसले हालको डिस्क लेआउट पनि रिसेट गर्नेछ। के तपाईं पक्का हुनुहुन्छ?"
 
 msgid "Save and exit"
-msgstr ""
+msgstr "बचत गर्नुहोस् र बाहिर निस्कनुहोस्"
 
 msgid ""
 "{}\n"
 "contains queued partitions, this will remove those, are you sure?"
 msgstr ""
+"{}\n"
+"मा लामबद्ध पार्टिसनहरू छन्, यसले ती हटाउनेछ, के तपाईं पक्का हुनुहुन्छ?"
 
 msgid "No audio server"
-msgstr ""
+msgstr "कुनै अडियो सर्भर छैन"
 
 msgid "(default)"
-msgstr ""
+msgstr "(पूर्वनिर्धारित)"
 
 msgid "Use ESC to skip"
-msgstr ""
+msgstr "छोड्नको लागि ESC प्रयोग गर्नुहोस्"
 
 msgid ""
 "Use CTRL+C to reset current selection\n"
 "\n"
 msgstr ""
+"हालको चयन रिसेट गर्न CTRL+C प्रयोग गर्नुहोस्\n"
+"\n"
 
 msgid "Copy to: "
-msgstr ""
+msgstr "यसमा प्रतिलिपि गर्नुहोस्: "
 
 msgid "Edit: "
-msgstr ""
+msgstr "सम्पादन: "
 
 msgid "Key: "
-msgstr ""
+msgstr "कुञ्जी (Key): "
 
 msgid "Edit {}: "
-msgstr ""
+msgstr "सम्पादन {}: "
 
 msgid "Add: "
-msgstr ""
+msgstr "थप्नुहोस्: "
 
 msgid "Value: "
-msgstr ""
+msgstr "मान (Value): "
 
 msgid "You can skip selecting a drive and partitioning and use whatever drive-setup is mounted at /mnt (experimental)"
 msgstr ""


### PR DESCRIPTION
Quick update: I have just pushed a major expansion to the Nepali (ne) translation.

Progress Update:

Total Strings: Now at 700+ translated strings.

Key Additions: >   * Full BTRFS subvolume and compression management.

Desktop Environment (GNOME, KDE, Sway) and Window Manager profiles.

Network interface manual configuration (Static IP/DHCP).

Final installation summary and post-install chroot prompts.

Build: Updated both base.po and the compiled base.mo binary.

I am on track to finish the remaining strings by the end of this week as promised. Tagging @svartkanin for visibility. Thanks!