### PR TITLE
fix(luks): surface cryptsetup error output when unlock fails

### DIFF
--- a/archinstall/lib/disk/luks.py
+++ b/archinstall/lib/disk/luks.py
@@ -149,7 +149,11 @@ class Luks2:
 			'luks2',
 		]
 
-		result = run(cmd, input_data=passphrase)
+		try:
+			result = run(cmd, input_data=passphrase)
+		except CalledProcessError as err:
+			output = err.stdout.decode().rstrip()
+			raise DiskError(f'Could not unlock luks2 device "{self.luks_dev_path}": {output}')
 
 		debug(f'cryptsetup open output: {result.stdout.decode().rstrip()}')
 


### PR DESCRIPTION
### What

`Luks2.unlock()` calls `cryptsetup open` through `run()` with no error handling. When the command fails it raises a bare `CalledProcessError`, and Python's default rendering of that exception prints only the exit status (`returned non-zero exit status N`) while discarding the captured output. Since `run()` sets `stderr=subprocess.STDOUT`, that discarded output is exactly cryptsetup's stderr, so the real diagnostic never reaches `install.log`.

This wraps the call and raises a `DiskError` that includes the captured output, mirroring what `encrypt()` already does a few lines above in the same file:

```python
try:
    result = run(cmd, input_data=passphrase)
except CalledProcessError as err:
    output = err.stdout.decode().rstrip()
    raise DiskError(f'Could not encrypt volume "{self.luks_dev_path}": {output}')
```

### Why

Reported in #4327: a manually partitioned encrypted btrfs install failed at "unlocking luks2 device" with only a traceback ending in `returned non-zero exit status 5`. The reporter noted that the log did not include the stderr of cryptsetup and had to re-run the command by hand to discover the actual cause (`device-mapper: crypt: unknown table type`). With this change that message would have been written straight to the install log.

This does not try to fix the underlying device-mapper condition in #4327, which looks environmental and was not reproducible by other contributors. It makes that whole class of unlock failure diagnosable from the log instead of opaque.

### Notes

- Success path is unchanged. Only the failure path differs: a clean `DiskError` instead of an uncaught `CalledProcessError`.
- Consistent with the existing `encrypt()` error handling in the same module.
- `ruff check` and `ruff format --check` pass.
