### PR TITLE
Fix Plymouth theme preset focus and add missing strings to base.pot

### DIFF
--- a/archinstall/lib/bootloader/bootloader_menu.py
+++ b/archinstall/lib/bootloader/bootloader_menu.py
@@ -235,7 +235,7 @@ async def select_bootloader(
 async def select_plymouth_theme(preset: PlymouthTheme | None = None) -> PlymouthTheme | None:
 	items = [MenuItem(t.value, value=t) for t in PlymouthTheme]
 	group = MenuItemGroup(items, sort_items=False)
-	group.set_selected_by_value(preset.value if preset else None)
+	group.set_focus_by_value(preset)
 
 	result = await Selection[PlymouthTheme](
 		group,

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -209,6 +209,9 @@ msgstr ""
 msgid "Install to removable location"
 msgstr ""
 
+msgid "Plymouth"
+msgstr ""
+
 msgid "Will install to /EFI/BOOT/ (removable location, safe default)"
 msgstr ""
 
@@ -246,6 +249,9 @@ msgid "Select bootloader to install"
 msgstr ""
 
 msgid "UEFI is not detected and some options are disabled"
+msgstr ""
+
+msgid "Select Plymouth theme"
 msgstr ""
 
 msgid "The specified configuration will be applied"
@@ -880,6 +886,10 @@ msgid "UKI enabled"
 msgstr ""
 
 msgid "Removable"
+msgstr ""
+
+#, python-brace-format
+msgid "Plymouth \"{}\""
 msgstr ""
 
 msgid "Use a best-effort default partition layout"


### PR DESCRIPTION
Two small follow-ups to #4555:

- `select_plymouth_theme()` passed `preset.value` (a string) to `set_selected_by_value()`, while the menu items hold `PlymouthTheme` enum values - so the previously selected theme was never highlighted when reopening the menu. Switched to `set_focus_by_value(preset)`, matching `select_bootloader()` and the other single-select menus.
- Regenerated `base.pot` to pick up the three Plymouth strings ("Plymouth", "Select Plymouth theme", "Plymouth \"{}\"").
