### PR TITLE
Enable power management services after package installation

### DIFF
--- a/archinstall/applications/power_management.py
+++ b/archinstall/applications/power_management.py
@@ -21,6 +21,18 @@ class PowerManagementApp:
 			'tuned-ppd',
 		]
 
+	@property
+	def ppd_services(self) -> list[str]:
+		return [
+			'power-profiles-daemon.service',
+		]
+
+	@property
+	def tuned_services(self) -> list[str]:
+		return [
+			'tuned.service',
+		]
+
 	def install(
 		self,
 		install_session: Installer,
@@ -31,5 +43,7 @@ class PowerManagementApp:
 		match power_management_config.power_management:
 			case PowerManagement.POWER_PROFILES_DAEMON:
 				install_session.add_additional_packages(self.ppd_packages)
+				install_session.enable_service(self.ppd_services)
 			case PowerManagement.TUNED:
 				install_session.add_additional_packages(self.tuned_packages)
+				install_session.enable_service(self.tuned_services)


### PR DESCRIPTION
Fixes #2557 

## PR Description:
The power management handler installs the selected packages but does not enable their systemd services. After reboot, neither power-profiles-daemon nor tuned starts automatically, making the power management selection ineffective.

This adds enable_service() calls for power-profiles-daemon.service and tuned.service, matching the pattern already used by Bluetooth, Firewall, and Print Service handlers.

## Tests and Checks
- Select "Power management" in Applications menu on a system with battery
- Choose power-profiles-daemon, complete installation, reboot
- Verify systemctl is-enabled power-profiles-daemon.service returns enabled
- Repeat with tuned, verify systemctl is-enabled tuned.service returns enabled
