### PR TITLE
Warn before enabling Plymouth in the bootloader menu

### DIFF
--- a/archinstall/lib/bootloader/bootloader_menu.py
+++ b/archinstall/lib/bootloader/bootloader_menu.py
@@ -130,6 +130,34 @@ class BootloaderMenu(AbstractSubMenu[BootloaderConfiguration]):
 		return bootloader
 
 	async def _select_plymouth(self, preset: PlymouthTheme | None) -> PlymouthTheme | None:
+		# Plymouth is purely cosmetic and a frequent source of boot breakage
+		# (notably with the NVIDIA driver and disk encryption), so confirm before
+		# enabling it. When it is already enabled the user is only changing the
+		# theme, so the warning is skipped.
+		if preset is None:
+			prompt = (
+				'[ansi_bright_yellow]'
+				+ tr('Plymouth adds a cosmetic boot splash but can cause boot problems on some setups:')
+				+ '\n\n  • '
+				+ tr('black screen with the NVIDIA driver')
+				+ '\n  • '
+				+ tr('hidden password prompt with disk encryption (LUKS)')
+				+ '\n\n'
+				+ tr('Would you like to enable it?')
+				+ '[/]\n'
+			)
+
+			result = await Confirmation(header=prompt, allow_skip=True, preset=False).show()
+
+			match result.type_:
+				case ResultType.Skip:
+					return preset
+				case ResultType.Selection:
+					if not result.get_value():
+						return preset
+				case ResultType.Reset:
+					raise ValueError('Unhandled result type')
+
 		return await select_plymouth_theme(preset)
 
 	async def _select_uki(self, preset: bool) -> bool:

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -218,6 +218,20 @@ msgstr ""
 msgid "Will install to custom location with NVRAM entry"
 msgstr ""
 
+msgid ""
+"Plymouth adds a cosmetic boot splash but can cause boot problems on some "
+"setups:"
+msgstr ""
+
+msgid "black screen with the NVIDIA driver"
+msgstr ""
+
+msgid "hidden password prompt with disk encryption (LUKS)"
+msgstr ""
+
+msgid "Would you like to enable it?"
+msgstr ""
+
 msgid "Would you like to use unified kernel images?"
 msgstr ""
 


### PR DESCRIPTION
When enabling Plymouth in the bootloader menu, show a yellow confirmation warning that lists the most common ways it breaks booting, and ask the user to confirm. When Plymouth is already enabled the user is only switching the theme, so the warning is skipped in that case.

The warning text:

> Plymouth adds a cosmetic boot splash but can cause boot problems on some setups:
>
>   - black screen with the NVIDIA driver
>   - hidden password prompt with disk encryption (LUKS)
>
> Would you like to enable it?

## Why

Plymouth is purely cosmetic but is a frequent source of "system does not boot" reports, most notably a black screen with the NVIDIA driver and a hidden LUKS passphrase prompt (you cannot tell the system is waiting for your password). A confirmation step makes the risk visible before the user commits to it, while keeping the feature available for those who want it.

This follows the discussion in #4585, where a warning on selection was preferred over hiding Plymouth behind `--advanced`.

## Notes

- The warning only fires when going from disabled to enabled; theme changes are untouched.
- New strings are added to `base.pot`.

Part of #4585.