### PR TITLE
Fix argv injection in _create_user and gpasswd loop

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1922,16 +1922,17 @@ class Installer:
 		if not handled_by_plugin:
 			info(f'Creating user {user.username}')
 
-			cmd = 'useradd -m'
+			cmd = ['arch-chroot', '-S', str(self.target), 'useradd', '-m']
 
 			if user.sudo:
-				cmd += ' -G wheel'
+				cmd += ['-G', 'wheel']
 
-			cmd += f' {user.username}'
+			cmd.append(user.username)
 
 			try:
-				self.arch_chroot(cmd)
-			except SysCallError as err:
+				run(cmd)
+			except CalledProcessError as err:
+				debug(f'Error creating user {user.username}: {err}')
 				raise SystemError(f'Could not create user inside installation: {err}')
 
 		for plugin in plugins.values():
@@ -1942,7 +1943,11 @@ class Installer:
 		self.set_user_password(user)
 
 		for group in user.groups:
-			self.arch_chroot(f'gpasswd -a {user.username} {group}')
+			cmd = ['arch-chroot', '-S', str(self.target), 'gpasswd', '-a', user.username, group]
+			try:
+				run(cmd)
+			except CalledProcessError as err:
+				debug(f'Error adding {user.username} to group {group}: {err}')
 
 		if user.sudo:
 			self.enable_sudo(user)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -739,6 +739,9 @@ class Installer:
 
 		return self.run_command(cmd, peek_output=peek_output)
 
+	def _chroot_argv(self, *args: str) -> list[str]:
+		return ['arch-chroot', '-S', str(self.target), *args]
+
 	def drop_to_shell(self) -> None:
 		subprocess.check_call(f'arch-chroot {self.target}', shell=True)
 
@@ -987,17 +990,7 @@ class Installer:
 			}
 
 			for config_name, mountpoint in snapper.items():
-				command = [
-					'arch-chroot',
-					'-S',
-					str(self.target),
-					'snapper',
-					'--no-dbus',
-					'-c',
-					config_name,
-					'create-config',
-					mountpoint,
-				]
+				command = self._chroot_argv('snapper', '--no-dbus', '-c', config_name, 'create-config', mountpoint)
 
 				try:
 					SysCommand(command, peek_output=True)
@@ -1336,13 +1329,7 @@ class Installer:
 
 		boot_dir = Path('/boot')
 
-		command = [
-			'arch-chroot',
-			'-S',
-			str(self.target),
-			'grub-install',
-			'--debug',
-		]
+		command = self._chroot_argv('grub-install', '--debug')
 
 		if SysInfo.has_uefi():
 			if not efi_partition:
@@ -1922,12 +1909,12 @@ class Installer:
 		if not handled_by_plugin:
 			info(f'Creating user {user.username}')
 
-			cmd = ['arch-chroot', '-S', str(self.target), 'useradd', '-m']
+			cmd = self._chroot_argv('useradd', '-m')
 
 			if user.sudo:
 				cmd += ['-G', 'wheel']
 
-			cmd.append(user.username)
+			cmd += ['--', user.username]
 
 			try:
 				run(cmd)
@@ -1943,11 +1930,11 @@ class Installer:
 		self.set_user_password(user)
 
 		for group in user.groups:
-			cmd = ['arch-chroot', '-S', str(self.target), 'gpasswd', '-a', user.username, group]
+			cmd = self._chroot_argv('gpasswd', '-a', user.username, group)
 			try:
 				run(cmd)
 			except CalledProcessError as err:
-				debug(f'Error adding {user.username} to group {group}: {err}')
+				warn(f'Failed to add {user.username} to group {group}: {err}')
 
 		if user.sudo:
 			self.enable_sudo(user)
@@ -1962,7 +1949,7 @@ class Installer:
 			return False
 
 		input_data = f'{user.username}:{enc_password}'.encode()
-		cmd = ['arch-chroot', '-S', str(self.target), 'chpasswd', '--encrypted']
+		cmd = self._chroot_argv('chpasswd', '--encrypted')
 
 		try:
 			run(cmd, input_data=input_data)
@@ -1974,7 +1961,7 @@ class Installer:
 	def user_set_shell(self, user: str, shell: str) -> bool:
 		info(f'Setting shell for {user} to {shell}')
 
-		cmd = ['arch-chroot', '-S', str(self.target), 'chsh', '-s', shell, user]
+		cmd = self._chroot_argv('chsh', '-s', shell, user)
 		try:
 			run(cmd)
 			return True
@@ -1984,7 +1971,7 @@ class Installer:
 
 	def chown(self, owner: str, path: str, options: list[str] | None = None) -> bool:
 		options = options or []
-		cmd = ['arch-chroot', '-S', str(self.target), 'chown', *options, owner, path]
+		cmd = self._chroot_argv('chown', *options, '--', owner, path)
 		try:
 			run(cmd)
 			return True


### PR DESCRIPTION
Same class of bug as #4443, two sibling call sites that were missed back then. `_create_user` and the `gpasswd` loop interpolate `user.username` and `group` into f-strings that reach `SysCommand(f'arch-chroot -S {target} {cmd}')`, where `shlex.split` parses the payload as argv. A `username` like `--uid 0` or `-G wheel,root` is accepted as `useradd`/`gpasswd` flags and gives trivial escalation. Vector is the same as #4443: custom `install.py`, plugins, tampered `--config` JSON.

## Changes
`_create_user` now builds an argv list and calls `run()`. Failures are logged via `debug()`, and the `SystemError` re-raise is kept so guided install still aborts.

The `gpasswd` loop gets the same switch. Also wrapped it in `try/except` with `debug()` - previously a failing `gpasswd` was silently ignored. 