### PR TITLE
Fix plugin

### DIFF
--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 import urllib.error
 import urllib.parse
 from argparse import ArgumentParser, Namespace
@@ -56,7 +57,8 @@ class Arguments:
 	debug: bool = False
 	offline: bool = False
 	no_pkg_lookups: bool = False
-	plugin: str | None = None
+	plugin: Path | None = None
+	plugin_url: str | None = None
 	skip_version_check: bool = False
 	skip_wifi_check: bool = False
 	advanced: bool = False
@@ -517,9 +519,16 @@ class ArchConfigHandler:
 		parser.add_argument(
 			'--plugin',
 			nargs='?',
-			type=str,
+			type=Path,
 			default=None,
 			help='File path to a plugin to load',
+		)
+		parser.add_argument(
+			'--plugin-url',
+			type=str,
+			nargs='?',
+			default=None,
+			help='Url to a plugin file to load',
 		)
 		parser.add_argument(
 			'--skip-version-check',
@@ -560,7 +569,11 @@ class ArchConfigHandler:
 			warn(f'Warning: --debug mode will write certain credentials to {logger.path}!')
 
 		if args.plugin:
-			plugin_path = Path(args.plugin)
+			load_plugin(args.plugin)
+
+		if args.plugin_url:
+			plugin_data = self._fetch_from_url(args.plugin_url)
+			plugin_path = self._write_plugin_to_temp_file(plugin_data)
 			load_plugin(plugin_path)
 
 		if args.creds_decryption_key is None:
@@ -651,6 +664,19 @@ class ArchConfigHandler:
 			error('Not a valid url')
 
 		sys.exit(1)
+
+	def _write_plugin_to_temp_file(self, plugin_data: str) -> Path:
+		tmp_file = tempfile.NamedTemporaryFile(
+			mode='w',
+			suffix='.py',
+			prefix='archinstall_plugin_',
+			delete=False,
+		)
+
+		with tmp_file as f:
+			f.write(plugin_data)
+
+		return Path(tmp_file.name)
 
 	def _read_file(self, path: Path) -> str:
 		if not path.exists():

--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -666,6 +666,10 @@ class ArchConfigHandler:
 		sys.exit(1)
 
 	def _write_plugin_to_temp_file(self, plugin_data: str) -> Path:
+		if not plugin_data.strip():
+			error('The downloaded plugin is empty')
+			sys.exit(1)
+
 		tmp_file = tempfile.NamedTemporaryFile(
 			mode='w',
 			suffix='.py',
@@ -673,8 +677,12 @@ class ArchConfigHandler:
 			delete=False,
 		)
 
-		with tmp_file as f:
-			f.write(plugin_data)
+		try:
+			with tmp_file as f:
+				f.write(plugin_data)
+		except OSError as err:
+			error(f'Could not write the downloaded plugin to a temporary file: {err}')
+			sys.exit(1)
 
 		return Path(tmp_file.name)
 

--- a/archinstall/lib/plugins.py
+++ b/archinstall/lib/plugins.py
@@ -1,9 +1,6 @@
-import hashlib
 import importlib.util
 import os
 import sys
-import urllib.parse
-import urllib.request
 from importlib import metadata
 from pathlib import Path
 
@@ -32,23 +29,6 @@ for plugin_definition in metadata.entry_points().select(group='archinstall.plugi
 # plugins in runtime. Useful in profiles_bck and other things.
 def plugin(f, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
 	plugins[f.__name__] = f
-
-
-def _localize_path(path: Path) -> Path:
-	"""
-	Support structures for load_plugin()
-	"""
-	url = urllib.parse.urlparse(str(path))
-
-	if url.scheme and url.scheme in ('https', 'http'):
-		converted_path = Path(f'/tmp/{path.stem}_{hashlib.md5(os.urandom(12)).hexdigest()}.py')
-
-		with open(converted_path, 'w') as temp_file:
-			temp_file.write(urllib.request.urlopen(url.geturl()).read().decode('utf-8'))
-
-		return converted_path
-	else:
-		return path
 
 
 def _import_via_path(path: Path, namespace: str | None = None) -> str:
@@ -82,17 +62,10 @@ def _import_via_path(path: Path, namespace: str | None = None) -> str:
 
 def load_plugin(path: Path) -> None:
 	namespace: str | None = None
-	parsed_url = urllib.parse.urlparse(str(path))
-	info(f'Loading plugin from url {parsed_url}')
+	info(f'Loading plugin from {path}')
 
-	# The Profile was not a direct match on a remote URL
-	if not parsed_url.scheme:
-		# Path was not found in any known examples, check if it's an absolute path
-		if os.path.isfile(path):
-			namespace = _import_via_path(path)
-	elif parsed_url.scheme in ('https', 'http'):
-		localized = _localize_path(path)
-		namespace = _import_via_path(localized)
+	if os.path.isfile(path):
+		namespace = _import_via_path(path)
 
 	if namespace and namespace in sys.modules:
 		# Version dependency via __archinstall__version__ variable (if present) in the plugin

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -50,6 +50,7 @@ def test_default_args(monkeypatch: MonkeyPatch) -> None:
 		offline=False,
 		no_pkg_lookups=False,
 		plugin=None,
+		plugin_url=None,
 		skip_version_check=False,
 		advanced=False,
 	)
@@ -82,6 +83,8 @@ def test_correct_parsing_args(
 			'--no-pkg-lookups',
 			'--plugin',
 			'pytest_plugin.py',
+			'--plugin-url',
+			'https://example.com/plugin.py',
 			'--skip-version-check',
 			'--advanced',
 			'--dry-run',
@@ -106,7 +109,8 @@ def test_correct_parsing_args(
 		debug=True,
 		offline=True,
 		no_pkg_lookups=True,
-		plugin='pytest_plugin.py',
+		plugin=Path('pytest_plugin.py'),
+		plugin_url='https://example.com/plugin.py',
 		skip_version_check=True,
 		advanced=True,
 	)

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -83,8 +83,6 @@ def test_correct_parsing_args(
 			'--no-pkg-lookups',
 			'--plugin',
 			'pytest_plugin.py',
-			'--plugin-url',
-			'https://example.com/plugin.py',
 			'--skip-version-check',
 			'--advanced',
 			'--dry-run',
@@ -110,7 +108,7 @@ def test_correct_parsing_args(
 		offline=True,
 		no_pkg_lookups=True,
 		plugin=Path('pytest_plugin.py'),
-		plugin_url='https://example.com/plugin.py',
+		plugin_url=None,
 		skip_version_check=True,
 		advanced=True,
 	)


### PR DESCRIPTION
- This fix issue: #3021 

## PR Description:

Changes in archinstall/lib/args.py:

- Arguments: added plugin_url: str | None and changed plugin to Path | None for consistency with creds.
- CLI: --plugin now uses type=Path (was str); added a new --plugin-url option to specify a remote plugin location.
- _parse_args: if --plugin is set, loads the plugin from the local path as before. If --plugin-url is set instead, the content is downloaded via the existing _fetch_from_url helper and written to a local temp file via a new _write_plugin_to_temp_file helper, then that local path is passed to load_plugin.

Changes in archinstall/lib/plugins.py:

- Removed _localize_path and the URL-handling branch in load_plugin and now-unused imports (hashlib, urllib.parse, urllib.request).

## Tests and Checks
- [x ] I have tested the code!
