### PR TITLE
Fix urllib.parse import to avoid warnings with ty and Pyright

### DIFF
--- a/archinstall/lib/mirror/mirror_handler.py
+++ b/archinstall/lib/mirror/mirror_handler.py
@@ -1,5 +1,5 @@
 import time
-import urllib
+import urllib.parse
 from pathlib import Path
 
 from archinstall.lib.models import MirrorRegion


### PR DESCRIPTION
## PR Description:

This commit fixes these type checker warnings:

**Pyright**
```
archinstall/lib/mirror/mirror_handler.py:149:22 - error: "parse" is not a known attribute of module "urllib" (reportAttributeAccessIssue)
```

**ty**
```
archinstall/lib/mirror/mirror_handler.py:149:15: warning[possibly-missing-submodule] Submodule `parse` might not have been imported
```