### PR TITLE
feat: add LUKS cipher selection to disk encryption menu

### DIFF
--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -7,6 +7,7 @@ from archinstall.lib.menu.helpers import Input, Selection, Table
 from archinstall.lib.menu.menu_helper import MenuHelper
 from archinstall.lib.menu.util import get_password
 from archinstall.lib.models.device import (
+	DEFAULT_CIPHER,
 	DEFAULT_ITER_TIME,
 	DeviceModification,
 	DiskEncryption,
@@ -73,6 +74,14 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				key='iter_time',
 			),
 			MenuItem(
+				text=tr('Encryption cipher'),
+				action=select_cipher,
+				value=self._enc_config.cipher,
+				dependencies=[self._check_dep_enc_type],
+				preview_action=self._prev_cipher,
+				key='cipher',
+			),
+			MenuItem(
 				text=tr('Partitions'),
 				action=lambda x: select_partitions_to_encrypt(self._device_modifications, x),
 				value=self._enc_config.partitions,
@@ -130,6 +139,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		enc_type: EncryptionType | None = self._item_group.find_by_key('encryption_type').value
 		enc_password: Password | None = self._item_group.find_by_key('encryption_password').value
 		iter_time: int | None = self._item_group.find_by_key('iter_time').value
+		cipher: str | None = self._item_group.find_by_key('cipher').value
 		enc_partitions = self._item_group.find_by_key('partitions').value
 		enc_lvm_vols = self._item_group.find_by_key('lvm_volumes').value
 
@@ -151,6 +161,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				lvm_volumes=enc_lvm_vols,
 				hsm_device=enc_config.hsm_device,
 				iter_time=iter_time or DEFAULT_ITER_TIME,
+				cipher=cipher or DEFAULT_CIPHER,
 			)
 
 		return None
@@ -221,6 +232,11 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		output = str(fido_device.path)
 		output += f' ({fido_device.manufacturer}, {fido_device.product})'
 		return f'{tr("HSM device")}: {output}'
+
+	def _prev_cipher(self, item: MenuItem) -> str | None:
+		if item.value:
+			return f'{tr("Encryption cipher")}: {item.value}'
+		return None
 
 	def _prev_iter_time(self, item: MenuItem) -> str | None:
 		if item.value:
@@ -370,6 +386,44 @@ async def select_lvm_vols_to_encrypt(
 				return volumes
 
 	return []
+
+
+async def select_cipher(preset: str | None = None) -> str | None:
+	ciphers = [
+		'aes-xts-plain64',
+		'chacha20-plain64',
+		'serpent-xts-plain64',
+		'twofish-xts-plain64',
+	]
+
+	descriptions = {
+		'aes-xts-plain64':      tr('AES (default, hardware accelerated on most CPUs)'),
+		'chacha20-plain64':     tr('ChaCha20 (faster on CPUs without AES-NI)'),
+		'serpent-xts-plain64':  tr('Serpent (conservative security, slower)'),
+		'twofish-xts-plain64':  tr('Twofish (conservative security, slower)'),
+	}
+
+	if not preset:
+		preset = ciphers[0]
+
+	items = [MenuItem(f'{c}  —  {descriptions[c]}', value=c) for c in ciphers]
+	group = MenuItemGroup(items)
+	group.set_focus_by_value(preset)
+
+	result = await Selection[str](
+		group,
+		header=tr('Select encryption cipher'),
+		allow_skip=True,
+		allow_reset=True,
+	).show()
+
+	match result.type_:
+		case ResultType.Reset:
+			return None
+		case ResultType.Skip:
+			return preset
+		case ResultType.Selection:
+			return result.get_value()
 
 
 async def select_iteration_time(preset: int | None = None) -> int | None:

--- a/archinstall/lib/disk/luks.py
+++ b/archinstall/lib/disk/luks.py
@@ -8,7 +8,7 @@ from archinstall.lib.command import SysCommand, SysCommandWorker, run
 from archinstall.lib.disk.utils import get_lsblk_info, umount
 from archinstall.lib.exceptions import DiskError, SysCallError
 from archinstall.lib.log import debug, info
-from archinstall.lib.models.device import DEFAULT_ITER_TIME
+from archinstall.lib.models.device import DEFAULT_CIPHER, DEFAULT_ITER_TIME
 from archinstall.lib.models.users import Password
 from archinstall.lib.utils.util import generate_password
 
@@ -72,6 +72,7 @@ class Luks2:
 		key_size: int = 512,
 		hash_type: str = 'sha512',
 		iter_time: int = DEFAULT_ITER_TIME,
+		cipher: str = DEFAULT_CIPHER,
 		key_file: Path | None = None,
 	) -> Path | None:
 		debug(f'Luks2 encrypting: {self.luks_dev_path}')
