### PR TITLE
ci: Strip Arch pkgrel from Repology versions in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,8 @@
       ],
       "depNameTemplate": "arch/python-{{{depName}}}",
       "datasourceTemplate": "repology",
-      "versioningTemplate": "loose"
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^(?<version>.*)-\\d+$"
     },
     {
       "customType": "regex",
@@ -29,7 +30,8 @@
       ],
       "depNameTemplate": "arch/python-systemd",
       "datasourceTemplate": "repology",
-      "versioningTemplate": "loose"
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^(?<version>.*)-\\d+$"
     }
   ],
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
       "depNameTemplate": "arch/python-{{{depName}}}",
       "datasourceTemplate": "repology",
       "versioningTemplate": "loose",
-      "extractVersionTemplate": "^(?<version>.*)-\\d+$"
+      "extractVersionTemplate": "^(?<version>.+)-\\d+$"
     },
     {
       "customType": "regex",
@@ -31,7 +31,7 @@
       "depNameTemplate": "arch/python-systemd",
       "datasourceTemplate": "repology",
       "versioningTemplate": "loose",
-      "extractVersionTemplate": "^(?<version>.*)-\\d+$"
+      "extractVersionTemplate": "^(?<version>.+)-\\d+$"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Adds `extractVersionTemplate` to both Repology custom managers to strip the trailing Arch `pkgrel` suffix (e.g. `-1`) from versions before writing to `pyproject.toml`.

Without this, Renovate proposes invalid PEP 440 versions like `8.2.4-1` instead of `8.2.4`.

Fixes the issue seen in #4448.