### PR TITLE
Enable flake8-gettext checks in ruff

### DIFF
--- a/archinstall/locales/locales_generator.sh
+++ b/archinstall/locales/locales_generator.sh
@@ -67,19 +67,9 @@ cmd_check_po_syntax() {
 	echo "All .po files passed syntax check."
 }
 
-cmd_check_no_tr_fstring() {
-	echo "Checking for tr(f-string) anti-pattern..."
-	if grep -rnE "tr\(\s*f['\"]" . --include='*.py'; then
-		echo "ERROR: use tr('...{}').format(...) instead of tr(f'...')" >&2
-		return 1
-	fi
-	echo "No tr(f-string) anti-pattern found."
-}
-
 cmd_check() {
 	local failed=0
 	cmd_check_po_syntax || failed=1
-	cmd_check_no_tr_fstring || failed=1
 	if [ "$failed" -eq 1 ]; then
 		echo "Some translation checks failed." >&2
 		exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,9 +202,6 @@ indent-style = "tab"
 quote-style = "single"
 docstring-code-format = true
 
-[tool.ruff.lint.flake8-tidy-imports]
-ban-relative-imports = "all"
-
 [tool.ruff.lint]
 select = [
     "ASYNC",  # flake8-async
@@ -220,6 +217,7 @@ select = [
     "G",      # flake8-logging-format
     "I",      # isort
     "ICN",    # flake8-import-conventions
+    "INT",    # flake8-gettext
     "ISC",    # flake8-implicit-str-concat
     "LOG",    # flake8-logging
     "PGH",    # pygrep-hooks
@@ -232,10 +230,10 @@ select = [
     "RUF",    # Ruff-specific rules
     "SLOT",   # flake8-slot
     "T10",    # flake8-debugger
+    "TID",    # flake8-tidy-imports (Enables TID252)
     "UP",     # pyupgrade
     "W",      # pycodestyle warnings
     "YTT",    # flake8-2020
-    "TID",    # flake8-tidy-imports (Enables TID252)
 ]
 
 ignore = [
@@ -255,6 +253,15 @@ ignore = [
     "RUF039",   # unraw-re-pattern
     "W191",     # tab-indentation
 ]
+
+[tool.ruff.lint.flake8-gettext]
+function-names = [
+    "tr",
+    "tr_noop",
+]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
 
 [tool.ruff.lint.mccabe]
 max-complexity = 40


### PR DESCRIPTION
## PR Description:

This will help catch incorrect translation placeholders, like those fixed in commit dccd0c8cc.

This commit also removes custom checking code from the `locales_generator.sh` script.

cc: @Softer 