### PR TITLE
Fix shell injection in Installer.user_set_shell and Installer.chown

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1964,18 +1964,22 @@ class Installer:
 	def user_set_shell(self, user: str, shell: str) -> bool:
 		info(f'Setting shell for {user} to {shell}')
 
+		cmd = ['arch-chroot', '-S', str(self.target), 'chsh', '-s', shell, user]
 		try:
-			self.arch_chroot(f'sh -c "chsh -s {shell} {user}"')
+			run(cmd)
 			return True
-		except SysCallError:
+		except CalledProcessError as err:
+			debug(f'Error setting user shell: {err}')
 			return False
 
-	def chown(self, owner: str, path: str, options: list[str] = []) -> bool:
-		cleaned_path = path.replace("'", "\\'")
+	def chown(self, owner: str, path: str, options: list[str] | None = None) -> bool:
+		options = options or []
+		cmd = ['arch-chroot', '-S', str(self.target), 'chown', *options, owner, path]
 		try:
-			self.arch_chroot(f"sh -c 'chown {' '.join(options)} {owner} {cleaned_path}'")
+			run(cmd)
 			return True
-		except SysCallError:
+		except CalledProcessError as err:
+			debug(f'Error changing ownership of {path}: {err}')
 			return False
 
 	def set_vconsole(self, locale_config: LocaleConfiguration) -> None:


### PR DESCRIPTION
`Installer.user_set_shell` and `Installer.chown` built shell commands via f-string interpolation inside `sh -c "..."`, allowing command injection via caller-supplied username, shell, path, or options.

Replaced both with argv lists passed directly to `run()`, matching the pattern already used by `user_set_password`. The full string is now a single argv element and cannot be shell-parsed.

Both methods are public API of the `Installer` class and are reachable from custom `install.py` scripts and plugin code. Any caller that passes unsanitized strings (e.g. a username containing `;`, `$()`, backticks, or spaces) would execute arbitrary shell commands in the chroot. The fix removes the shell layer entirely.

## Changes
- `user_set_shell`: `sh -c "chsh -s {shell} {user}"` -> `run(['arch-chroot', '-S', target, 'chsh', '-s', shell, user])`
- `chown`: `sh -c 'chown {options} {owner} {cleaned_path}'` -> `run(['arch-chroot', '-S', target, 'chown', *options, owner, path])`
- Dropped the `cleaned_path` quote-escape hack (no longer needed).
- Fixed mutable default argument `options: list[str] = []` -> `options: list[str] | None = None`.
- Added `debug()` log on `CalledProcessError` in both methods.

## Tests
- [x] Unit test with malicious inputs (`; rm -rf /`, `$(id)`, backticks, spaces, quotes) confirms the entire string stays a single argv element and is never shell-parsed