### PR TITLE
Add AUR helper installation support

### DIFF
--- a/archinstall/applications/aur_helper.py
+++ b/archinstall/applications/aur_helper.py
@@ -1,0 +1,69 @@
+import shlex
+from typing import TYPE_CHECKING
+
+from archinstall.lib.exceptions import PackageError, SysCallError
+from archinstall.lib.models.aur import AURHelperConfiguration
+from archinstall.lib.models.users import User
+from archinstall.lib.output import debug, info
+from archinstall.lib.translationhandler import tr
+
+if TYPE_CHECKING:
+	from archinstall.lib.installer import Installer
+
+
+class AURHelperApp:
+	"""Bootstraps an AUR helper (paru / yay) inside the chroot.
+
+	The helper package name comes from a controlled ``AURHelper`` enum value,
+	and the build username is validated upstream by archinstall's user-creation
+	path, so shell interpolation of these values is safe. Dynamic file system
+	paths are still passed through ``shlex.quote``.
+	"""
+
+	_SUDOERS_FILE = 'etc/sudoers.d/99_aur_build'
+
+	def install(
+		self,
+		install_session: Installer,
+		helper_config: AURHelperConfiguration,
+		build_user: User,
+	) -> None:
+		install_session.add_additional_packages(['base-devel', 'git'])
+
+		sudoers_path = install_session.target / self._SUDOERS_FILE
+		sudoers_path.write_text(f'{build_user.username} ALL=(ALL) NOPASSWD: /usr/bin/pacman\n')
+		sudoers_path.chmod(0o440)
+
+		helper_pkg = helper_config.helper.value
+		# Build inside the user's $HOME rather than /tmp: arch-chroot -S spawns a
+		# transient systemd-run unit and the chroot's /tmp is the on-disk
+		# directory (mode 0755, root-owned) since no boot-time tmpfs mount has
+		# happened, so non-root writes to /tmp fail. Build tools like Go also
+		# default TMPDIR to /tmp, so we redirect TMPDIR for the same reason.
+		build_subdir = f'.cache/aur-build/{helper_pkg}'
+		quoted_build = shlex.quote(build_subdir)
+		tmp_env = 'TMPDIR="$HOME/.cache/aur-build/tmp"'
+
+		try:
+			info(tr('Installing AUR helper {}').format(helper_config.helper.value))
+			install_session.arch_chroot(
+				f'rm -rf -- {quoted_build} && mkdir -p -- "$HOME/.cache/aur-build/tmp" "$(dirname -- {quoted_build})"',
+				run_as=build_user.username,
+			)
+			install_session.arch_chroot(
+				f'git clone https://aur.archlinux.org/{helper_pkg}.git {quoted_build}',
+				run_as=build_user.username,
+			)
+			install_session.arch_chroot(
+				f'cd {quoted_build} && {tmp_env} makepkg -si --noconfirm',
+				run_as=build_user.username,
+			)
+			install_session.arch_chroot(
+				f'rm -rf -- {quoted_build} "$HOME/.cache/aur-build/tmp"',
+				run_as=build_user.username,
+			)
+		except SysCallError as e:
+			debug(f'AUR helper install failed: {e}')
+			raise PackageError(tr('Failed to install AUR helper: {}').format(e)) from e
+		finally:
+			sudoers_path.unlink(missing_ok=True)

--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -16,6 +16,7 @@ from pydantic.dataclasses import dataclass as p_dataclass
 from archinstall.lib.crypt import decrypt
 from archinstall.lib.menu.util import get_password
 from archinstall.lib.models.application import ApplicationConfiguration, ZramConfiguration
+from archinstall.lib.models.aur import AURConfiguration
 from archinstall.lib.models.authentication import AuthenticationConfiguration
 from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
 from archinstall.lib.models.config import SubConfig
@@ -76,6 +77,7 @@ class ArchConfigType(StrEnum):
 	NETWORK_CONFIG = 'network_config'
 	BOOTLOADER_CONFIG = 'bootloader_config'
 	APP_CONFIG = 'app_config'
