### PR TITLE
Fix OVMF paths in README QEMU examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ This can be done by installing `pacman -S arch-install-scripts util-linux` local
     # losetup --partscan --show ./testimage.img
     # pip install --upgrade archinstall
     # python -m archinstall --script guided
-    # qemu-system-x86_64 -enable-kvm -machine q35,accel=kvm -device intel-iommu -cpu host -m 4096 -boot order=d -drive file=./testimage.img,format=raw -drive if=pflash,format=raw,readonly,file=/usr/share/ovmf/x64/OVMF.4m.fd -drive if=pflash,format=raw,readonly,file=/usr/share/ovmf/x64/OVMF.4m.fd 
+    # qemu-system-x86_64 -enable-kvm -machine q35,accel=kvm -device intel-iommu -cpu host -m 4096 -boot order=d -drive file=./testimage.img,format=raw -drive if=pflash,format=raw,readonly,file=/usr/share/edk2/x64/OVMF_CODE.4m.fd -drive if=pflash,format=raw,readonly,file=/usr/share/edk2/x64/OVMF_VARS.4m.fd 
 
 This will create a *20 GB* `testimage.img` and create a loop device which we can use to format and install to.<br>
 `archinstall` is installed and executed in [guided mode](#docs-todo). Once the installation is complete, ~~you can use qemu/kvm to boot the test media.~~<br>
@@ -199,8 +199,8 @@ You may want to boot an ISO image in a VM to test `archinstall` in there.
 qemu-system-x86_64 -enable-kvm \
 -machine q35,accel=kvm -device intel-iommu \
 -cpu host -m 4096 -boot order=d \
--drive if=pflash,format=raw,readonly,file=/usr/share/ovmf/x64/OVMF.4m.fd \
--drive if=pflash,format=raw,readonly,file=/usr/share/ovmf/x64/OVMF.4m.fd \
+-drive if=pflash,format=raw,readonly,file=/usr/share/edk2/x64/OVMF_CODE.4m.fd \
+-drive if=pflash,format=raw,readonly,file=/usr/share/edk2/x64/OVMF_VARS.4m.fd \
 -drive file=./archlinux-2025.12.01-x86_64.iso,format=raw
 ```
 
@@ -209,8 +209,8 @@ HINT: For espeakup support
 qemu-system-x86_64 -enable-kvm \
 -machine q35,accel=kvm -device intel-iommu \
 -cpu host -m 4096 -boot order=d \
--drive if=pflash,format=raw,readonly,file=/usr/share/ovmf/x64/OVMF.4m.fd \
--drive if=pflash,format=raw,readonly,file=/usr/share/ovmf/x64/OVMF.4m.fd \
+-drive if=pflash,format=raw,readonly,file=/usr/share/edk2/x64/OVMF_CODE.4m.fd \
+-drive if=pflash,format=raw,readonly,file=/usr/share/edk2/x64/OVMF_VARS.4m.fd \
 -drive file=./archlinux-2025.12.01-x86_64.iso,format=raw \
 -device intel-hda -device hda-duplex,audiodev=snd0 \
 -audiodev pa,id=snd0,server=/run/user/1000/pulse/native


### PR DESCRIPTION
All three `qemu-system-x86_64` examples in README pointed both `-drive if=pflash` entries at the same file. OVMF needs `OVMF_CODE` first and `OVMF_VARS` second; as written, EFI NVRAM is not initialized correctly. 

Path `/usr/share/ovmf/x64/` is also stale - Arch replaced `ovmf` with `edk2-ovmf`, which installs under `/usr/share/edk2/x64/`.

Fixed in three places (testimage loop, base Boot ISO, espeakup variant). Paths verified via `pacman -Qo` against `edk2-ovmf 202508-1`.