### PR TITLE
fix ValueError exception when no disks are detected in the disk menu

### DIFF
--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -314,7 +314,7 @@ async def select_devices(preset: list[BDevice] | None = []) -> list[BDevice] | N
 	if len(devices) < 1:
 		await Notify(tr("No disks were detected. A disk is required to be able to install Arch Linux")).show()
 		return None
-	
+
 	items = [
 		MenuItem(
 			str(d.device_info.path),

--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -311,6 +311,10 @@ async def select_devices(preset: list[BDevice] | None = []) -> list[BDevice] | N
 
 	devices = device_handler.devices
 
+	if len(devices) < 1:
+		await Notify(tr("No disks were detected. A disk is required to be able to install Arch Linux")).show()
+		return None
+	
 	items = [
 		MenuItem(
 			str(d.device_info.path),

--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -312,7 +312,7 @@ async def select_devices(preset: list[BDevice] | None = []) -> list[BDevice] | N
 	devices = device_handler.devices
 
 	if len(devices) < 1:
-		await Notify(tr("No disks were detected. A disk is required to be able to install Arch Linux")).show()
+		await Notify(tr('No disks were detected. A disk is required to be able to install Arch Linux')).show()
 		return None
 
 	items = [


### PR DESCRIPTION
so in lib/disk/disk_menu.py, the menu items are created using info from a list called "devices" (device_handler.devices). when no block devices are detected, the list is empty. right now, theres no empty list detection so it goes ahead and creates zero MenuItems, and causes this ValueError from tui:

ValueError: Menu must have at least one item

i added a check to see if the length of the list is shorter than 1 (empty list) before constructing the menu. if the list is empty, the user will be notified that no disks were detected. otherwise, the menu is created and behaves as normal