### PR TITLE
Adding a reference to why AUR is not bundled as an option in archinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ qemu-system-x86_64 -enable-kvm \
 
 # FAQ
 
+## AUR
+
+`archinstall` will not offer or bundle AUR helpers or AUR packages due to a current consensus. This is not any individual developers decision. The reasons and discussions for this stance on the topic can be found on our mailing list thread: [(optional) AUR helper in archinstall](https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/VYOULH2GOJLFM2BXOFLWH3D754YXFPSL/).
+
 ## Keyring out-of-date
 For a description of the problem see https://archinstall.archlinux.page/help/known_issues.html#keyring-is-out-of-date-2213 and discussion in issue https://github.com/archlinux/archinstall/issues/2213.
 


### PR DESCRIPTION
This closes:
- https://github.com/archlinux/archinstall/pull/4447#issuecomment-4307198749
- https://github.com/archlinux/archinstall/discussions/4075

We'll give it until 2026-04-26, to see if anything changes on the mailing list: https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/VYOULH2GOJLFM2BXOFLWH3D754YXFPSL/

But the initial stance seems clear, so prepping this PR.