### PR TITLE
Return bytes from fetch_data_from_url()

### DIFF
--- a/archinstall/lib/mirror/mirror_handler.py
+++ b/archinstall/lib/mirror/mirror_handler.py
@@ -56,8 +56,8 @@ class MirrorListHandler:
 
 		for attempt_nr in range(attempts):
 			try:
-				mirrorlist = fetch_data_from_url(url)
-				self._status_mappings = self._parse_remote_mirror_list(mirrorlist)
+				data = fetch_data_from_url(url)
+				self._status_mappings = self._parse_remote_mirror_list(data)
 				return True
 			except Exception as e:
 				debug(f'Error while fetching mirror list: {e}')
@@ -85,9 +85,9 @@ class MirrorListHandler:
 		# just return as-is without sorting?
 		return region_list
 
-	def _parse_remote_mirror_list(self, mirrorlist: str) -> dict[str, list[MirrorStatusEntryV3]]:
+	def _parse_remote_mirror_list(self, data: bytes) -> dict[str, list[MirrorStatusEntryV3]]:
 		context = {'verbose': self.verbose}
-		mirror_status = MirrorStatusListV3.model_validate_json(mirrorlist, context=context)
+		mirror_status = MirrorStatusListV3.model_validate_json(data, context=context)
 
 		sorting_placeholder: dict[str, list[MirrorStatusEntryV3]] = {}
 

--- a/archinstall/lib/networking.py
+++ b/archinstall/lib/networking.py
@@ -121,7 +121,7 @@ def enrich_iface_types(interfaces: list[str]) -> dict[str, str]:
 	return result
 
 
-def fetch_data_from_url(url: str, params: dict[str, str] | None = None, timeout: int = 30) -> str:
+def fetch_data_from_url(url: str, params: dict[str, str] | None = None, timeout: int = 30) -> bytes:
 	ssl_context = ssl.create_default_context()
 	ssl_context.check_hostname = False
 	ssl_context.verify_mode = ssl.CERT_NONE
@@ -134,8 +134,7 @@ def fetch_data_from_url(url: str, params: dict[str, str] | None = None, timeout:
 
 	try:
 		response = urlopen(full_url, context=ssl_context, timeout=timeout)
-		data = response.read().decode('UTF-8')
-		return data
+		return response.read()
 	except URLError as e:
 		raise ValueError(f'Unable to fetch data from url: {url}\n{e}')
 	except Exception as e:

--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -262,10 +262,8 @@ class ProfileHandler:
 			err = tr('Unable to fetch profile from specified url: {}').format(url)
 			error(err)
 		else:
-			b_data = bytes(data, 'utf-8')
-
 			with NamedTemporaryFile(delete=False, suffix='.py') as fp:
-				fp.write(b_data)
+				fp.write(data)
 				filepath = Path(fp.name)
 
 			profiles = self._process_profile_file(filepath)


### PR DESCRIPTION
`model_validate_json` can handle bytes.

https://pydantic.dev/docs/validation/latest/api/pydantic/base_model/#pydantic.BaseModel.model_validate_json

Imported profiles were decoded from bytes to be encoded back into bytes before the write as well.