### PR TITLE
Fix syntax errors

### DIFF
--- a/archinstall/lib/command.py
+++ b/archinstall/lib/command.py
@@ -379,6 +379,6 @@ def _append_log(file: str, content: str) -> None:
 
 		if change_perm:
 			path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
-	except PermissionError, FileNotFoundError:
+	except (PermissionError, FileNotFoundError):
 		# If the file does not exist, ignore the error
 		pass

--- a/archinstall/lib/models/network.py
+++ b/archinstall/lib/models/network.py
@@ -231,7 +231,7 @@ class WifiConfiguredNetwork:
 						flags=flags,
 					)
 				)
-			except ValueError, IndexError:
+			except (ValueError, IndexError):
 				debug('Parsing error for network output')
 
 		return networks


### PR DESCRIPTION
Here is a complete, pre-filled Pull Request template that you can copy and paste directly into the GitHub PR description:

```markdown
- This fix issue: Fixes Python 3 syntax errors in exception handling.

## PR Description:

This PR corrects two Python syntax errors caused by unparenthesized multiple exception catching blocks, which are invalid in Python 3 and prevent successful byte-compilation or execution of the respective modules. 

Specifically:
- archinstall/lib/command.py: Parenthesized `PermissionError, FileNotFoundError` on line 382 to `(PermissionError, FileNotFoundError)`.
- archinstall/lib/models/network.py: Parenthesized `ValueError, IndexError` on line 234 to `(ValueError, IndexError)`.

These fixes restore compliance with standard Python 3 exception handling syntax.

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      Successfully compiled all Python modules using Python's compiler module (`py_compile`) recursively across the entire repository to verify that all modules now parse and byte-compile 100% cleanly without any syntactic or parsing errors.
  -->
```