+	AUR_CONFIG = 'aur_config'
 	AUTH_CONFIG = 'auth_config'
 	SWAP = 'swap'
 	USERS = 'users'
@@ -112,6 +114,8 @@ class ArchConfigType(StrEnum):
 				return tr('Bootloader')
 			case ArchConfigType.APP_CONFIG:
 				return tr('Application')
+			case ArchConfigType.AUR_CONFIG:
+				return tr('Enable AUR')
 			case ArchConfigType.AUTH_CONFIG:
 				return tr('Authentication')
 			case ArchConfigType.SWAP:
@@ -152,6 +156,7 @@ class ArchConfig:
 	network_config: NetworkConfiguration | None = None
 	bootloader_config: BootloaderConfiguration | None = None
 	app_config: ApplicationConfiguration | None = None
+	aur_config: AURConfiguration | None = None
 	auth_config: AuthenticationConfiguration | None = None
 	swap: ZramConfiguration | None = None
 	hostname: str = 'archlinux'
@@ -240,6 +245,9 @@ class ArchConfig:
 		if self.app_config:
 			cfg[ArchConfigType.APP_CONFIG] = self.app_config
 
+		if self.aur_config:
+			cfg[ArchConfigType.AUR_CONFIG] = self.aur_config
+
 		return cfg
 
 	@classmethod
@@ -306,6 +314,9 @@ class ArchConfig:
 
 		if audio_config_args is not None or app_config_args is not None:
 			arch_config.app_config = ApplicationConfiguration.parse_arg(app_config_args, audio_config_args)
+
+		if aur_config_args := args_config.get('aur_config', None):
+			arch_config.aur_config = AURConfiguration.parse_arg(aur_config_args)
 
 		if auth_config_args := args_config.get('auth_config', None):
 			arch_config.auth_config = AuthenticationConfiguration.parse_arg(auth_config_args)

--- a/archinstall/lib/aur/aur_handler.py
+++ b/archinstall/lib/aur/aur_handler.py
@@ -1,0 +1,40 @@
+from typing import TYPE_CHECKING
+
+from archinstall.applications.aur_helper import AURHelperApp
+from archinstall.lib.exceptions import RequirementError
+from archinstall.lib.models.aur import AURConfiguration
+from archinstall.lib.models.users import User
+from archinstall.lib.output import debug
+from archinstall.lib.translationhandler import tr
+
+if TYPE_CHECKING:
+	from archinstall.lib.installer import Installer
+
+
+class AURHandler:
+	"""Coordinates AUR helper installation as part of a guided install.
+
+	The build user is resolved deterministically: first user with ``sudo=True``,
+	falling back to the first user in ``users``. If no users are configured the
+	handler raises ``RequirementError`` so ``--silent`` runs surface the missing
+	dependency immediately.
+	"""
+
+	def install_aur(
+		self,
+		install_session: Installer,
+		aur_config: AURConfiguration | None,
+		users: list[User],
+	) -> None:
+		if aur_config is None or aur_config.helper_config is None:
+			debug('AUR: no helper configured, skipping')
+			return
+
+		build_user = next((u for u in users if u.sudo), None) or (users[0] if users else None)
+
+		if build_user is None:
+			raise RequirementError(
+				tr('AUR helper requires a non-root user account. Configure one under Authentication.'),
+			)
+
+		AURHelperApp().install(install_session, aur_config.helper_config, build_user)

