### PR TITLE
Include core packages in all Plasma settings

### DIFF
--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -57,11 +57,11 @@ class PlasmaFlavor(StrEnum):
 	def packages(self) -> list[str]:
 		match self:
 			case PlasmaFlavor.Meta:
-				return ['plasma-meta']
+				return ['plasma-meta', 'konsole', 'dolphin', 'kate', 'ark']
 			case PlasmaFlavor.Plasma:
-				return ['plasma']
+				return ['plasma', 'konsole', 'dolphin', 'kate', 'ark']
 			case PlasmaFlavor.Desktop:
-				return ['plasma-desktop']
+				return ['plasma-desktop', 'konsole', 'dolphin']
 
 
 class PlasmaProfile(Profile):

--- a/archinstall/default_profiles/desktops/plasma.py
+++ b/archinstall/default_profiles/desktops/plasma.py
@@ -57,11 +57,11 @@ class PlasmaFlavor(StrEnum):
 	def packages(self) -> list[str]:
 		match self:
 			case PlasmaFlavor.Meta:
-				return ['plasma-meta', 'konsole', 'dolphin', 'kate', 'ark']
+				return ['plasma-meta', 'konsole', 'dolphin']
 			case PlasmaFlavor.Plasma:
 				return ['plasma', 'konsole', 'dolphin', 'kate', 'ark']
 			case PlasmaFlavor.Desktop:
-				return ['plasma-desktop', 'konsole', 'dolphin']
+				return ['plasma-desktop', 'konsole']
 
 
 class PlasmaProfile(Profile):


### PR DESCRIPTION

## PR Description:

- adds additional core packages, seen as commonalities in a plasma installation (à la #4460)
- the `plasma` setting includes the full range of core packages previously seen in archinstall's Plasma profile, while `plasma-meta` only includes `konsole`and `dolphin` and `plasma-desktop` only includes `konsole`. This is to keep up the overall profile's granularity (since having a GUI terminal is the bottom line when looking at other desktop profiles)

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
