### PR TITLE
ci: Update renovate to track Arch Linux repos using repology

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,11 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-    "pyparted>=3.13.0",
+    "pyparted==3.13.0",
     "pydantic==2.12.5",
-    "cryptography>=45.0.7",
-    "textual>=5.3.0",
-    "markdown-it-py[linkify]>=4.0.0",
+    "cryptography==46.0.7",
+    "textual==8.2.3",
+    "markdown-it-py[linkify]==4.0.0",
 ]
 
 [project.urls]

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,30 @@
   "pre-commit": {
     "enabled": true
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track runtime Python deps via Arch Linux repos instead of PyPI",
+      "managerFilePatterns": ["**/pyproject.toml"],
+      "matchStrings": [
+        "\"(?<depName>pyparted|pydantic|cryptography|textual|markdown-it-py)(?:\\[.*?\\])?==(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "arch/python-{{{depName}}}",
+      "datasourceTemplate": "repology",
+      "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "description": "Track systemd_python via Arch Linux repos (different package name)",
+      "managerFilePatterns": ["**/pyproject.toml"],
+      "matchStrings": [
+        "\"systemd_python==(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "arch/python-systemd",
+      "datasourceTemplate": "repology",
+      "versioningTemplate": "loose"
+    }
+  ],
   "packageRules": [
     {
       "matchDepTypes": [
@@ -24,6 +48,19 @@
         "astral-sh/ruff-pre-commit"
       ],
       "automerge": true
+    },
+    {
+      "description": "Disable PyPI updates for runtime deps tracked via Arch repos",
+      "matchDatasources": ["pypi"],
+      "matchPackageNames": [
+        "pyparted",
+        "pydantic",
+        "cryptography",
+        "textual",
+        "markdown-it-py",
+        "systemd_python"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Pin runtime deps to current Arch package versions and configure Renovate to use the Repology datasource (Arch repos) instead of PyPI for version bumps. This prevents mismatches like #4427 where a PyPI release landed before Arch shipped it. Dev deps stay on PyPI since they only run in CI.