### PR TITLE
Fix broken localization in U2F, LUKS, and gfx driver preview

### DIFF
--- a/archinstall/lib/authentication/authentication_handler.py
+++ b/archinstall/lib/authentication/authentication_handler.py
@@ -81,7 +81,7 @@ class AuthenticationHandler:
 
 		install_session.pacman.strap('pam-u2f')
 
-		print(tr(f'Setting up U2F login: {u2f_config.u2f_login_method.value}'))
+		print(tr('Setting up U2F login: {}').format(u2f_config.u2f_login_method.value))
 
 		# https://developers.yubico.com/pam-u2f/
 		u2f_auth_file = install_session.target / 'etc/u2f_mappings'

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -375,7 +375,7 @@ async def select_lvm_vols_to_encrypt(
 async def select_iteration_time(preset: int | None = None) -> int | None:
 	header = tr('Enter iteration time for LUKS encryption (in milliseconds)') + '\n'
 	header += tr('Higher values increase security but slow down boot time') + '\n'
-	header += tr(f'Default: {DEFAULT_ITER_TIME}ms, Recommended range: 1000-60000') + '\n'
+	header += tr('Default: {}ms, Recommended range: 1000-60000').format(DEFAULT_ITER_TIME) + '\n'
 
 	def validate_iter_time(value: str) -> str | None:
 		try:

--- a/archinstall/lib/profile/profile_menu.py
+++ b/archinstall/lib/profile/profile_menu.py
@@ -113,7 +113,7 @@ class ProfileMenu(AbstractSubMenu[ProfileConfiguration]):
 		if item.value:
 			driver = item.get_value().value
 			packages = item.get_value().packages_text()
-			return f'Driver: {driver}\n{packages}'
+			return f'{tr("Graphics driver")}: {driver}\n{packages}'
 		return None
 
 	def _prev_greeter(self, item: MenuItem) -> str | None:

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -2285,3 +2285,11 @@ msgstr ""
 #, python-brace-format
 msgid "Default: {DEFAULT_ITER_TIME}ms, Recommended range: 1000-60000"
 msgstr ""
+
+#, python-brace-format
+msgid "Setting up U2F login: {}"
+msgstr ""
+
+#, python-brace-format
+msgid "Default: {}ms, Recommended range: 1000-60000"
+msgstr ""


### PR DESCRIPTION
Several places where strings that should be localized never reached translators. 

- authentication_handler.py:84 and encryption_menu.py:378 wrapped f-strings in tr(). The f-string evaluates before tr() runs, so xgettext extracts the literal placeholder syntax as the msgid while runtime passes the already-formatted string - the two never match. Switched both to tr('...{}').format(...), matching the pattern already used on line 95 of the same authentication file.
- profile_menu.py:116 had a hardcoded Driver: label in the gfx driver hover preview. Wrapped with the existing Graphics driver msgid - already translated in every locale and used in the same context in global_menu.py:524.

base.pot updated to expose the two new placeholder-based msgids.