### PR TITLE
Check user's jurisdiction and prevent installation in certain regions

### DIFF
--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -72,6 +72,7 @@ class ArchConfig:
 	hostname: str = 'archlinux'
 	kernels: list[str] = field(default_factory=lambda: ['linux'])
 	ntp: bool = True
+	jurisdiction_restriction: bool = False
 	packages: list[str] = field(default_factory=list)
 	parallel_downloads: int = 0
 	timezone: str = 'UTC'
@@ -112,6 +113,7 @@ class ArchConfig:
 			'bootloader_config': self.bootloader_config.json() if self.bootloader_config else None,
 			'app_config': self.app_config.json() if self.app_config else None,
 			'auth_config': self.auth_config.json() if self.auth_config else None,
+			'jurisdiction_restriction': self.jurisdiction_restriction,
 		}
 
 		if self.locale_config:
@@ -139,6 +141,8 @@ class ArchConfig:
 
 		if script := args_config.get('script', None):
 			arch_config.script = script
+
+		arch_config.jurisdiction_restriction = args_config.get('jurisdiction_restriction', False)
 
 		if archinstall_lang := args_config.get('archinstall-language', None):
 			arch_config.archinstall_language = translation_handler.get_language_by_name(archinstall_lang)

--- a/archinstall/lib/general/general_menu.py
+++ b/archinstall/lib/general/general_menu.py
@@ -15,6 +15,22 @@ class PostInstallationAction(Enum):
 	CHROOT = tr('chroot into installation for post-installation configurations')
 
 
+async def select_jurisdiction(preset: bool = False) -> bool:
+	header = tr('Are you located in California, Brazil, or any other region that mandates operating systems to verify or assist to verify the age, name, sex, or any other identifying information of the user?') + '\n'
+
+	result = await Confirmation(
+		header=header,
+		allow_skip=False,
+		preset=preset,
+	).show()
+
+	match result.type_:
+		case ResultType.Selection:
+			return result.item() == MenuItem.yes()
+		case _:
+			raise ValueError('Unhandled return type')
+
+
 async def select_ntp(preset: bool = True) -> bool:
 	header = tr('Would you like to use automatic time synchronization (NTP) with the default time servers?\n') + '\n'
 	header += (

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -7,7 +7,7 @@ from archinstall.lib.authentication.authentication_menu import AuthenticationMen
 from archinstall.lib.bootloader.bootloader_menu import BootloaderMenu
 from archinstall.lib.configuration import save_config
 from archinstall.lib.disk.disk_menu import DiskLayoutConfigurationMenu
-from archinstall.lib.general.general_menu import add_number_of_parallel_downloads, select_hostname, select_ntp, select_timezone
+from archinstall.lib.general.general_menu import add_number_of_parallel_downloads, select_hostname, select_ntp, select_timezone, select_jurisdiction
 from archinstall.lib.general.system_menu import select_kernel, select_swap
 from archinstall.lib.hardware import SysInfo
 from archinstall.lib.locale.locale_menu import LocaleMenu
@@ -60,6 +60,13 @@ class GlobalMenu(AbstractMenu[None]):
 				action=self._select_archinstall_language,
 				preview_action=self._prev_archinstall_language,
 				key='archinstall_language',
+			),
+			MenuItem(
+				text=tr('Jurisdiction Restriction'),
+				action=select_jurisdiction,
+				value=False,
+				preview_action=self._prev_jurisdiction,
+				key='jurisdiction_restriction',
 			),
 			MenuItem(
 				text=tr('Locales'),
@@ -198,6 +205,7 @@ class GlobalMenu(AbstractMenu[None]):
 	def _missing_configs(self) -> list[str]:
 		item: MenuItem = self._item_group.find_by_key('auth_config')
 		auth_config: AuthenticationConfiguration | None = item.value
+		jurisdiction_restriction_item: MenuItem = self._item_group.find_by_key('jurisdiction_restriction')
 
 		def check(s: str) -> bool:
 			item = self._item_group.find_by_key(s)
@@ -205,6 +213,10 @@ class GlobalMenu(AbstractMenu[None]):
 
 		missing = set()
 
+		if jurisdiction_restriction_item.value:
+			missing.add(
+				tr('We do not provide Arch Linux to your jurisdiction. Please contact your local lawmakers if you have any question.'),
+			)
 		if (auth_config is None or auth_config.root_enc_password is None) and not (auth_config and auth_config.has_superuser()):
 			missing.add(
 				tr('Either root-password or at least 1 user with sudo privileges must be specified'),
@@ -369,6 +381,13 @@ class GlobalMenu(AbstractMenu[None]):
 		if item.value is not None:
 			output = f'{tr("NTP")}: '
 			output += tr('Enabled') if item.value else tr('Disabled')
+			return output
+		return None
+
+	def _prev_jurisdiction(self, item: MenuItem) -> str | None:
+		if item.value is not None:
+			output = f'{tr("Jurisdiction Restriction")}: '
+			output += tr('Yes') if item.value else tr('No')
 			return output
 		return None
 


### PR DESCRIPTION
Stop providing installation to certain jurisdictions

## Motivation

Recent age verification laws in California (AB-1043), Colorado (SB26-051), Brazil (Lei 15.211/2025), etc. require OS providers to verify user age. I hope that, by stopping providing Arch Linux installation to these regions, we can be fully compliant to the requirement.  

### Changes

Adding a field for users to declare whether they are located in regions that require an OS to provide or facilitate age, name, sex, or any other identifying information.  If they are, simply do not allow installation.  

I believe this is a less less intrusive alternative to  PR #4290. 

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
