### PR TITLE
Add optional "Additional fonts" selection to Applications menu

### DIFF
--- a/archinstall/applications/fonts.py
+++ b/archinstall/applications/fonts.py
@@ -1,0 +1,14 @@
+from typing import TYPE_CHECKING
+
+from archinstall.lib.models.application import FontsConfiguration
+from archinstall.lib.output import debug
+
+if TYPE_CHECKING:
+	from archinstall.lib.installer import Installer
+
+
+class FontsApp:
+	def install(self, install_session: Installer, fonts_config: FontsConfiguration) -> None:
+		packages = [f.value for f in fonts_config.fonts]
+		debug(f'Installing fonts: {packages}')
+		install_session.add_additional_packages(packages)

--- a/archinstall/lib/applications/application_handler.py
+++ b/archinstall/lib/applications/application_handler.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from archinstall.applications.audio import AudioApp
 from archinstall.applications.bluetooth import BluetoothApp
 from archinstall.applications.firewall import FirewallApp
+from archinstall.applications.fonts import FontsApp
 from archinstall.applications.power_management import PowerManagementApp
 from archinstall.applications.print_service import PrintServiceApp
 from archinstall.lib.models import Audio
@@ -41,4 +42,10 @@ class ApplicationHandler:
 			FirewallApp().install(
 				install_session,
 				app_config.firewall_config,
+			)
+
+		if app_config.fonts_config:
+			FontsApp().install(
+				install_session,
+				app_config.fonts_config,
 			)

--- a/archinstall/lib/applications/application_menu.py
+++ b/archinstall/lib/applications/application_menu.py
@@ -80,7 +80,7 @@ class ApplicationMenu(AbstractSubMenu[ApplicationConfiguration]):
 				key='firewall_config',
 			),
 			MenuItem(
-				text=tr('Fonts'),
+				text=tr('Additional fonts'),
 				action=select_fonts,
 				value=self._app_config.fonts_config,
 				preview_action=self._prev_fonts,
@@ -128,7 +128,7 @@ class ApplicationMenu(AbstractSubMenu[ApplicationConfiguration]):
 		if item.value is not None:
 			config: FontsConfiguration = item.value
 			packages = ', '.join(f.value for f in config.fonts)
-			return f'{tr("Fonts")}: {packages}'
+			return f'{tr("Additional fonts")}: {packages}'
 		return None
 
 

--- a/archinstall/lib/applications/application_menu.py
+++ b/archinstall/lib/applications/application_menu.py
@@ -237,6 +237,7 @@ async def select_firewall(preset: FirewallConfiguration | None = None) -> Firewa
 
 async def select_fonts(preset: FontsConfiguration | None = None) -> FontsConfiguration | None:
 	descriptions = {
+		FontPackage.NOTO: tr('Unicode font coverage for most languages'),
 		FontPackage.EMOJI: tr('color emoji for browsers and apps'),
 		FontPackage.CJK: tr('Chinese, Japanese, Korean characters'),
 	}

--- a/archinstall/lib/applications/application_menu.py
+++ b/archinstall/lib/applications/application_menu.py
@@ -10,6 +10,8 @@ from archinstall.lib.models.application import (
 	BluetoothConfiguration,
 	Firewall,
 	FirewallConfiguration,
+	FontPackage,
+	FontsConfiguration,
 	PowerManagement,
 	PowerManagementConfiguration,
 	PrintServiceConfiguration,
@@ -77,6 +79,13 @@ class ApplicationMenu(AbstractSubMenu[ApplicationConfiguration]):
 				preview_action=self._prev_firewall,
 				key='firewall_config',
 			),
+			MenuItem(
+				text=tr('Fonts'),
+				action=select_fonts,
+				value=self._app_config.fonts_config,
+				preview_action=self._prev_fonts,
+				key='fonts_config',
+			),
 		]
 
 	def _prev_power_management(self, item: MenuItem) -> str | None:
@@ -113,6 +122,13 @@ class ApplicationMenu(AbstractSubMenu[ApplicationConfiguration]):
 		if item.value is not None:
 			config: FirewallConfiguration = item.value
 			return f'{tr("Firewall")}: {config.firewall.value}'
+		return None
+
+	def _prev_fonts(self, item: MenuItem) -> str | None:
+		if item.value is not None:
+			config: FontsConfiguration = item.value
+			packages = ', '.join(f.value for f in config.fonts)
+			return f'{tr("Fonts")}: {packages}'
 		return None
 
 
@@ -215,5 +231,37 @@ async def select_firewall(preset: FirewallConfiguration | None = None) -> Firewa
 			return preset
 		case ResultType.Selection:
 			return FirewallConfiguration(firewall=result.get_value())