@@ -86,6 +87,8 @@ class Luks2:
 			'luks2',
 			'--pbkdf',
 			'argon2id',
+			'--cipher',
+			cipher,
 			'--hash',
 			hash_type,
 			'--key-size',

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -19,6 +19,7 @@ from archinstall.lib.translationhandler import tr
 
 ENC_IDENTIFIER = 'ainst'
 DEFAULT_ITER_TIME = 10000
+DEFAULT_CIPHER = 'aes-xts-plain64'
 
 
 class DiskLayoutType(Enum):
@@ -1468,6 +1469,7 @@ class _DiskEncryptionSerialization(TypedDict):
 	lvm_volumes: list[str]
 	hsm_device: NotRequired[_Fido2DeviceSerialization]
 	iter_time: NotRequired[int]
+	cipher: NotRequired[str]
 
 
 @dataclass
@@ -1478,6 +1480,7 @@ class DiskEncryption:
 	lvm_volumes: list[LvmVolume] = field(default_factory=list)
 	hsm_device: Fido2Device | None = None
 	iter_time: int = DEFAULT_ITER_TIME
+	cipher: str = DEFAULT_CIPHER
 
 	def __post_init__(self) -> None:
 		if self.encryption_type in [EncryptionType.LUKS, EncryptionType.LVM_ON_LUKS] and not self.partitions:
@@ -1504,6 +1507,8 @@ class DiskEncryption:
 
 		if self.iter_time != DEFAULT_ITER_TIME:  # Only include if not default
 			obj['iter_time'] = self.iter_time
+		if self.cipher != DEFAULT_CIPHER:  # Only include if not default
+			obj['cipher'] = self.cipher
 
 		return obj
 
@@ -1561,6 +1566,8 @@ class DiskEncryption:
 
 		if iter_time := disk_encryption.get('iter_time', None):
 			enc.iter_time = iter_time
+		if cipher := disk_encryption.get('cipher', None):
+			enc.cipher = cipher
 
 		return enc
 


### PR DESCRIPTION
Allow users to select the encryption cipher when setting up LUKS disk encryption. Previously the cipher was hardcoded to aes-xts-plain64.

Changes:
- Add DEFAULT_CIPHER constant to device.py
- Add cipher field to DiskEncryption dataclass with serialization support
- Add --cipher flag to cryptsetup command in luks.py encrypt()
- Add cipher selection menu item to DiskEncryptionMenu
- Add select_cipher() function with four cipher options:
  * aes-xts-plain64 (default, hardware accelerated)
  * chacha20-plain64 (faster on CPUs without AES-NI)
  * serpent-xts-plain64 (conservative security)
  * twofish-xts-plain64 (conservative security)

Closes #4521

- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

This PR implements cipher selection for LUKS disk encryption, addressing #4521.

Previously the encryption cipher was hardcoded to aes-xts-plain64 with no way for users to change it. This adds a new Encryption cipher menu item to the disk encryption configuration screen with four options:

aes-xts-plain64 ,default, hardware accelerated on most modern CPUs via AES-NI
chacha20-plain64 ,better performance on CPUs without AES-NI (older hardware, some ARM boards)
serpent-xts-plain64 , conservative security choice, slower
twofish-xts-plain64 , conservative security choice, slower

The cipher is passed to cryptsetup luksFormat via the --cipher flag. It defaults to aes-xts-plain64 so existing behavior is unchanged for users who don't select a different cipher.
## Tests and Checks
- I have tested the code!
