### PR TITLE
fix: add ufw SSH allow rule when sshd is enabled

### DIFF
--- a/archinstall/applications/firewall.py
+++ b/archinstall/applications/firewall.py
@@ -46,6 +46,11 @@ class FirewallApp:
 				# write default conf file to enabled
 				ufw_conf = install_session.target / 'etc/ufw/ufw.conf'
 				ufw_conf.write_text(ufw_conf.read_text().replace('ENABLED=no', 'ENABLED=yes'))
+				# if sshd is enabled, allow SSH through ufw to prevent lockout
+				sshd_symlink = install_session.target / 'etc/systemd/system/multi-user.target.wants/sshd.service'
+				if sshd_symlink.exists():
+					debug('sshd detected, adding ufw allow rule for SSH')
+					install_session.arch_chroot('ufw allow SSH')
 
 			case Firewall.FWD:
 				install_session.add_additional_packages(self.fwd_packages)


### PR DESCRIPTION
When UFW firewall is selected alongside sshd during installation, UFW would block SSH connections on first boot, locking users out of their system.

Check if sshd.service is enabled in the target system by checking the systemd symlink, and if so, run 'ufw allow SSH' inside the chroot to ensure SSH access is not blocked.

Fixes #4616

- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:
When a user selects both UFW firewall and sshd during archinstall, UFW is enabled but no SSH allow rule is added. This means on first boot, all SSH connections are blocked by UFW, completely locking the user out of a remote system with no recovery path short of physical access.

Fix:

After enabling and configuring UFW, check if sshd.service is enabled in the target system by looking for its systemd symlink at etc/systemd/system/multi-user.target.wants/sshd.service. If found, run ufw allow SSH inside the chroot before installation completes.

This ensures SSH access is preserved when both sshd and UFW are selected together, which is the expected behavior for any server installation.

Why this approach:

The installer has no central registry of enabled services, so checking the systemd symlink is the most reliable way to detect whether sshd was enabled during the current install session without requiring refactoring of the service tracking logic.