+		case ResultType.Reset:
+			return None
+
+
+async def select_fonts(preset: FontsConfiguration | None = None) -> FontsConfiguration | None:
+	descriptions = {
+		FontPackage.EMOJI: tr('color emoji for browsers and apps'),
+		FontPackage.CJK: tr('Chinese, Japanese, Korean characters'),
+	}
+	items = [MenuItem(f'{f.value} ({descriptions[f]})', value=f) for f in FontPackage]
+	group = MenuItemGroup(items)
+
+	if preset:
+		for f in preset.fonts:
+			group.set_selected_by_value(f)
+
+	result = await Selection[FontPackage](
+		group,
+		header=tr('Select font packages to install'),
+		allow_skip=True,
+		allow_reset=True,
+		multi=True,
+	).show()
+
+	match result.type_:
+		case ResultType.Skip:
+			return preset
+		case ResultType.Selection:
+			selected = result.get_values()
+			if selected:
+				return FontsConfiguration(fonts=selected)
+			return None
 		case ResultType.Reset:
 			return None

--- a/archinstall/lib/applications/application_menu.py
+++ b/archinstall/lib/applications/application_menu.py
@@ -236,12 +236,7 @@ async def select_firewall(preset: FirewallConfiguration | None = None) -> Firewa
 
 
 async def select_fonts(preset: FontsConfiguration | None = None) -> FontsConfiguration | None:
-	descriptions = {
-		FontPackage.NOTO: tr('Unicode font coverage for most languages'),
-		FontPackage.EMOJI: tr('color emoji for browsers and apps'),
-		FontPackage.CJK: tr('Chinese, Japanese, Korean characters'),
-	}
-	items = [MenuItem(f'{f.value} ({descriptions[f]})', value=f) for f in FontPackage]
+	items = [MenuItem(f'{f.value} ({f.description()})', value=f) for f in FontPackage]
 	group = MenuItemGroup(items)
 
 	if preset:

--- a/archinstall/lib/models/application.py
+++ b/archinstall/lib/models/application.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import StrEnum, auto
 from typing import Any, NotRequired, Self, TypedDict
 
+from archinstall.lib.translationhandler import tr
+
 
 class PowerManagement(StrEnum):
 	POWER_PROFILES_DAEMON = 'power-profiles-daemon'
@@ -43,6 +45,15 @@ class FontPackage(StrEnum):
 	NOTO = 'noto-fonts'
 	EMOJI = 'noto-fonts-emoji'
 	CJK = 'noto-fonts-cjk'
+
+	def description(self) -> str:
+		match self:
+			case FontPackage.NOTO:
+				return tr('Unicode font coverage for most languages')
+			case FontPackage.EMOJI:
+				return tr('color emoji for browsers and apps')
+			case FontPackage.CJK:
+				return tr('Chinese, Japanese, Korean characters')
 
 
 class FontsConfigSerialization(TypedDict):

--- a/archinstall/lib/models/application.py
+++ b/archinstall/lib/models/application.py
@@ -39,6 +39,15 @@ class FirewallConfigSerialization(TypedDict):
 	firewall: str
 
 
+class FontPackage(StrEnum):
+	EMOJI = 'noto-fonts-emoji'
+	CJK = 'noto-fonts-cjk'
+
+
+class FontsConfigSerialization(TypedDict):
+	fonts: list[str]
+
+
 class ZramAlgorithm(StrEnum):
 	ZSTD = 'zstd'
 	LZO_RLE = 'lzo-rle'
@@ -53,6 +62,7 @@ class ApplicationSerialization(TypedDict):
 	power_management_config: NotRequired[PowerManagementConfigSerialization]
 	print_service_config: NotRequired[PrintServiceConfigSerialization]
 	firewall_config: NotRequired[FirewallConfigSerialization]
+	fonts_config: NotRequired[FontsConfigSerialization]
 
 
 @dataclass
@@ -127,6 +137,18 @@ class FirewallConfiguration:
 		)
 
 
+@dataclass
+class FontsConfiguration:
+	fonts: list[FontPackage]
+
+	def json(self) -> FontsConfigSerialization:
+		return {'fonts': [f.value for f in self.fonts]}
+
+	@classmethod
+	def parse_arg(cls, arg: FontsConfigSerialization) -> Self:
+		return cls(fonts=[FontPackage(f) for f in arg['fonts']])
+
+
 @dataclass(frozen=True)
 class ZramConfiguration:
 	enabled: bool
@@ -149,6 +171,7 @@ class ApplicationConfiguration:
 	power_management_config: PowerManagementConfiguration | None = None
 	print_service_config: PrintServiceConfiguration | None = None
 	firewall_config: FirewallConfiguration | None = None
