### PR TITLE
Keep standalone initramfs for grub-btrfs when UKI is enabled

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1806,7 +1806,6 @@ class Installer:
 		bootloader: Bootloader,
 		uki_enabled: bool = False,
 		bootloader_removable: bool = False,
-		keep_initramfs: bool = False,
 	) -> None:
 		"""
 		Adds a bootloader to the installation instance.
@@ -1856,6 +1855,12 @@ class Installer:
 				bootloader_removable = False
 
 		if uki_enabled:
+			keep_initramfs = (
+				bootloader == Bootloader.Grub
+				and self._disk_config.has_default_btrfs_vols()
+				and self._disk_config.btrfs_options is not None
+				and self._disk_config.btrfs_options.snapshot_config is not None
+			)
 			self._config_uki(root, efi_partition, keep_initramfs)
 
 		match bootloader:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1754,6 +1754,7 @@ class Installer:
 		self,
 		root: PartitionModification | LvmVolume,
 		efi_partition: PartitionModification | None,
+		keep_initramfs: bool = False,
 	) -> None:
 		if not efi_partition or not efi_partition.mountpoint:
 			raise ValueError(f'Could not detect ESP at mountpoint {self.target}')
@@ -1777,11 +1778,11 @@ class Installer:
 			config = preset.read_text().splitlines(True)
 
 			for index, line in enumerate(config):
-				# Avoid storing redundant image file
 				if m := image_re.match(line):
-					image = self.target / m.group(2)
-					image.unlink(missing_ok=True)
-					config[index] = '#' + m.group(1)
+					if not keep_initramfs:
+						image = self.target / m.group(2)
+						image.unlink(missing_ok=True)
+						config[index] = '#' + m.group(1)
 				elif m := uki_re.match(line):
 					if diff_mountpoint:
 						config[index] = m.group(2) + diff_mountpoint + m.group(3)
@@ -1800,7 +1801,13 @@ class Installer:
 		if not self.mkinitcpio(['-P']):
 			error('Error generating initramfs (continuing anyway)')
 
-	def add_bootloader(self, bootloader: Bootloader, uki_enabled: bool = False, bootloader_removable: bool = False) -> None:
+	def add_bootloader(
+		self,
+		bootloader: Bootloader,
+		uki_enabled: bool = False,
+		bootloader_removable: bool = False,
+		keep_initramfs: bool = False,
+	) -> None:
 		"""
 		Adds a bootloader to the installation instance.
 		Archinstall supports one of five types:
@@ -1849,7 +1856,7 @@ class Installer:
 				bootloader_removable = False
 
 		if uki_enabled:
-			self._config_uki(root, efi_partition)
+			self._config_uki(root, efi_partition, keep_initramfs)
 
 		match bootloader:
 			case Bootloader.Systemd:

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -115,21 +115,10 @@ def perform_installation(
 			installation.setup_swap(algo=config.swap.algorithm)
 
 		if config.bootloader_config and config.bootloader_config.bootloader != Bootloader.NO_BOOTLOADER:
-			keep_initramfs = False
-			if (
-				config.bootloader_config.uki
-				and config.bootloader_config.bootloader == Bootloader.Grub
-				and disk_config.has_default_btrfs_vols()
-				and disk_config.btrfs_options
-				and disk_config.btrfs_options.snapshot_config
-			):
-				keep_initramfs = True
-
 			installation.add_bootloader(
 				config.bootloader_config.bootloader,
 				config.bootloader_config.uki,
 				config.bootloader_config.removable,
-				keep_initramfs,
 			)
 
 		if config.network_config:

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -115,7 +115,22 @@ def perform_installation(
 			installation.setup_swap(algo=config.swap.algorithm)
 
 		if config.bootloader_config and config.bootloader_config.bootloader != Bootloader.NO_BOOTLOADER:
-			installation.add_bootloader(config.bootloader_config.bootloader, config.bootloader_config.uki, config.bootloader_config.removable)
+			keep_initramfs = False
+			if (
+				config.bootloader_config.uki
+				and config.bootloader_config.bootloader == Bootloader.Grub
+				and disk_config.has_default_btrfs_vols()
+				and disk_config.btrfs_options
+				and disk_config.btrfs_options.snapshot_config
+			):
+				keep_initramfs = True
+
+			installation.add_bootloader(
+				config.bootloader_config.bootloader,
+				config.bootloader_config.uki,
+				config.bootloader_config.removable,
+				keep_initramfs,
+			)
 
 		if config.network_config:
 			install_network_config(


### PR DESCRIPTION
Fixes #4505

When UKI and Grub are used together with btrfs snapshots (Snapper or Timeshift), _config_uki() no longer comments out *_image= lines in mkinitcpio presets and no longer deletes initramfs files. This lets mkinitcpio -P generate both UKI and standalone initramfs, so grub-btrfs can find initramfs-linux.img for snapshot boot entries.

Without this fix, _config_uki() unconditionally disables standalone initramfs generation, leaving grub-btrfs without a bootable kernel image for snapshots.