### PR TITLE
Fix WiFi SSIDs with spaces missing from scan list

### DIFF
--- a/archinstall/lib/models/network.py
+++ b/archinstall/lib/models/network.py
@@ -178,12 +178,24 @@ class WifiNetwork:
 			if not line:
 				continue
 
-			parts = line.split()
-			if len(parts) != 5:
+			if line.lower().startswith('bssid'):
 				continue
 
-			wifi = cls(bssid=parts[0], frequency=parts[1], signal_level=parts[2], flags=parts[3], ssid=parts[4])
-			entries.append(wifi)
+			parts = line.split(None, 4)
+			if len(parts) < 4:
+				continue
+
+			ssid = parts[4] if len(parts) == 5 else ''
+
+			entries.append(
+				cls(
+					bssid=parts[0],
+					frequency=parts[1],
+					signal_level=parts[2],
+					flags=parts[3],
+					ssid=ssid,
+				)
+			)
 
 		return entries
 

--- a/tests/test_wifi_network_from_wpa.py
+++ b/tests/test_wifi_network_from_wpa.py
@@ -1,0 +1,60 @@
+from archinstall.lib.models.network import WifiNetwork
+
+SAMPLE_SCAN_RESULTS = """bssid / frequency / signal level / flags / ssid
+aa:bb:cc:dd:ee:01	2412	-40	[WPA2-PSK-CCMP][ESS]	NoSpacesSSID
+aa:bb:cc:dd:ee:02	2412	-50	[WPA2-PSK-CCMP][ESS]	My Home Network
+aa:bb:cc:dd:ee:03	5180	-60	[WPA2-PSK-CCMP][WPS][ESS]	Free Public WiFi
+aa:bb:cc:dd:ee:04	2412	-70	[WPA2-PSK-CCMP][ESS]
+"""
+
+
+def test_from_wpa_ssid_without_spaces() -> None:
+	networks = WifiNetwork.from_wpa(SAMPLE_SCAN_RESULTS)
+	ssids = [network.ssid for network in networks]
+
+	assert 'NoSpacesSSID' in ssids
+
+
+def test_from_wpa_ssid_with_spaces() -> None:
+	networks = WifiNetwork.from_wpa(SAMPLE_SCAN_RESULTS)
+	ssids = [network.ssid for network in networks]
+
+	assert 'My Home Network' in ssids
+
+
+def test_from_wpa_ssid_with_multiple_spaces() -> None:
+	networks = WifiNetwork.from_wpa(SAMPLE_SCAN_RESULTS)
+	ssids = [network.ssid for network in networks]
+
+	assert 'Free Public WiFi' in ssids
+
+
+def test_from_wpa_empty_ssid() -> None:
+	networks = WifiNetwork.from_wpa(SAMPLE_SCAN_RESULTS)
+	empty = [network for network in networks if network.bssid == 'aa:bb:cc:dd:ee:04']
+
+	assert len(empty) == 1
+	assert empty[0].ssid == ''
+
+
+def test_from_wpa_skips_header_and_blank_lines() -> None:
+	results = """
+bssid / frequency / signal level / flags / ssid
+
+aa:bb:cc:dd:ee:01	2412	-40	[WPA2-PSK-CCMP][ESS]	SimpleNet
+"""
+	networks = WifiNetwork.from_wpa(results)
+
+	assert len(networks) == 1
+	assert networks[0].ssid == 'SimpleNet'
+	assert networks[0].bssid == 'aa:bb:cc:dd:ee:01'
+
+
+def test_from_wpa_preserves_flags_and_fields() -> None:
+	networks = WifiNetwork.from_wpa(SAMPLE_SCAN_RESULTS)
+	network = next(n for n in networks if n.ssid == 'My Home Network')
+
+	assert network.bssid == 'aa:bb:cc:dd:ee:02'
+	assert network.frequency == '2412'
+	assert network.signal_level == '-50'
+	assert network.flags == '[WPA2-PSK-CCMP][ESS]'


### PR DESCRIPTION
- This fixes issue: #4632

## PR Description:

`WifiNetwork.from_wpa` used `line.split()` and required exactly 5 fields. SSIDs with spaces produced more tokens and were dropped silently, so they never appeared in the TUI list.

- Parse with `split(None, 4)` so the SSID is the remainder (spaces preserved)
- Skip the header row explicitly
- Allow empty SSID (hidden networks)

Unit tests cover SSIDs with and without spaces, empty SSID, header/blank line skip, and field preservation.

## Tests and Checks
- [x] I have tested the code