+	fonts_config: FontsConfiguration | None = None
 
 	@classmethod
 	def parse_arg(
@@ -177,6 +200,9 @@ class ApplicationConfiguration:
 		if args and (firewall_config := args.get('firewall_config')) is not None:
 			app_config.firewall_config = FirewallConfiguration.parse_arg(firewall_config)
 
+		if args and (fonts_config := args.get('fonts_config')) is not None:
+			app_config.fonts_config = FontsConfiguration.parse_arg(fonts_config)
+
 		return app_config
 
 	def json(self) -> ApplicationSerialization:
@@ -196,5 +222,8 @@ class ApplicationConfiguration:
 
 		if self.firewall_config:
 			config['firewall_config'] = self.firewall_config.json()
+
+		if self.fonts_config:
+			config['fonts_config'] = self.fonts_config.json()
 
 		return config

--- a/archinstall/lib/models/application.py
+++ b/archinstall/lib/models/application.py
@@ -40,6 +40,7 @@ class FirewallConfigSerialization(TypedDict):
 
 
 class FontPackage(StrEnum):
+	NOTO = 'noto-fonts'
 	EMOJI = 'noto-fonts-emoji'
 	CJK = 'noto-fonts-cjk'
 

--- a/archinstall/lib/models/application.py
+++ b/archinstall/lib/models/application.py
@@ -45,6 +45,8 @@ class FontPackage(StrEnum):
 	NOTO = 'noto-fonts'
 	EMOJI = 'noto-fonts-emoji'
 	CJK = 'noto-fonts-cjk'
+	LIBERATION = 'ttf-liberation'
+	DEJAVU = 'ttf-dejavu'
 
 	def description(self) -> str:
 		match self:
@@ -54,6 +56,10 @@ class FontPackage(StrEnum):
 				return tr('color emoji for browsers and apps')
 			case FontPackage.CJK:
 				return tr('Chinese, Japanese, Korean characters')
+			case FontPackage.LIBERATION:
+				return tr('Arial/Times/Courier replacement, Cyrillic support for Steam/games')
+			case FontPackage.DEJAVU:
+				return tr('wide Unicode coverage, good fallback font')
 
 
 class FontsConfigSerialization(TypedDict):

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -1940,7 +1940,7 @@ msgstr ""
 msgid "Firewall"
 msgstr ""
 
-msgid "Fonts"
+msgid "Additional fonts"
 msgstr ""
 
 msgid "Select font packages to install"

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -1946,6 +1946,9 @@ msgstr ""
 msgid "Select font packages to install"
 msgstr ""
 
+msgid "Unicode font coverage for most languages"
+msgstr ""
+
 msgid "color emoji for browsers and apps"
 msgstr ""
 

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -1940,6 +1940,18 @@ msgstr ""
 msgid "Firewall"
 msgstr ""
 
+msgid "Fonts"
+msgstr ""
+
+msgid "Select font packages to install"
+msgstr ""
+
+msgid "color emoji for browsers and apps"
+msgstr ""
+
+msgid "Chinese, Japanese, Korean characters"
+msgstr ""
+
 msgid "Select audio configuration"
 msgstr ""
 

--- a/archinstall/locales/uk/LC_MESSAGES/base.po
+++ b/archinstall/locales/uk/LC_MESSAGES/base.po
@@ -1887,6 +1887,9 @@ msgstr "Додаткові шрифти"
 msgid "Select font packages to install"
 msgstr "Оберіть пакети шрифтів для встановлення"
 
+msgid "Unicode font coverage for most languages"
+msgstr "покриття шрифтами Unicode для більшості мов"
+
 msgid "color emoji for browsers and apps"
 msgstr "кольорові емодзі для браузерів та програм"
 

--- a/archinstall/locales/uk/LC_MESSAGES/base.po
+++ b/archinstall/locales/uk/LC_MESSAGES/base.po
@@ -1881,8 +1881,8 @@ msgstr "Використовувати NetworkManager (з iwd)"
 msgid "Firewall"
 msgstr "Брандмауер"
 
-msgid "Fonts"
-msgstr "Шрифти"
+msgid "Additional fonts"
+msgstr "Додаткові шрифти"
 
 msgid "Select font packages to install"
 msgstr "Оберіть пакети шрифтів для встановлення"

--- a/archinstall/locales/uk/LC_MESSAGES/base.po
+++ b/archinstall/locales/uk/LC_MESSAGES/base.po
@@ -1881,6 +1881,18 @@ msgstr "Використовувати NetworkManager (з iwd)"
 msgid "Firewall"
 msgstr "Брандмауер"
 
+msgid "Fonts"
+msgstr "Шрифти"
+
+msgid "Select font packages to install"
+msgstr "Оберіть пакети шрифтів для встановлення"
+
+msgid "color emoji for browsers and apps"
+msgstr "кольорові емодзі для браузерів та програм"
+
+msgid "Chinese, Japanese, Korean characters"
+msgstr "китайські, японські, корейські символи"
+
 msgid "Select audio configuration"
 msgstr "Оберіть конфігурацію аудіо"
 


### PR DESCRIPTION
Closes #4412

## PR Description:
Adds a multi-select "Additional fonts" option to the Applications menu, allowing users to install common font packages during installation:
- noto-fonts (Unicode font coverage for most languages)
- noto-fonts-emoji (color emoji for browsers and apps)
- noto-fonts-cjk (Chinese, Japanese, Korean characters)

Nothing is pre-selected - users pick what they need or skip entirely. Follows the same pattern as Audio, Bluetooth, and Firewall applications.

## Tests and Checks
- Open Applications -> Additional fonts -> select one or more -> install completes with packages
- Skip fonts entirely -> no font packages installed
- Save/load config with fonts_config via --config