### PR TITLE
Support aarch64 for GRUB and Limine EFI installation

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1355,7 +1355,7 @@ class Installer:
 				boot_dir = boot_partition.mountpoint
 
 			add_options = [
-				f'--target={platform.machine()}-efi',
+				f'--target={"arm64" if platform.machine() == "aarch64" else platform.machine()}-efi',
 				f'--efi-directory={efi_partition.mountpoint}',
 				*boot_dir_arg,
 				'--bootloader-id=GRUB',
@@ -1489,15 +1489,19 @@ class Installer:
 
 			efi_dir_path.mkdir(parents=True, exist_ok=True)
 
+			efi_binaries: tuple[str, ...]
+			if platform.machine() == 'aarch64':
+				efi_binaries = ('BOOTAA64.EFI',)
+			else:
+				efi_binaries = ('BOOTIA32.EFI', 'BOOTX64.EFI')
+
 			try:
-				for file in ('BOOTIA32.EFI', 'BOOTX64.EFI'):
+				for file in efi_binaries:
 					(limine_path / file).copy_into(efi_dir_path)
 			except Exception as err:
 				raise DiskError(f'Failed to install Limine in {self.target}{efi_partition.mountpoint}: {err}')
 
-			hook_command = (
-				f'/usr/bin/cp /usr/share/limine/BOOTIA32.EFI {efi_dir_path_target}/ && /usr/bin/cp /usr/share/limine/BOOTX64.EFI {efi_dir_path_target}/'
-			)
+			hook_command = ' && '.join(f'/usr/bin/cp /usr/share/limine/{file} {efi_dir_path_target}/' for file in efi_binaries)
 
 			if not bootloader_removable:
 				# Create EFI boot menu entry for Limine.
@@ -1508,7 +1512,7 @@ class Installer:
 					raise OSError(f'Could not open or read /sys/firmware/efi/fw_platform_size to determine EFI bitness: {err}')
 
 				if efi_bitness == '64':
-					loader_path = '\\EFI\\arch-limine\\BOOTX64.EFI'
+					loader_path = f'\\EFI\\arch-limine\\{"BOOTAA64.EFI" if platform.machine() == "aarch64" else "BOOTX64.EFI"}'
 				elif efi_bitness == '32':
 					loader_path = '\\EFI\\arch-limine\\BOOTIA32.EFI'
 				else:


### PR DESCRIPTION
On aarch64 both the GRUB and Limine installers assume x86 and fail.

GRUB names its EFI target 'arm64', but platform.machine() returns 'aarch64', so passing --target=aarch64-efi is rejected. Map aarch64 to the arm64 target name expected by grub-install.

Limine ships architecture-specific default EFI binaries: BOOTAA64.EFI on aarch64 versus BOOTIA32.EFI and BOOTX64.EFI on x86. Select the correct binaries in the three places that reference them: when copying them into the ESP, when building the pacman hook that refreshes them on update, and when choosing the 64-bit EFI boot menu loader path.

## Tests and Checks
- [X] I have tested the code!<br>
 