### PR TITLE
Updated Hyprland packages list for Desktop profile

### DIFF
--- a/archinstall/default_profiles/desktops/hyprland.py
+++ b/archinstall/default_profiles/desktops/hyprland.py
@@ -24,13 +24,17 @@ class HyprlandProfile(Profile):
 			'kitty',
 			'uwsm',
 			'dolphin',
-			'wofi',
+			'hyprlauncher',
 			'xdg-desktop-portal-hyprland',
 			'qt5-wayland',
 			'qt6-wayland',
-			'polkit-kde-agent',
+			'hyprpolkitagent',
 			'grim',
 			'slurp',
+			'wl-clipboard',
+			'hyprpaper',
+			'waybar',
+			'quickshell',
 		]
 
 	@property


### PR DESCRIPTION
Updated the Hyprland packages for it's Desktop profile.

## PR Description:

Hyprland on first startup now has a "Welcome" screen  ( `hyprland-welcome` ) that mentions these applications are missing and should be installed. 

<img width="998" height="560" alt="screenshot-20260718-162956" src="https://github.com/user-attachments/assets/5d2e1d05-85d7-45bc-b8b0-ffb8d196df2d" />

Replaced 'wofi' with 'hyprlauncher' as is specifically made for Hyprland. Same with hyprpolkitagent.

