### PR TITLE
Add console font selection to Locales menu

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1990,12 +1990,10 @@ class Installer:
 	def set_vconsole(self, locale_config: LocaleConfiguration) -> None:
 		# use the already set kb layout
 		kb_vconsole: str = locale_config.kb_layout
-		# this is the default used in ISO other option for hdpi screens TER16x32
-		# can be checked using
-		# zgrep "CONFIG_FONT" /proc/config.gz
-		# https://wiki.archlinux.org/title/Linux_console#Fonts
+		font_vconsole = locale_config.console_font
 
-		font_vconsole = 'default8x16'
+		if font_vconsole.startswith('ter-'):
+			self.pacman.strap(['terminus-font'])
 
 		# Ensure /etc exists
 		vconsole_dir: Path = self.target / 'etc'

--- a/archinstall/lib/locale/locale_menu.py
+++ b/archinstall/lib/locale/locale_menu.py
@@ -1,6 +1,6 @@
 from typing import override
 
-from archinstall.lib.locale.utils import list_keyboard_languages, list_locales, set_kb_layout
+from archinstall.lib.locale.utils import list_console_fonts, list_keyboard_languages, list_locales, set_kb_layout
 from archinstall.lib.menu.abstract_menu import AbstractSubMenu
 from archinstall.lib.menu.helpers import Selection
 from archinstall.lib.models.locale import LocaleConfiguration
@@ -46,6 +46,13 @@ class LocaleMenu(AbstractSubMenu[LocaleConfiguration]):
 				value=self._locale_conf.sys_enc,
 				preview_action=lambda item: item.get_value(),
 				key='sys_enc',
+			),
+			MenuItem(
+				text=tr('Console font'),
+				action=select_console_font,
+				value=self._locale_conf.console_font,
+				preview_action=lambda item: item.get_value(),
+				key='console_font',
 			),
 		]
 
@@ -129,6 +136,28 @@ async def select_kb_layout(preset: str | None = None) -> str | None:
 
 	result = await Selection[str](
 		header=tr('Keyboard layout'),
+		group=group,
+		enable_filter=True,
+	).show()
+
+	match result.type_:
+		case ResultType.Selection:
+			return result.get_value()
+		case ResultType.Skip:
+			return preset
+		case _:
+			raise ValueError('Unhandled return type')
+
+
+async def select_console_font(preset: str | None = None) -> str | None:
+	fonts = list_console_fonts()
+
+	items = [MenuItem(f, value=f) for f in fonts]
+	group = MenuItemGroup(items, sort_items=False)
+	group.set_focus_by_value(preset)
+
+	result = await Selection[str](
+		header=tr('Console font'),
 		group=group,
 		enable_filter=True,
 	).show()

--- a/archinstall/lib/locale/utils.py
+++ b/archinstall/lib/locale/utils.py
@@ -1,3 +1,5 @@
+import os
+
 from archinstall.lib.command import SysCommand
 from archinstall.lib.exceptions import ServiceException, SysCallError
 from archinstall.lib.output import error
@@ -24,6 +26,17 @@ def list_locales() -> list[str]:
 				locales.append(line.rstrip())
 
 	return locales
+
+
+def list_console_fonts() -> list[str]:
+	fonts: set[str] = set()
+
+	for entry in os.listdir('/usr/share/kbd/consolefonts'):
+		if entry.endswith('.gz'):
+			name = entry.removesuffix('.gz').removesuffix('.psfu').removesuffix('.psf').removesuffix('.cp').removesuffix('.fnt')
+			fonts.add(name)
+
+	return sorted(fonts)
 
 
 def list_x11_keyboard_languages() -> list[str]:

--- a/archinstall/lib/locale/utils.py
+++ b/archinstall/lib/locale/utils.py
@@ -1,4 +1,5 @@
-import os
+from functools import lru_cache
+from pathlib import Path
 
 from archinstall.lib.command import SysCommand
 from archinstall.lib.exceptions import ServiceException, SysCallError
@@ -28,14 +29,10 @@ def list_locales() -> list[str]:
 	return locales
 
 
+@lru_cache
 def list_console_fonts() -> list[str]:
