### PR TITLE
Add IWD standalone option to network configuration + fix NM_IWD

### DIFF
--- a/archinstall/lib/models/network.py
+++ b/archinstall/lib/models/network.py
@@ -23,7 +23,7 @@ class NicType(Enum):
 			case NicType.NM_IWD:
 				return tr('Use Network Manager (iwd backend)')
 			case NicType.IWD:
-				return tr('Use iwd standalone (no Network Manager)')
+				return tr('Use standalone iwd')
 			case NicType.MANUAL:
 				return tr('Manual configuration')
 

--- a/archinstall/lib/models/network.py
+++ b/archinstall/lib/models/network.py
@@ -11,6 +11,7 @@ class NicType(Enum):
 	ISO = 'iso'
 	NM = 'nm'
 	NM_IWD = 'nm_iwd'
+	IWD = 'iwd'
 	MANUAL = 'manual'
 
 	def display_msg(self) -> str:
@@ -21,6 +22,8 @@ class NicType(Enum):
 				return tr('Use Network Manager (default backend)')
 			case NicType.NM_IWD:
 				return tr('Use Network Manager (iwd backend)')
+			case NicType.IWD:
+				return tr('Use iwd standalone (no Network Manager)')
 			case NicType.MANUAL:
 				return tr('Manual configuration')
 
@@ -125,6 +128,10 @@ class NetworkConfiguration:
 				return cls(NicType.ISO)
 			case NicType.NM:
 				return cls(NicType.NM)
+			case NicType.NM_IWD:
+				return cls(NicType.NM_IWD)
+			case NicType.IWD:
+				return cls(NicType.IWD)
 			case NicType.MANUAL:
 				nics_arg = config.get('nics', [])
 				if nics_arg:

