### PR TITLE
Enable non-empty-init-module ruff rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,6 @@ ignore = [
     "RUF005",   # collection-literal-concatenation
     "RUF015",   # unnecessary-iterable-allocation-for-first-element
     "RUF039",   # unraw-re-pattern
-    "RUF067",   # non-empty-init-module
     "W191",     # tab-indentation
 ]
 


### PR DESCRIPTION
Ignoring this rule has not been needed since ba7dbea.

https://docs.astral.sh/ruff/rules/non-empty-init-module/
