### PR TITLE
Fix some inconsistent-return-statements Pylint warnings

### DIFF
--- a/archinstall/lib/authentication/authentication_handler.py
+++ b/archinstall/lib/authentication/authentication_handler.py
@@ -53,7 +53,7 @@ class AuthenticationHandler:
 	def _add_u2f_entry(self, file: Path, entry: str) -> None:
 		if not file.exists():
 			debug(f'File does not exist: {file}')
-			return None
+			return
 
 		content = file.read_text().splitlines()
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -402,7 +402,7 @@ class Installer:
 
 	def _mount_luks_partition(self, part_mod: PartitionModification, luks_handler: Luks2) -> None:
 		if not luks_handler.mapper_dev:
-			return None
+			return
 
 		if part_mod.fs_type == FilesystemType.BTRFS and part_mod.btrfs_subvols:
 			# Only mount BTRFS subvolumes that have mountpoints specified

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -133,7 +133,7 @@ class Journald:
 		try:
 			import systemd.journal  # type: ignore[import-not-found]
 		except ModuleNotFoundError:
-			return None
+			return
 
 		log_adapter = logging.getLogger('archinstall')
 		log_fmt = logging.Formatter('[%(levelname)s]: %(message)s')

--- a/archinstall/tui/ui/components.py
+++ b/archinstall/tui/ui/components.py
@@ -350,7 +350,7 @@ class OptionListScreen(BaseScreen[ValueT]):
 
 	def _set_preview(self, item_id: str) -> None:
 		if self._preview_location is None:
-			return None
+			return
 
 		preview_widget = self.query_one('#preview_content', Label)
 		item = self._group.find_by_id(item_id)
@@ -530,7 +530,7 @@ class SelectListScreen(BaseScreen[ValueT]):
 		selection_list = self.query_one(SelectionList)
 
 		if not selection_list.has_focus or event.key != 'enter':
-			return None
+			return
 
 		if len(self._selected_items) < 1:
 			index = selection_list.highlighted
@@ -743,7 +743,7 @@ class ConfirmationScreen(BaseScreen[ValueT]):
 			if self._is_btn_focus():
 				item = self._group.focus_item
 				if not item:
-					return None
+					return
 				_ = self.dismiss(Result(ResultType.Selection, _item=item))
 
 


### PR DESCRIPTION
## PR Description:

The rule (R1710) is not currently enabled in `pyproject.toml`, so the warnings don't show up by default yet.