--- a/archinstall/lib/network/network_handler.py
+++ b/archinstall/lib/network/network_handler.py
@@ -32,6 +32,12 @@ def install_network_config(
 				_configure_nm_iwd(installation)
 				installation.disable_service('iwd.service')
 
+		case NicType.IWD:
+			installation.add_additional_packages(['iwd'])
+			_configure_iwd_standalone(installation)
+			installation.enable_service('iwd.service')
+			installation.enable_service('systemd-resolved.service')
+
 		case NicType.MANUAL:
 			for nic in network_config.nics:
 				installation.configure_nic(nic)
@@ -45,3 +51,12 @@ def _configure_nm_iwd(installation: Installer) -> None:
 
 	iwd_backend_conf = nm_conf_dir / 'wifi_backend.conf'
 	_ = iwd_backend_conf.write_text('[device]\nwifi.backend=iwd\n')
+
+
+def _configure_iwd_standalone(installation: Installer) -> None:
+	# Let iwd handle DHCP/DNS itself; resolved picks up its DNS via the symlink.
+	iwd_conf_dir = installation.target / 'etc/iwd'
+	iwd_conf_dir.mkdir(parents=True, exist_ok=True)
+
+	main_conf = iwd_conf_dir / 'main.conf'
+	_ = main_conf.write_text('[General]\nEnableNetworkConfiguration=true\n\n[Network]\nNameResolvingService=systemd\n')

--- a/archinstall/lib/network/network_handler.py
+++ b/archinstall/lib/network/network_handler.py
@@ -65,7 +65,7 @@ def _configure_iwd_standalone(installation: Installer) -> None:
 	networkd_dir = installation.target / 'etc/systemd/network'
 	networkd_dir.mkdir(parents=True, exist_ok=True)
 	wired_conf = networkd_dir / '20-wired.network'
-	_ = wired_conf.write_text('[Match]\nName=en*\nName=eth*\n\n[Network]\nDHCP=yes\n')
+	_ = wired_conf.write_text('[Match]\nType=ether\nKind=!*\n\n[Network]\nDHCP=yes\n')
 
 	resolv = installation.target / 'etc/resolv.conf'
 	resolv.unlink(missing_ok=True)

--- a/archinstall/lib/network/network_handler.py
+++ b/archinstall/lib/network/network_handler.py
@@ -36,6 +36,7 @@ def install_network_config(
 			installation.add_additional_packages(['iwd'])
 			_configure_iwd_standalone(installation)
 			installation.enable_service('iwd.service')
+			installation.enable_service('systemd-networkd.service')
 			installation.enable_service('systemd-resolved.service')
 
 		case NicType.MANUAL:
@@ -54,9 +55,18 @@ def _configure_nm_iwd(installation: Installer) -> None:
 
 
 def _configure_iwd_standalone(installation: Installer) -> None:
-	# Let iwd handle DHCP/DNS itself; resolved picks up its DNS via the symlink.
+	# iwd manages wireless only; systemd-networkd handles wired DHCP.
 	iwd_conf_dir = installation.target / 'etc/iwd'
 	iwd_conf_dir.mkdir(parents=True, exist_ok=True)
 
 	main_conf = iwd_conf_dir / 'main.conf'
 	_ = main_conf.write_text('[General]\nEnableNetworkConfiguration=true\n\n[Network]\nNameResolvingService=systemd\n')
+
+	networkd_dir = installation.target / 'etc/systemd/network'
+	networkd_dir.mkdir(parents=True, exist_ok=True)
+	wired_conf = networkd_dir / '20-wired.network'
+	_ = wired_conf.write_text('[Match]\nName=en*\nName=eth*\n\n[Network]\nDHCP=yes\n')
+
+	resolv = installation.target / 'etc/resolv.conf'
+	resolv.unlink(missing_ok=True)
+	resolv.symlink_to('/run/systemd/resolve/stub-resolv.conf')

--- a/archinstall/lib/network/network_handler.py
+++ b/archinstall/lib/network/network_handler.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from archinstall.lib.installer import Installer
 from archinstall.lib.models.network import NetworkConfiguration, NicType
 from archinstall.lib.models.profile import ProfileConfiguration
@@ -60,12 +62,27 @@ def _configure_iwd_standalone(installation: Installer) -> None:
 	iwd_conf_dir.mkdir(parents=True, exist_ok=True)
 
 	main_conf = iwd_conf_dir / 'main.conf'
-	_ = main_conf.write_text('[General]\nEnableNetworkConfiguration=true\n\n[Network]\nNameResolvingService=systemd\n')
+	main_conf_content = textwrap.dedent("""\
+		[General]
+		EnableNetworkConfiguration=true
+
+		[Network]
+		NameResolvingService=systemd
+	""")
+	_ = main_conf.write_text(main_conf_content)
 
 	networkd_dir = installation.target / 'etc/systemd/network'
 	networkd_dir.mkdir(parents=True, exist_ok=True)
 	wired_conf = networkd_dir / '20-wired.network'
-	_ = wired_conf.write_text('[Match]\nType=ether\nKind=!*\n\n[Network]\nDHCP=yes\n')
+	wired_conf_content = textwrap.dedent("""\
+		[Match]
+		Type=ether
+		Kind=!*
+
+		[Network]
+		DHCP=yes
+	""")
+	_ = wired_conf.write_text(wired_conf_content)
 
 	resolv = installation.target / 'etc/resolv.conf'
 	resolv.unlink(missing_ok=True)

--- a/archinstall/lib/network/network_menu.py
+++ b/archinstall/lib/network/network_menu.py
@@ -202,6 +202,8 @@ async def select_network(preset: NetworkConfiguration | None) -> NetworkConfigur
 					return NetworkConfiguration(NicType.NM)
 				case NicType.NM_IWD:
 					return NetworkConfiguration(NicType.NM_IWD)
+				case NicType.IWD:
+					return NetworkConfiguration(NicType.IWD)
 				case NicType.MANUAL:
 					preset_nics = preset.nics if preset else []
 					nics = await ManualNetworkConfig(tr('Configure interfaces'), preset_nics).show()


### PR DESCRIPTION
This PR enables `iwd` to be picked standalone (**WITHOUT** the dep chain `networkmanager → wpa_supplicant → pcsclite → polkit`) which enables minimal `seatd` setups better. 

`iwd` handles DHCP on the wireless link, `systemd-resolved` handles DNS ( Services: `iwd.service` + `systemd-networkd.service` + `systemd-resolved.service`) using stub symlink. 

> Would benefit from a small helper `Installer.link_resolved_stub()` since this is very similar to `Copy from ISO` option, but I limited scope there. (Perhaps for a follow-up).

_Misc: was missing parse case for `NM_IWD` my mistake in PR #4025 saved configs with this type were silently falling through._  [L:131](https://github.com/evoquus/archinstall-patches/blob/49c4206c8691f12e486d4e6745de5eb1f0cbd971/archinstall/lib/models/network.py#L131)

**Tests:** Both cases several times over, check existence of config files in target, ping.