### PR TITLE
Fix Limine install with ESP mounted outside /boot

### DIFF
--- a/archinstall/lib/bootloader/utils.py
+++ b/archinstall/lib/bootloader/utils.py
@@ -3,9 +3,7 @@ from enum import Enum, auto
 from pathlib import Path
 
 from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
-from archinstall.lib.models.device import DiskLayoutConfiguration, FilesystemType
-
-_FAT_FILESYSTEMS = (FilesystemType.FAT12, FilesystemType.FAT16, FilesystemType.FAT32)
+from archinstall.lib.models.device import DiskLayoutConfiguration
 
 
 class BootloaderValidationFailureKind(Enum):
@@ -39,7 +37,7 @@ def validate_bootloader_layout(
 
 		# Limine reads its config and kernels from the boot partition, which
 		# must be FAT.
-		if boot_part and boot_part.fs_type not in _FAT_FILESYSTEMS:
+		if boot_part and (boot_part.fs_type is None or not boot_part.fs_type.is_fat()):
 			return BootloaderValidationFailure(
 				kind=BootloaderValidationFailureKind.LimineNonFatBoot,
 				description='Limine does not support booting with a non-FAT boot partition.',

--- a/archinstall/lib/bootloader/utils.py
+++ b/archinstall/lib/bootloader/utils.py
@@ -1,36 +1,65 @@
+from dataclasses import dataclass
+from enum import Enum, auto
 from pathlib import Path
 
 from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
-from archinstall.lib.models.device import DiskLayoutConfiguration
+from archinstall.lib.models.device import DiskLayoutConfiguration, FilesystemType
+
+_FAT_FILESYSTEMS = (FilesystemType.FAT12, FilesystemType.FAT16, FilesystemType.FAT32)
+
+
+class BootloaderValidationFailureKind(Enum):
+	LimineNonFatBoot = auto()
+	LimineLayout = auto()
+
+
+@dataclass(frozen=True)
+class BootloaderValidationFailure:
+	kind: BootloaderValidationFailureKind
+	description: str
 
 
 def validate_bootloader_layout(
 	bootloader_config: BootloaderConfiguration | None,
 	disk_config: DiskLayoutConfiguration | None,
-) -> str | None:
+) -> BootloaderValidationFailure | None:
 	"""Validate bootloader configuration against disk layout.
 
-	Returns an error message if the configuration would produce an
-	unbootable system, or None if it is valid.
+	Returns a failure with a human-readable description if the configuration
+	would produce an unbootable system, or None if it is valid.
 	"""
-	# Limine can only read FAT. When the ESP is the boot partition but
-	# mounted outside /boot and UKI is disabled, the kernel ends up on the
-	# root filesystem which Limine cannot access.
-	if not (bootloader_config and bootloader_config.bootloader == Bootloader.Limine and not bootloader_config.uki and disk_config):
+	if not (bootloader_config and disk_config):
 		return None
 
-	efi_part = next(
-		(p for m in disk_config.device_modifications if (p := m.get_efi_partition())),
-		None,
-	)
-	boot_part = next(
-		(p for m in disk_config.device_modifications if (p := m.get_boot_partition())),
-		None,
-	)
-
-	if efi_part and boot_part == efi_part and efi_part.mountpoint != Path('/boot'):
-		return (
-			f'Limine requires kernels on a FAT partition. The ESP is mounted at {efi_part.mountpoint}, '
-			'enable UKI or add a separate /boot partition to install Limine.'
+	if bootloader_config.bootloader == Bootloader.Limine:
+		boot_part = next(
+			(p for m in disk_config.device_modifications if (p := m.get_boot_partition())),
+			None,
 		)
+
+		# Limine reads its config and kernels from the boot partition, which
+		# must be FAT.
+		if boot_part and boot_part.fs_type not in _FAT_FILESYSTEMS:
+			return BootloaderValidationFailure(
+				kind=BootloaderValidationFailureKind.LimineNonFatBoot,
+				description='Limine does not support booting with a non-FAT boot partition.',
+			)
+
+		# When the ESP is the boot partition but mounted outside /boot and
+		# UKI is disabled, kernels end up on the root filesystem which
+		# Limine cannot access.
+		if not bootloader_config.uki:
+			efi_part = next(
+				(p for m in disk_config.device_modifications if (p := m.get_efi_partition())),
+				None,
+			)
+			if efi_part and efi_part == boot_part and efi_part.mountpoint != Path('/boot'):
+				return BootloaderValidationFailure(
+					kind=BootloaderValidationFailureKind.LimineLayout,
+					description=(
+						f'Limine requires kernels on a FAT partition. The ESP is mounted at {efi_part.mountpoint}, '
+						'enable UKI or add a separate /boot partition to install Limine.'
+					),
+				)
+
 	return None

--- a/archinstall/lib/bootloader/utils.py
+++ b/archinstall/lib/bootloader/utils.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
+from archinstall.lib.models.device import DiskLayoutConfiguration
+
+
+def validate_bootloader_layout(
+	bootloader_config: BootloaderConfiguration | None,
+	disk_config: DiskLayoutConfiguration | None,
+) -> str | None:
+	"""Validate bootloader configuration against disk layout.
+
+	Returns an error message if the configuration would produce an
+	unbootable system, or None if it is valid.
+	"""
+	# Limine can only read FAT. When the ESP is the boot partition but
+	# mounted outside /boot and UKI is disabled, the kernel ends up on the
+	# root filesystem which Limine cannot access.
+	if not (bootloader_config and bootloader_config.bootloader == Bootloader.Limine and not bootloader_config.uki and disk_config):
+		return None
+
+	efi_part = next(
+		(p for m in disk_config.device_modifications if (p := m.get_efi_partition())),
+		None,
+	)
+	boot_part = next(
+		(p for m in disk_config.device_modifications if (p := m.get_boot_partition())),
+		None,
+	)
+
+	if efi_part and boot_part == efi_part and efi_part.mountpoint != Path('/boot'):
+		return (
+			f'Limine requires kernels on a FAT partition. The ESP is mounted at {efi_part.mountpoint}, '
+			'enable UKI or add a separate /boot partition to install Limine.'
+		)
+	return None

--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -250,7 +250,7 @@ class DeviceHandler:
 			case FilesystemType.EXT2 | FilesystemType.EXT3 | FilesystemType.EXT4:
 				# Force create
 				options.append('-F')
-			case FilesystemType.FAT12 | FilesystemType.FAT16 | FilesystemType.FAT32:
+			case _ if fs_type.is_fat():
 				mkfs_type = 'fat'
 				# Set FAT size
 				options.extend(('-F', fs_type.value.removeprefix(mkfs_type)))

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -18,7 +18,7 @@ from archinstall.lib.mirror.mirror_menu import MirrorMenu
 from archinstall.lib.models.application import ApplicationConfiguration, ZramConfiguration
 from archinstall.lib.models.authentication import AuthenticationConfiguration
 from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
-from archinstall.lib.models.device import DiskLayoutConfiguration, DiskLayoutType, FilesystemType, PartitionModification
+from archinstall.lib.models.device import DiskLayoutConfiguration, DiskLayoutType, PartitionModification
 from archinstall.lib.models.locale import LocaleConfiguration
 from archinstall.lib.models.mirrors import MirrorConfiguration
 from archinstall.lib.models.network import NetworkConfiguration, NicType
@@ -487,7 +487,7 @@ class GlobalMenu(AbstractMenu[None]):
 			if efi_partition is None:
 				return 'EFI system partition (ESP) not found'
 
-			if efi_partition.fs_type not in [FilesystemType.FAT12, FilesystemType.FAT16, FilesystemType.FAT32]:
+			if efi_partition.fs_type is None or not efi_partition.fs_type.is_fat():
 				return 'ESP must be formatted as a FAT filesystem'
 
 		if bootloader == Bootloader.Refind and not self._uefi:

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import override
 
 from archinstall.default_profiles.profile import GreeterType
@@ -492,6 +493,11 @@ class GlobalMenu(AbstractMenu[None]):
 		if bootloader == Bootloader.Limine:
 			if boot_partition.fs_type not in [FilesystemType.FAT12, FilesystemType.FAT16, FilesystemType.FAT32]:
 				return 'Limine does not support booting with a non-FAT boot partition'
+			if self._uefi and efi_partition and boot_partition == efi_partition and efi_partition.mountpoint != Path('/boot') and not bootloader_config.uki:
+				return (
+					f'Limine requires kernels on a FAT partition. The ESP is mounted at {efi_partition.mountpoint}, '
+					'enable UKI or add a separate /boot partition'
+				)
 
 		elif bootloader == Bootloader.Refind:
 			if not self._uefi:

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import override
 
 from archinstall.default_profiles.profile import GreeterType
@@ -6,6 +5,7 @@ from archinstall.lib.applications.application_menu import ApplicationMenu
 from archinstall.lib.args import ArchConfig
 from archinstall.lib.authentication.authentication_menu import AuthenticationMenu
 from archinstall.lib.bootloader.bootloader_menu import BootloaderMenu
+from archinstall.lib.bootloader.utils import validate_bootloader_layout
 from archinstall.lib.configuration import save_config
 from archinstall.lib.disk.disk_menu import DiskLayoutConfigurationMenu
 from archinstall.lib.general.general_menu import select_hostname, select_ntp, select_timezone
@@ -490,18 +490,11 @@ class GlobalMenu(AbstractMenu[None]):
 			if efi_partition.fs_type not in [FilesystemType.FAT12, FilesystemType.FAT16, FilesystemType.FAT32]:
 				return 'ESP must be formatted as a FAT filesystem'
 
-		if bootloader == Bootloader.Limine:
-			if boot_partition.fs_type not in [FilesystemType.FAT12, FilesystemType.FAT16, FilesystemType.FAT32]:
-				return 'Limine does not support booting with a non-FAT boot partition'
-			if self._uefi and efi_partition and boot_partition == efi_partition and efi_partition.mountpoint != Path('/boot') and not bootloader_config.uki:
-				return (
-					f'Limine requires kernels on a FAT partition. The ESP is mounted at {efi_partition.mountpoint}, '
-					'enable UKI or add a separate /boot partition'
-				)
+		if bootloader == Bootloader.Refind and not self._uefi:
+			return 'rEFInd can only be used on UEFI systems'
 
-		elif bootloader == Bootloader.Refind:
-			if not self._uefi:
-				return 'rEFInd can only be used on UEFI systems'
+		if failure := validate_bootloader_layout(bootloader_config, disk_config):
+			return failure.description
 
 		return None
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -12,6 +12,7 @@ from types import TracebackType
 from typing import Any, Self
 
 from archinstall.lib.boot import Boot
+from archinstall.lib.bootloader.utils import validate_bootloader_layout
 from archinstall.lib.command import SysCommand, run
 from archinstall.lib.disk.fido import Fido2
 from archinstall.lib.disk.luks import Luks2, unlock_luks2_dev
@@ -30,7 +31,7 @@ from archinstall.lib.linux_path import LPath
 from archinstall.lib.locale.utils import verify_keyboard_layout, verify_x11_keyboard_layout
 from archinstall.lib.mirror.mirror_handler import MirrorListHandler
 from archinstall.lib.models.application import ZramAlgorithm
-from archinstall.lib.models.bootloader import Bootloader
+from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
 from archinstall.lib.models.device import (
 	DiskEncryption,
 	DiskLayoutConfiguration,
@@ -1466,15 +1467,13 @@ class Installer:
 			elif not efi_partition.mountpoint:
 				raise ValueError('EFI partition is not mounted')
 
-			# Limine can only read FAT filesystems. When the ESP doubles as
-			# the boot partition but is mounted outside /boot (e.g. /efi,
-			# /boot/efi) and UKI is disabled, kernels end up on the root
-			# filesystem under /boot/ which Limine cannot access.
-			if boot_partition == efi_partition and efi_partition.mountpoint != Path('/boot') and not uki_enabled:
-				raise DiskError(
-					f'Limine requires kernels on a FAT partition. The ESP is mounted at {efi_partition.mountpoint}, '
-					'so enable UKI or add a separate /boot partition to install Limine.',
-				)
+			# Safety net for programmatic callers that bypass GlobalMenu and
+			# guided.py validation.
+			if failure := validate_bootloader_layout(
+				BootloaderConfiguration(bootloader=Bootloader.Limine, uki=uki_enabled),
+				self._disk_config,
+			):
+				raise DiskError(failure.description)
 
 			info(f'Limine EFI partition: {efi_partition.dev_path}')
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1466,6 +1466,16 @@ class Installer:
 			elif not efi_partition.mountpoint:
 				raise ValueError('EFI partition is not mounted')
 
+			# Limine can only read FAT filesystems. When the ESP doubles as
+			# the boot partition but is mounted outside /boot (e.g. /efi,
+			# /boot/efi) and UKI is disabled, kernels end up on the root
+			# filesystem under /boot/ which Limine cannot access.
+			if boot_partition == efi_partition and efi_partition.mountpoint != Path('/boot') and not uki_enabled:
+				raise DiskError(
+					f'Limine requires kernels on a FAT partition. The ESP is mounted at {efi_partition.mountpoint}, '
+					'so enable UKI or add a separate /boot partition to install Limine.',
+				)
+
 			info(f'Limine EFI partition: {efi_partition.dev_path}')
 
 			parent_dev_path = get_parent_device_path(efi_partition.safe_dev_path)
@@ -1476,15 +1486,11 @@ class Installer:
 				if bootloader_removable:
 					efi_dir_path = efi_dir_path / 'BOOT'
 					efi_dir_path_target = efi_dir_path_target / 'BOOT'
-
-					boot_limine_path = self.target / 'boot' / 'limine'
-					boot_limine_path.mkdir(parents=True, exist_ok=True)
-					config_path = boot_limine_path / 'limine.conf'
 				else:
 					efi_dir_path = efi_dir_path / 'arch-limine'
 					efi_dir_path_target = efi_dir_path_target / 'arch-limine'
 
-					config_path = efi_dir_path / 'limine.conf'
+				config_path = efi_dir_path / 'limine.conf'
 
 				efi_dir_path.mkdir(parents=True, exist_ok=True)
 

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -802,6 +802,9 @@ class FilesystemType(StrEnum):
 	def is_crypto(self) -> bool:
 		return self == FilesystemType.CRYPTO_LUKS
 
+	def is_fat(self) -> bool:
+		return self in (FilesystemType.FAT12, FilesystemType.FAT16, FilesystemType.FAT32)
+
 	@property
 	def parted_value(self) -> str:
 		return self.value + '(v1)' if self == FilesystemType.LINUX_SWAP else self.value

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -1,11 +1,11 @@
 import os
 import sys
 import time
-from pathlib import Path
 
 from archinstall.lib.applications.application_handler import ApplicationHandler
 from archinstall.lib.args import ArchConfig, ArchConfigHandler
 from archinstall.lib.authentication.authentication_handler import AuthenticationHandler
+from archinstall.lib.bootloader.utils import validate_bootloader_layout
 from archinstall.lib.configuration import ConfigurationOutput
 from archinstall.lib.disk.filesystem import FilesystemHandler
 from archinstall.lib.disk.utils import disk_layouts
@@ -196,35 +196,6 @@ def perform_installation(
 						pass
 
 
-def _check_bootloader_layout(config: ArchConfig) -> str | None:
-	"""Validate bootloader configuration against disk layout.
-
-	Returns an error message if the configuration would produce an
-	unbootable system, or None if it is valid.
-	"""
-	# Limine can only read FAT. When the ESP is the boot partition but
-	# mounted outside /boot and UKI is disabled, the kernel ends up on the
-	# root filesystem which Limine cannot access.
-	if not (config.bootloader_config and config.bootloader_config.bootloader == Bootloader.Limine and not config.bootloader_config.uki and config.disk_config):
-		return None
-
-	efi_part = next(
-		(p for m in config.disk_config.device_modifications if (p := m.get_efi_partition())),
-		None,
-	)
-	boot_part = next(
-		(p for m in config.disk_config.device_modifications if (p := m.get_boot_partition())),
-		None,
-	)
-
-	if efi_part and boot_part == efi_part and efi_part.mountpoint != Path('/boot'):
-		return (
-			f'Limine requires kernels on a FAT partition. The ESP is mounted at {efi_part.mountpoint}, '
-			'enable UKI or add a separate /boot partition to install Limine.'
-		)
-	return None
-
-
 def main(arch_config_handler: ArchConfigHandler | None = None) -> None:
 	if arch_config_handler is None:
 		arch_config_handler = ArchConfigHandler()
@@ -243,7 +214,10 @@ def main(arch_config_handler: ArchConfigHandler | None = None) -> None:
 
 	# Safety net for silent/config-file flow. The TUI menu blocks Install via
 	# GlobalMenu._validate_bootloader() before reaching this point.
-	if err_msg := _check_bootloader_layout(arch_config_handler.config):
+	if err_msg := validate_bootloader_layout(
+		arch_config_handler.config.bootloader_config,
+		arch_config_handler.config.disk_config,
+	):
 		error(err_msg)
 		return
 

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -214,11 +214,11 @@ def main(arch_config_handler: ArchConfigHandler | None = None) -> None:
 
 	# Safety net for silent/config-file flow. The TUI menu blocks Install via
 	# GlobalMenu._validate_bootloader() before reaching this point.
-	if err_msg := validate_bootloader_layout(
+	if failure := validate_bootloader_layout(
 		arch_config_handler.config.bootloader_config,
 		arch_config_handler.config.disk_config,
 	):
-		error(err_msg)
+		error(failure.description)
 		return
 
 	if arch_config_handler.args.dry_run:

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+from pathlib import Path
 
 from archinstall.lib.applications.application_handler import ApplicationHandler
 from archinstall.lib.args import ArchConfig, ArchConfigHandler
@@ -195,6 +196,35 @@ def perform_installation(
 						pass
 
 
+def _check_bootloader_layout(config: ArchConfig) -> str | None:
+	"""Validate bootloader configuration against disk layout.
+
+	Returns an error message if the configuration would produce an
+	unbootable system, or None if it is valid.
+	"""
+	# Limine can only read FAT. When the ESP is the boot partition but
+	# mounted outside /boot and UKI is disabled, the kernel ends up on the
+	# root filesystem which Limine cannot access.
+	if not (config.bootloader_config and config.bootloader_config.bootloader == Bootloader.Limine and not config.bootloader_config.uki and config.disk_config):
+		return None
+
+	efi_part = next(
+		(p for m in config.disk_config.device_modifications if (p := m.get_efi_partition())),
+		None,
+	)
+	boot_part = next(
+		(p for m in config.disk_config.device_modifications if (p := m.get_boot_partition())),
+		None,
+	)
+
+	if efi_part and boot_part == efi_part and efi_part.mountpoint != Path('/boot'):
+		return (
+			f'Limine requires kernels on a FAT partition. The ESP is mounted at {efi_part.mountpoint}, '
+			'enable UKI or add a separate /boot partition to install Limine.'
+		)
+	return None
+
+
 def main(arch_config_handler: ArchConfigHandler | None = None) -> None:
 	if arch_config_handler is None:
 		arch_config_handler = ArchConfigHandler()
@@ -210,6 +240,12 @@ def main(arch_config_handler: ArchConfigHandler | None = None) -> None:
 	config = ConfigurationOutput(arch_config_handler.config)
 	config.write_debug()
 	config.save()
+
+	# Safety net for silent/config-file flow. The TUI menu blocks Install via
+	# GlobalMenu._validate_bootloader() before reaching this point.
+	if err_msg := _check_bootloader_layout(arch_config_handler.config):
+		error(err_msg)
+		return
 
 	if arch_config_handler.args.dry_run:
 		return


### PR DESCRIPTION
Fixes #4333.

Selecting Limine with the ESP mounted at `/efi` or `/boot/efi` (without UKI or a separate `/boot`) left the system unbootable: `limine.conf` ended up on the root fs instead of the ESP, and the kernel path in the config pointed to a non-FAT volume that Limine cannot read.

## Changes
- `installer.py` - write `limine.conf` next to the EFI binary on the ESP so it is found regardless of ESP mountpoint.
- `global_menu.py` - `_validate_bootloader()` blocks `Install` when `Limine + ESP==boot + mountpoint != /boot + !UKI`; preview explains why.
- `guided.py` - same pre-flight check in `main()` before any filesystem operations, covering `--silent`/`--config` flow.
- `installer.py` - `_add_limine_bootloader()` raises `DiskError` on the same condition as a safety net.

Same rule at three layers (UI / CLI / lib) for defense in depth. Can extract into a helper if preferred.

## Tests
QEMU/OVMF, rebuilt ISO from this branch, fresh 30G qcow2 each run.

- [x] **Regression** `ESP=/boot, removable, non-UKI` - installs and boots normally.
- [x] **Valid** `ESP=/efi, removable, UKI` - installs; Limine loads UKI from ESP.
- [x] **Valid** `ESP=/efi, removable, non-UKI, separate FAT /boot` - installs; Limine reads kernel from `/boot`.
- [x] **Blocker silent** `ESP=/efi, removable, non-UKI, --silent` - exits with `error()` before touching the disk.
- [x] **Blocker TUI** same config in menu - `Install` disabled with explanation in preview; enabling UKI clears it.