### PR TITLE
fix: restrict EFI partition permissions with fmask/dmask=0077

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -375,7 +375,7 @@ class Installer:
 		# it would be none if it's btrfs as the subvolumes will have the mountpoints defined
 		if part_mod.mountpoint:
 			target = self.target / part_mod.relative_mountpoint
-			options = list(part_mod.mount_options)
+			options = part_mod.mount_options
 
 			if part_mod.is_efi():
 				options = list(dict.fromkeys(options + ['fmask=0077', 'dmask=0077']))

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -375,7 +375,14 @@ class Installer:
 		# it would be none if it's btrfs as the subvolumes will have the mountpoints defined
 		if part_mod.mountpoint:
 			target = self.target / part_mod.relative_mountpoint
-			mount(part_mod.dev_path, target, options=part_mod.mount_options)
+			options = list(part_mod.mount_options)
+
+			if part_mod.is_efi():
+				for opt in ('fmask=0077', 'dmask=0077'):
+					if opt not in options:
+						options.append(opt)
+
+			mount(part_mod.dev_path, target, options=options)
 		elif part_mod.fs_type == FilesystemType.BTRFS:
 			# Only mount BTRFS subvolumes that have mountpoints specified
 			subvols_with_mountpoints = [sv for sv in part_mod.btrfs_subvols if sv.mountpoint is not None]

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -378,9 +378,7 @@ class Installer:
 			options = list(part_mod.mount_options)
 
 			if part_mod.is_efi():
-				for opt in ('fmask=0077', 'dmask=0077'):
-					if opt not in options:
-						options.append(opt)
+				options = list(dict.fromkeys(options + ['fmask=0077', 'dmask=0077']))
 
 			mount(part_mod.dev_path, target, options=options)
 		elif part_mod.fs_type == FilesystemType.BTRFS:


### PR DESCRIPTION
## Summary

- Mount the ESP with `fmask=0077` and `dmask=0077` to prevent world-readable files like `/efi/loader/random-seed`
- Options are added at mount time in `_mount_partition()` and carried into the installed system via `genfstab`
- Existing user-specified mount options are preserved; the restrictive masks are only appended if not already present

Closes #4241

## Test plan

- [ ] Install with default EFI partition layout, verify `/efi/loader/random-seed` is not world-readable
- [ ] Verify `fstab` entry for ESP includes `fmask=0077,dmask=0077`
- [ ] Install with custom mount options on EFI partition, verify no duplicate fmask/dmask entries