### PR TITLE
chore: fix non-working parallel download config examples

### DIFF
--- a/examples/config-sample.json
+++ b/examples/config-sample.json
@@ -133,7 +133,10 @@
   "ntp": true,
   "offline": false,
   "packages": [],
-  "parallel downloads": 0,
+  "pacman_config": {
+    "color": false,
+    "parallel_downloads": 5
+  },
   "profile_config": {
     "gfx_driver": "All open-source (default)",
     "greeter": "sddm",


### PR DESCRIPTION
### TL;DR:
- fix the config for 'parallel download'
- add config for setting color output for pacman

- This fix issue: #4568

## PR Description:
The given example config in the `examples/config-sample.json` (https://github.com/akileshas/archinstall/blob/b96afcc579c9a23b5779fa86b2c6775a556bf61b/examples/config-sample.json#L136) for setting the parrallel downloads in the `json` config file does not works.

Corrected the example config sample with an working example to set parallel downloads and colors for the pacman output.

I have attached an demo for this below.


https://github.com/user-attachments/assets/8996321a-c276-406b-a12b-594ee3415069



## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