-	fonts: set[str] = set()
-
-	for entry in os.listdir('/usr/share/kbd/consolefonts'):
-		if entry.endswith('.gz'):
-			name = entry.removesuffix('.gz').removesuffix('.psfu').removesuffix('.psf').removesuffix('.cp').removesuffix('.fnt')
-			fonts.add(name)
-
+	directory = Path('/usr/share/kbd/consolefonts')
+	fonts = {path.name.split('.')[0] for path in directory.glob('*.gz')}
 	return sorted(fonts)
 
 

--- a/archinstall/lib/models/locale.py
+++ b/archinstall/lib/models/locale.py
@@ -10,6 +10,11 @@ class LocaleConfiguration:
 	kb_layout: str
 	sys_lang: str
 	sys_enc: str
+	# this is the default used in ISO other option for hdpi screens TER16x32
+	# can be checked using
+	# zgrep "CONFIG_FONT" /proc/config.gz
+	# https://wiki.archlinux.org/title/Linux_console#Font
+	console_font: str = 'default8x16'
 
 	@classmethod
 	def default(cls) -> Self:
@@ -23,12 +28,14 @@ class LocaleConfiguration:
 			'kb_layout': self.kb_layout,
 			'sys_lang': self.sys_lang,
 			'sys_enc': self.sys_enc,
+			'console_font': self.console_font,
 		}
 
 	def preview(self) -> str:
 		output = '{}: {}\n'.format(tr('Keyboard layout'), self.kb_layout)
 		output += '{}: {}\n'.format(tr('Locale language'), self.sys_lang)
-		output += '{}: {}'.format(tr('Locale encoding'), self.sys_enc)
+		output += '{}: {}\n'.format(tr('Locale encoding'), self.sys_enc)
+		output += '{}: {}'.format(tr('Console font'), self.console_font)
 		return output
 
 	def _load_config(self, args: dict[str, str]) -> None:
@@ -38,6 +45,8 @@ class LocaleConfiguration:
 			self.sys_enc = args['sys_enc']
 		if 'kb_layout' in args:
 			self.kb_layout = args['kb_layout']
+		if 'console_font' in args:
+			self.console_font = args['console_font']
 
 	@classmethod
 	def parse_arg(cls, args: dict[str, Any]) -> Self:

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -252,6 +252,9 @@ msgstr ""
 msgid "Locale encoding"
 msgstr ""
 
+msgid "Console font"
+msgstr ""
+
 msgid "Drive(s)"
 msgstr ""
 

--- a/archinstall/locales/uk/LC_MESSAGES/base.po
+++ b/archinstall/locales/uk/LC_MESSAGES/base.po
@@ -256,6 +256,9 @@ msgstr "Мова локалізації"
 msgid "Locale encoding"
 msgstr "Кодування локалізації"
 
+msgid "Console font"
+msgstr "Шрифт консолі"
+
 msgid "Drive(s)"
 msgstr "Диск(и)"
 


### PR DESCRIPTION
## PR Description:
Adds a new `Console font` item (4th) to the Locales submenu, allowing the user to pick a font for the target system's TTY (written to `/etc/vconsole.conf`).
 
Font list is built from `/usr/share/kbd/consolefonts` on the running ISO.
 
If the user picks a `ter-*` terminus font, the `terminus-font` package is automatically added to the target install. 

## Why 

Currently the target TTY always gets `default8x16` regardless of the language the user picked. That breaks for users with languages that need a wider Unicode coverage (partialy addresses #3735). Giving a menu entry is the simplest fix that doesn't force heuristics on anyone.
 
## Behavior / backward compatibility 
 
- Default remains `default8x16`, so existing user configs and default installs produce the exact same `vconsole.conf` as before.
- `LocaleConfiguration` gains `console_font: str = 'default8x16'`. Old configuration JSONs without that field keep working via the default value. 
- The `json()` / `_load_config()` / `preview()` sides are updated symmetrically. 
 
## Scope 
One thing only - menu selection + vconsole write. A follow-up PR will offer to propagate the installer's chosen language (sys_lang / sys_enc / console_font) to the target locale configuration.
 
## Test

- Default install: `/etc/vconsole.conf` contains `FONT=default8x16` as before. 
- Pick `ter-v32b` in the menu: `FONT=ter-v32b`, `terminus-font` installed.
- Load an old `user_configuration.json` with no `console_font`: default kicks in, no crash.