### PR TITLE
Replace tab with spaces in preview package lists

### DIFF
--- a/archinstall/default_profiles/profile.py
+++ b/archinstall/default_profiles/profile.py
@@ -212,6 +212,6 @@ class Profile:
 		text = tr('Installed packages') + ':\n'
 
 		for pkg in sorted(packages):
-			text += f'\t- {pkg}\n'
+			text += f'    - {pkg}\n'
 
 		return text

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -73,7 +73,7 @@ class GfxDriver(Enum):
 		text = tr('Installed packages') + ':\n'
 
 		for p in sorted(pkg_names):
-			text += f'\t- {p}\n'
+			text += f'    - {p}\n'
 
 		return text
 


### PR DESCRIPTION
## PR Description:
Replace tab indentation with spaces in preview package lists.
Tabs render with unpredictable width in Textual TUI, causing more line wrapping in the preview panel that we need.

Before:
<img width="496" height="389" alt="image" src="https://github.com/user-attachments/assets/30c97829-2e83-4558-bcd7-06b2c6bb5d22" />
<img width="517" height="333" alt="image" src="https://github.com/user-attachments/assets/01a18a91-f1f2-4271-a871-6963112d7ad4" />


After:
<img width="522" height="366" alt="image" src="https://github.com/user-attachments/assets/aebc8e7e-1145-43b5-b962-f599c8aa4ccb" />

<img width="486" height="204" alt="image" src="https://github.com/user-attachments/assets/4e6f5729-0dcb-416c-be59-782184d248fe" />