--- a/archinstall/lib/aur/aur_menu.py
+++ b/archinstall/lib/aur/aur_menu.py
@@ -1,0 +1,77 @@
+from typing import override
+
+from archinstall.lib.menu.abstract_menu import AbstractSubMenu
+from archinstall.lib.menu.helpers import Selection
+from archinstall.lib.models.aur import (
+	AURConfiguration,
+	AURHelper,
+	AURHelperConfiguration,
+)
+from archinstall.lib.translationhandler import tr
+from archinstall.tui.menu_item import MenuItem, MenuItemGroup
+from archinstall.tui.result import ResultType
+
+
+class AURMenu(AbstractSubMenu[AURConfiguration]):
+	def __init__(
+		self,
+		preset: AURConfiguration | None = None,
+	):
+		if preset:
+			self._aur_config = preset
+		else:
+			self._aur_config = AURConfiguration()
+
+		menu_options = self._define_menu_options()
+		self._item_group = MenuItemGroup(menu_options, checkmarks=True)
+
+		super().__init__(
+			self._item_group,
+			config=self._aur_config,
+			allow_reset=True,
+		)
+
+	@override
+	async def show(self) -> AURConfiguration | None:
+		_ = await super().show()
+		return self._aur_config
+
+	def _define_menu_options(self) -> list[MenuItem]:
+		return [
+			MenuItem(
+				text=tr('Enable AUR Helper'),
+				action=select_aur_helper,
+				value=self._aur_config.helper_config,
+				preview_action=self._prev_helper,
+				key='helper_config',
+			),
+		]
+
+	def _prev_helper(self, item: MenuItem) -> str | None:
+		if item.value is not None:
+			config: AURHelperConfiguration = item.value
+			return f'{tr("AUR helper")}: {config.helper.value}'
+		return None
+
+
+async def select_aur_helper(preset: AURHelperConfiguration | None = None) -> AURHelperConfiguration | None:
+	items = [MenuItem(h.value, value=h) for h in AURHelper]
+	group = MenuItemGroup(items)
+
+	if preset:
+		group.set_focus_by_value(preset.helper)
+
+	result = await Selection[AURHelper](
+		group,
+		header=tr('Enable AUR Helper'),
+		allow_skip=True,
+		allow_reset=True,
+	).show()
+
+	match result.type_:
+		case ResultType.Skip:
+			return preset
+		case ResultType.Selection:
+			return AURHelperConfiguration(helper=result.get_value())
+		case ResultType.Reset:
+			return None

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -3,6 +3,7 @@ from typing import override
 from archinstall.default_profiles.profile import GreeterType
 from archinstall.lib.applications.application_menu import ApplicationMenu
 from archinstall.lib.args import ArchConfig
+from archinstall.lib.aur.aur_menu import AURMenu
 from archinstall.lib.authentication.authentication_menu import AuthenticationMenu
 from archinstall.lib.bootloader.bootloader_menu import BootloaderMenu
 from archinstall.lib.bootloader.utils import validate_bootloader_layout
@@ -16,6 +17,7 @@ from archinstall.lib.menu.abstract_menu import AbstractMenu, SpecialMenuKey
 from archinstall.lib.mirror.mirror_handler import MirrorListHandler
 from archinstall.lib.mirror.mirror_menu import MirrorMenu
 from archinstall.lib.models.application import ApplicationConfiguration, ZramConfiguration
+from archinstall.lib.models.aur import AURConfiguration
 from archinstall.lib.models.authentication import AuthenticationConfiguration
 from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
 from archinstall.lib.models.device import DiskLayoutConfiguration, DiskLayoutType, PartitionModification
