### PR TITLE
Fix sway+nvidia confirmation dialog (#4481)

### DIFF
--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -81,17 +81,6 @@ class GfxDriver(Enum):
 			case _:
 				return False
 
-	def is_nvidia_nouveau(self) -> bool:
-		"""
-		True for the open-source nouveau driver (Mesa) for Nvidia GPUs.
-		Currently only NvidiaOpenSource. Officially supported by Sway.
-		"""
-		match self:
-			case GfxDriver.NvidiaOpenSource:
-				return True
-			case _:
-				return False
-
 	def packages_text(self) -> str:
 		pkg_names = [p.value for p in self.gfx_packages()]
 		text = tr('Installed packages') + ':\n'

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -68,6 +68,30 @@ class GfxDriver(Enum):
 			case _:
 				return False
 
+	def is_nvidia_proprietary(self) -> bool:
+		"""
+		True for Nvidia drivers that ship proprietary userspace components.
+		Currently only NvidiaOpenKernel (nvidia-open-dkms): open kernel module
+		paired with proprietary userspace. NvidiaOpenSource (nouveau) is fully
+		open and works with Sway, so it is excluded.
+		"""
+		match self:
+			case GfxDriver.NvidiaOpenKernel:
+				return True
+			case _:
+				return False
+
+	def is_nvidia_nouveau(self) -> bool:
+		"""
+		True for the open-source nouveau driver (Mesa) for Nvidia GPUs.
+		Currently only NvidiaOpenSource. Officially supported by Sway.
+		"""
+		match self:
+			case GfxDriver.NvidiaOpenSource:
+				return True
+			case _:
+				return False
+
 	def packages_text(self) -> str:
 		pkg_names = [p.value for p in self.gfx_packages()]
 		text = tr('Installed packages') + ':\n'

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -105,8 +105,7 @@ class ProfileMenu(AbstractSubMenu[ProfileConfiguration]):
 						preset=False,
 					).show()
 
-					if not result.get_value():
-						return preset
+					return driver if result.get_value() else preset
 
 		return driver
 

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -95,7 +95,7 @@ class ProfileMenu(AbstractSubMenu[ProfileConfiguration]):
 				driver = await select_driver(preset=preset)
 
 			if driver and 'Sway' in profile.current_selection_names():
-				if driver.is_nvidia():
+				if driver.is_nvidia_proprietary():
 					header = tr('The proprietary Nvidia driver is not supported by Sway.') + '\n'
 					header += tr('It is likely that you will run into issues, are you okay with that?') + '\n'
 
@@ -105,7 +105,7 @@ class ProfileMenu(AbstractSubMenu[ProfileConfiguration]):
 						preset=False,
 					).show()
 
-					if result.get_value():
+					if not result.get_value():
 						return preset
 
 		return driver


### PR DESCRIPTION
Closes #4481.
 
The Sway+Nvidia confirmation dialog had two bugs:
 
1. Inverted boolean. When the user confirmed "yes, I'm okay with issues", the code reverted the driver to the previous selection instead of keeping the chosen Nvidia driver. The user got the opposite of what they confirmed.
 
2. False-positive warning for nouveau. The warning triggered for any Nvidia driver, including NvidiaOpenSource (nouveau), which is the open-source Mesa driver officially supported by Sway. Users selecting nouveau got a misleading warning that they were about to break their Sway setup.
 
This PR adds two methods on GfxDriver: 
- is_nvidia_proprietary() — true only for NvidiaOpenKernel (nvidia-open-dkms, proprietary userspace).
- is_nvidia_nouveau() — true only for NvidiaOpenSource (nouveau, fully open). 

The Sway warning now uses is_nvidia_proprietary() instead of is_nvidia(), so nouveau users no longer see it. The boolean check is also flipped so confirming "yes" actually keeps the driver.
 
is_nvidia_nouveau() is added for symmetry and future use (e.g. when other Wayland compositors get similar checks). 