### PR TITLE
fix: remove dead 0x0.st upload hint from error message

### DIFF
--- a/archinstall/main.py
+++ b/archinstall/main.py
@@ -141,8 +141,9 @@ def _error_message(exc: Exception) -> None:
 		Archinstall experienced the above error. If you think this is a bug, please report it to
 		https://github.com/archlinux/archinstall and include the log file "/var/log/archinstall/install.log".
 
-		Hint: To extract the log from a live ISO
-		curl -F 'file=@/var/log/archinstall/install.log' https://0x0.st
+		Hint: To extract the log from a live ISO you can mount a USB drive or use
+		cat /var/log/archinstall/install.log
+		to view and copy the relevant output.
 		"""
 	)
 	warn(text)


### PR DESCRIPTION
## Summary

- Remove the `curl -F ... https://0x0.st` hint from the error message since 0x0.st has disabled uploads
- Replace with a generic hint to view the log with `cat` for copying

0x0.st is currently returning "uploads disabled because it's been almost nothing but AI botnet spam." Users hitting an install error are then given a second broken command, which isn't a great experience.

If/when a replacement paste service is chosen, the hint can be updated to point there.

Ref #4396

## Test plan

- [ ] Trigger an archinstall error and verify the updated hint text is shown