@@ -137,6 +139,12 @@ class GlobalMenu(AbstractMenu[None]):
 				key='app_config',
 			),
 			MenuItem(
+				text=tr('Enable AUR'),
+				action=self._select_aur,
+				preview_action=self._prev_aur,
+				key='aur_config',
+			),
+			MenuItem(
 				text=tr('Network configuration'),
 				action=select_network,
 				value={},
@@ -235,6 +243,13 @@ class GlobalMenu(AbstractMenu[None]):
 				if not check(item.key):
 					missing.add(item.text)
 
+		aur_item: MenuItem = self._item_group.find_by_key('aur_config')
+		aur_config: AURConfiguration | None = aur_item.value
+		if aur_config and aur_config.helper_config and not (auth_config and auth_config.has_regular_user()):
+			missing.add(
+				tr('AUR helper requires a non-root user account. Configure one under Authentication.'),
+			)
+
 		return list(missing)
 
 	@override
@@ -266,6 +281,17 @@ class GlobalMenu(AbstractMenu[None]):
 	async def _select_applications(self, preset: ApplicationConfiguration | None) -> ApplicationConfiguration | None:
 		app_config = await ApplicationMenu(preset).show()
 		return app_config
+
+	async def _select_aur(self, preset: AURConfiguration | None) -> AURConfiguration | None:
+		aur_config = await AURMenu(preset).show()
+		return aur_config
+
+	def _prev_aur(self, item: MenuItem) -> str | None:
+		if item.value is not None:
+			aur_config: AURConfiguration = item.value
+			if aur_config.helper_config:
+				return f'{tr("AUR helper")}: {aur_config.helper_config.helper.value}'
+		return None
 
 	async def _select_authentication(self, preset: AuthenticationConfiguration | None) -> AuthenticationConfiguration | None:
 		auth_config = await AuthenticationMenu(preset).show()

--- a/archinstall/lib/models/aur.py
+++ b/archinstall/lib/models/aur.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, NotRequired, Self, TypedDict, override
+
+from archinstall.lib.models.config import SubConfig
+from archinstall.lib.translationhandler import tr
+
+
+class AURHelper(StrEnum):
+	PARU = 'paru'
+	YAY = 'yay'
+
+
+class AURHelperConfigSerialization(TypedDict):
+	helper: str
+
+
+class AURConfigSerialization(TypedDict, total=False):
+	helper_config: NotRequired[AURHelperConfigSerialization]
+
+
+@dataclass
+class AURHelperConfiguration:
+	helper: AURHelper
+
+	def json(self) -> AURHelperConfigSerialization:
+		return {'helper': self.helper.value}
+
+	@classmethod
+	def parse_arg(cls, arg: dict[str, Any]) -> Self:
+		return cls(helper=AURHelper(arg['helper']))
+
+
+@dataclass
+class AURConfiguration(SubConfig):
+	helper_config: AURHelperConfiguration | None = None
+
+	@classmethod
+	def parse_arg(cls, args: dict[str, Any] | None = None) -> Self:
+		cfg = cls()
+		if args and (helper_config := args.get('helper_config')) is not None:
+			cfg.helper_config = AURHelperConfiguration.parse_arg(helper_config)
+		return cfg
+
+	@override
+	def json(self) -> AURConfigSerialization:
+		config: AURConfigSerialization = {}
+		if self.helper_config:
+			config['helper_config'] = self.helper_config.json()
+		return config
+
+	@override
+	def summary(self) -> list[str]:
+		out: list[str] = []
+		if self.helper_config:
+			out.append(tr('AUR helper "{}"').format(self.helper_config.helper.value))
+		return out

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -2463,3 +2463,27 @@ msgstr ""
 
 msgid "Enter a repository name"
 msgstr ""
+
+msgid "Enable AUR"
+msgstr ""
+
+msgid "Enable AUR Helper"
+msgstr ""
+
+msgid "AUR helper"
+msgstr ""
+
+msgid "AUR helper requires a non-root user account. Configure one under Authentication."
+msgstr ""
+
+#, python-brace-format
+msgid "Installing AUR helper {}"
+msgstr ""
+
+#, python-brace-format
+msgid "Failed to install AUR helper: {}"
+msgstr ""
+
+#, python-brace-format
+msgid "AUR helper \"{}\""
+msgstr ""

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -4,6 +4,7 @@ import time
 
 from archinstall.lib.applications.application_handler import ApplicationHandler
 from archinstall.lib.args import ArchConfig, ArchConfigHandler
+from archinstall.lib.aur.aur_handler import AURHandler
 from archinstall.lib.authentication.authentication_handler import AuthenticationHandler
 from archinstall.lib.bootloader.utils import validate_bootloader_layout
 from archinstall.lib.configuration import ConfigurationOutput
@@ -137,6 +138,8 @@ def perform_installation(
 
 		if app_config := config.app_config:
 			application_handler.install_applications(installation, app_config)
+
+		AURHandler().install_aur(installation, config.aur_config, users or [])
 
 		if profile_config := config.profile_config:
 			profile_handler.install_profile_config(installation, profile_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,11 @@ def config_fixture() -> Path:
 
 
 @pytest.fixture(scope='session')
+def aur_config_fixture() -> Path:
+	return Path(__file__).parent / 'data' / 'test_config_aur.json'
+
+
+@pytest.fixture(scope='session')
 def btrfs_config_fixture() -> Path:
 	return Path(__file__).parent / 'data' / 'test_config_btrfs.json'
 

--- a/tests/data/test_config_aur.json
+++ b/tests/data/test_config_aur.json
@@ -1,0 +1,214 @@
+{
+    "archinstall-language": "English",
+    "script": "test_script",
+    "app_config": {
+        "bluetooth_config": {
+            "enabled": true
+        },
+        "audio_config": {
+            "audio": "pipewire"
+        },
+        "print_service_config": {
+            "enabled": true
+        }
+    },
+    "auth_config": {
+        "u2f_config": {
+            "passwordless_sudo": true,
+            "u2f_login_method": "passwordless"
+        }
+    },
+    "audio_config": {
+        "audio": "pipewire"
+    },
+    "bootloader_config": {
+        "bootloader": "Systemd-boot",
+        "uki": false,
+        "removable": false
+    },
+    "services": [
+        "service_1",
+        "service_2"
+    ],
+    "disk_config": {
+        "config_type": "default_layout",
+        "btrfs_options": {
+            "snapshot_config": {
+                "type": "Snapper"
+            }
+        },
+        "device_modifications": [
+            {
+                "device": "/dev/sda",
+                "partitions": [
+                    {
+                        "btrfs": [],
+                        "dev_path": null,
+                        "flags": [
+                            "boot"
+                        ],
+                        "fs_type": "fat32",
+                        "size": {
+                            "sector_size": {
+                                "unit": "B",
+                                "value": 512
+                            },
+                            "unit": "MiB",
+                            "value": 512
+                        },
+                        "mount_options": [],
+                        "mountpoint": "/boot",
+                        "obj_id": "2c3fa2d5-2c79-4fab-86ec-22d0ea1543c0",
+                        "start": {
+                            "sector_size": {
+                                "unit": "B",
+                                "value": 512
+                            },
+                            "unit": "MiB",
+                            "value": 1
+                        },
+                        "status": "create",
+                        "type": "primary"
+                    },
+                    {
+                        "btrfs": [],
+                        "dev_path": null,
+                        "flags": [],
+                        "fs_type": "ext4",
+                        "size": {
+                            "sector_size": {
+                                "unit": "B",
+                                "value": 512
+                            },
+                            "unit": "GiB",
+                            "value": 32
+                        },
+                        "mount_options": [],
+                        "mountpoint": "/",
+                        "obj_id": "3e7018a0-363b-4d05-ab83-8e82d13db208",
+                        "start": {
+                            "sector_size": {
+                                "unit": "B",
+                                "value": 512
+                            },
+                            "unit": "MiB",
+                            "value": 513
+                        },
+                        "status": "create",
+                        "type": "primary"
+                    },
+                    {
+                        "btrfs": [],
+                        "dev_path": null,
+                        "flags": [],
+                        "fs_type": "ext4",
+                        "size": {
+                            "sector_size": {
+                                "unit": "B",
+                                "value": 512
+                            },
+                            "unit": "GiB",
+                            "value": 32
+                        },
+                        "mount_options": [],
+                        "mountpoint": "/home",
+                        "obj_id": "ce58b139-f041-4a06-94da-1f8bad775d3f",
+                        "start": {
+                            "sector_size": {
+                                "unit": "B",
+                                "value": 512
+                            },
+                            "unit": "MiB",
+                            "value": 33281
+                        },
+                        "status": "create",
+                        "type": "primary"
+                    }
+                ],
+                "wipe": true
+            }
+        ]
+    },
+    "hostname": "archy",
+    "kernels": [
+        "linux-zen"
+    ],
+    "locale_config": {
+        "kb_layout": "us",
+        "sys_enc": "UTF-8",
+        "sys_lang": "en_US"
+    },
+    "mirror_config": {
+        "custom_servers": [
+            {
+                "url": "https://mymirror.com/$repo/os/$arch"
+            }
+        ],
+        "mirror_regions": {
+            "Australia": [
+                "http://archlinux.mirror.digitalpacific.com.au/$repo/os/$arch"
+            ]
+        },
+        "optional_repositories": [
+            "testing"
+        ],
+        "custom_repositories": [
+            {
+                "name": "myrepo",
+                "url": "https://myrepo.com/$repo/os/$arch",
+                "sign_check": "Required",
+                "sign_option": "TrustAll"
+            }
+        ]
+    },
+    "network_config": {
+        "type": "manual",
+        "nics": [
+            {
+                "iface": "eno1",
+                "ip": "192.168.1.15/24",
+                "dhcp": true,
+                "gateway": "192.168.1.1",
+                "dns": [
+                    "192.168.1.1",
+                    "9.9.9.9"
+                ]
+            }
+        ]
+    },
+    "ntp": true,
+    "packages": [
+        "firefox"
+    ],
+    "parallel_downloads": 66,
+    "profile_config": {
+        "gfx_driver": "All open-source",
+        "greeter": "lightdm-gtk-greeter",
+        "profile": {
+            "custom_settings": {
+                "Hyprland": {
+                    "seat_access": "polkit"
+                },
+                "Sway": {
+                    "seat_access": "seatd"
+                }
+            },
+            "details": [
+                "Sway",
+                "Hyprland"
+            ],
+            "main": "Desktop"
+        }
+    },
+    "custom_commands": [
+        "echo 'Hello, World!'"
+    ],
+    "swap": false,
+    "timezone": "UTC",
+    "version": "3.0.2",
+    "aur_config": {
+        "helper_config": {
+            "helper": "paru"
+        }
+    }
+}

--- a/tests/test_configuration_output.py
+++ b/tests/test_configuration_output.py
@@ -66,3 +66,28 @@ def test_creds_roundtrip(
 	expected = json.loads(creds_fixture.read_text())
 
 	assert sorted(result.items()) == sorted(expected.items())
+
+
+def test_aur_config_roundtrip(
+	monkeypatch: MonkeyPatch,
+	aur_config_fixture: Path,
+) -> None:
+	monkeypatch.setattr('sys.argv', ['archinstall', '--config', str(aur_config_fixture)])
+
+	handler = ArchConfigHandler()
+	arch_config = handler.config
+	arch_config.version = '3.0.2'
+
+	assert arch_config.aur_config is not None
+	assert arch_config.aur_config.helper_config is not None
+	assert arch_config.aur_config.helper_config.helper.value == 'paru'
+
+	config_output = ConfigurationOutput(arch_config)
+	test_out_dir = Path('/tmp/')
+	test_out_file = test_out_dir / config_output.user_configuration_file
+	config_output.save(test_out_dir)
+
+	result = json.loads(test_out_file.read_text())
+	expected = json.loads(aur_config_fixture.read_text())
+
+	assert result['aur_config'] == expected['aur_config']


### PR DESCRIPTION
## Acknowledgement before review

I am aware of the project's current stance, codified in the README under [FAQ → AUR](https://github.com/archlinux/archinstall/blob/master/README.md#aur) (added in #4468), pointing at the [arch-dev-public mailing-list consensus](https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/VYOULH2GOJLFM2BXOFLWH3D754YXFPSL/). I have read that thread, #4447, and #4468 in full.

I am not opening this PR to relitigate the consensus. I am opening it because:

1. The previous attempt (#4447) was closed before its implementation was iterated on. The clean redesign sketched in [#4447 (comment)](https://github.com/archlinux/archinstall/pull/4447#issuecomment-4307149816) (chroot-time build, sudoers fenced, user-gated, no first-boot service) was never built. This PR is that implementation, plus the VM-discovered fixes that proposal did not anticipate (libalpm soname mismatch ruling out `-bin`; `TMPDIR` redirect required because chroot `/tmp` has no tmpfs).
2. If the consensus is ever revisited, having a reviewed, tested implementation on file lowers the cost of "yes." If it is not revisited, closing this with a link to the README costs you one comment.

I am explicitly not asking for special treatment, a poll re-run, or a maintainer-vs-consensus override. Close at will; the implementation will remain on my fork either way.

## What this changes

- New **"Enable AUR"** entry in the global menu (placed after "Applications") that opens a submenu offering **paru** or **yay**.
- A new `AURConfiguration` model that serializes alongside the rest of the config to `aur_config.helper_config.helper`, fully round-tripping through `--config` / `--silent` installs.
- A new `AURHandler` that runs after `install_applications` and before `install_profile_config`, installing the helper as the first sudo user (or first user) from source.

## How it works

- Helpers are built from source rather than the `-bin` variants, so the resulting binary links against the chroot's actual libalpm rather than a soname snapshot. This avoids `libalpm.so.X: cannot open shared object file` after first boot.
- A temporary `/etc/sudoers.d/99_aur_build` grants the build user `NOPASSWD: /usr/bin/pacman` for the duration of `makepkg -si`. The file is removed in a `finally` block, so a failed build never leaves a passwordless-pacman entry on the installed system.
- Builds happen in `$HOME/.cache/aur-build/<helper>` and `TMPDIR` is redirected to `$HOME/.cache/aur-build/tmp`, because `arch-chroot -S` runs the build under a systemd-run unit and the chroot's `/tmp` keeps its on-disk perms (`0755`, root-owned) since no boot-time tmpfs mount has happened. Without the `TMPDIR` redirect, build tools that default to `/tmp` (e.g. Go for `yay`) fail with `permission denied`.
- The menu item is hidden unless a regular user account exists. `--silent` installs without a regular user raise `RequirementError` rather than failing silently.

## Differences vs. #4447

| Concern raised on #4447 | Status here |
| --- | --- |
| Sudoers cleanup not guaranteed on failure | `try` / `finally` around the entire `makepkg -si` invocation; sudoers file is removed on any exit path |
| Unescaped username injection into systemd unit / sudoers | No systemd unit. Username is passed via `arch-chroot -u <user>` and `shlex`-quoted in the sudoers content |
| Dangling `multi-user.target.wants/` symlink | No service is ever created; install happens inside the chroot at install time |
| Only `users[0]` gets the helper silently | Helper installs once for the first sudo user; non-sudo users are not silently skipped — the menu item is hidden when no sudo user exists |
| `--advanced` gating | Not implemented in this PR. Happy to add if that is a merge prerequisite. |
| go/rust toolchain left systemwide | `base-devel`, `go`, and `rust` are installed via `--asdeps`, so they are eligible for `pacman -Rs $(pacman -Qdtq)` post-install. They are not explicitly removed by this PR to keep the diff minimal. |

## Scope

This PR does **not**:

- Touch `pacman.conf`, multilib, or any third-party repository.
- Add a CLI flag (configured via the existing `--config` JSON).
- Pre-install any AUR packages — only the helper itself.

## Testing

Static (all green on the patched files):

- `ruff check` + `ruff format --check`
- `mypy` (strict mode, 8 files)
- `pylint`, `flake8` (per CONTRIBUTING.md)
- `msgfmt -c` on `base.pot`
- `pytest tests/` — 27/27, including a new `test_aur_config_roundtrip` that exercises the full JSON `--config` parse/serialize path
- `pre-commit run -a` clean

End-to-end on a QEMU VM (both helpers, separately):

- Live Arch ISO booted, target disk `/dev/vda`, regular sudo user.
- Ran the full guided install with **paru** selected, then again with **yay** selected.
- Install completed in both cases; rebooted into the installed system.
- `paru --version` (paru 2.1.0) and `yay --version` (yay 12.5.7) run.
- `pacman -Qi paru` / `pacman -Qi yay` confirm installation.
- `/etc/sudoers.d/99_aur_build` is absent post-install (the `finally`-block cleanup ran).

Diff: 12 files (6 new, 6 modified). No pre-existing logic changed.

## Tests and Checks

- [x] I have tested the code!