### PR TITLE
Change Budgie display server and update packages

### DIFF
--- a/archinstall/default_profiles/desktops/budgie.py
+++ b/archinstall/default_profiles/desktops/budgie.py
@@ -9,7 +9,7 @@ class BudgieProfile(Profile):
 			'Budgie',
 			ProfileType.DesktopEnv,
 			support_gfx_driver=True,
-			display_server=DisplayServerType.Xorg,
+			display_server=DisplayServerType.Wayland,
 		)
 
 	@property
@@ -18,12 +18,12 @@ class BudgieProfile(Profile):
 		return [
 			'materia-gtk-theme',
 			'budgie',
-			'mate-terminal',
-			'nemo',
+			'konsole',
+			'dolphin',
 			'papirus-icon-theme',
 		]
 
 	@property
 	@override
 	def default_greeter_type(self) -> GreeterType:
-		return GreeterType.LightdmSlick
+		return GreeterType.Sddm


### PR DESCRIPTION
Starting with version 10.10, Budgie has transitioned to a Wayland-only session, making the inclusion of Xorg unnecessary.

Joshua Strobl, the founder and lead developer of the Buddies of Budgie organization (the upstream project), is the primary maintainer for the Fedora Budgie Spin. For Fedora 44, the Budgie Spin (10.10) will use SDDM for a native Wayland session from boot, including KDE applications for better integration.

Here's an official commit and a video showing the KDE apps:

https://forge.moderndesktop.dev/BuddiesOfBudgie/fedora-budgie-desktop-defaults/src/branch/main/budgie/com.solus-project.icon-tasklist.gschema.override

https://pagure.io/fork/leigh123linux/fedora-comps/c/793ff2dd39d79c9991cfc9daf3817e7bcf0dc3fe?branch=main

https://www.youtube.com/watch?v=gKGIGxm6nZQ