### PR TITLE
Fix bspwm black screen: add provision() delegation and default configs

### DIFF
--- a/archinstall/default_profiles/desktop.py
+++ b/archinstall/default_profiles/desktop.py
@@ -9,6 +9,7 @@ from archinstall.tui.ui.result import ResultType
 
 if TYPE_CHECKING:
 	from archinstall.lib.installer import Installer
+	from archinstall.lib.models.users import User
 
 
 class DesktopProfile(Profile):
@@ -87,6 +88,11 @@ class DesktopProfile(Profile):
 	def post_install(self, install_session: Installer) -> None:
 		for profile in self.current_selection:
 			profile.post_install(install_session)
+
+	@override
+	def provision(self, install_session: Installer, users: list[User]) -> None:
+		for profile in self.current_selection:
+			profile.provision(install_session, users)
 
 	@override
 	def install(self, install_session: Installer) -> None:

--- a/archinstall/default_profiles/desktops/bspwm.py
+++ b/archinstall/default_profiles/desktops/bspwm.py
@@ -1,6 +1,10 @@
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from archinstall.default_profiles.profile import DisplayServerType, GreeterType, Profile, ProfileType
+
+if TYPE_CHECKING:
+	from archinstall.lib.installer import Installer
+	from archinstall.lib.models.users import User
 
 
 class BspwmProfile(Profile):
@@ -27,3 +31,11 @@ class BspwmProfile(Profile):
 	@override
 	def default_greeter_type(self) -> GreeterType:
 		return GreeterType.Lightdm
+
+	@override
+	def provision(self, install_session: Installer, users: list[User]) -> None:
+		for user in users:
+			install_session.arch_chroot('mkdir -p ~/.config/bspwm ~/.config/sxhkd', run_as=user.username)
+			install_session.arch_chroot('cp /usr/share/doc/bspwm/examples/bspwmrc ~/.config/bspwm/', run_as=user.username)
+			install_session.arch_chroot('cp /usr/share/doc/bspwm/examples/sxhkdrc ~/.config/sxhkd/', run_as=user.username)
+			install_session.arch_chroot('chmod +x ~/.config/bspwm/bspwmrc', run_as=user.username)

--- a/archinstall/default_profiles/desktops/bspwm.py
+++ b/archinstall/default_profiles/desktops/bspwm.py
@@ -1,10 +1,8 @@
-from typing import TYPE_CHECKING, override
+from typing import override
 
 from archinstall.default_profiles.profile import DisplayServerType, GreeterType, Profile, ProfileType
-
-if TYPE_CHECKING:
-	from archinstall.lib.installer import Installer
-	from archinstall.lib.models.users import User
+from archinstall.lib.installer import Installer
+from archinstall.lib.models.users import User
 
 
 class BspwmProfile(Profile):


### PR DESCRIPTION
bspwm profile installs packages but does not provision configuration files. After login via lightdm the user sees a black screen with no keybindings because ~/.config/bspwm/bspwmrc and ~/.config/sxhkd/sxhkdrc do not exist.
 
Two fixes: 

- DesktopProfile did not override provision() to delegate to sub-profiles (unlike ServerProfile), so BspwmProfile.provision() was never called. Added the missing delegation.
- BspwmProfile.provision() now copies example configs from /usr/share/doc/bspwm/examples/ to each user's ~/.config/ and makes bspwmrc executable. This matches what the Arch Wiki recommends for a minimal working setup.