### PR TITLE
Refactor run_custom_user_commands

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -2131,13 +2131,12 @@ def accessibility_tools_in_use() -> bool:
 
 def run_custom_user_commands(commands: list[str], installation: Installer) -> None:
 	for index, command in enumerate(commands):
-		script_path = f'/var/tmp/user-command.{index}.sh'
-		chroot_path = f'{installation.target}/{script_path}'
+		script_path = LPath(f'/var/tmp/user-command.{index}.sh')
+		chroot_path = installation.target / script_path.relative_to_root()
 
 		info(f'Executing custom command "{command}" ...')
-		with open(chroot_path, 'w') as user_script:
-			user_script.write(command)
+		chroot_path.write_text(command)
 
 		SysCommand(f'arch-chroot -S {installation.target} bash {script_path}')
 
-		os.unlink(chroot_path)
+		chroot_path.unlink()


### PR DESCRIPTION
With #2026, the issue was misdiagnosed.

On the `pathlib` slash operator:

> If the argument is an absolute path, the previous path is ignored.

Source: https://docs.python.org/3/library/pathlib.html#operators

Example of the problem, `script_path` as an absolute path:

```python
>>> from pathlib import Path
>>> target = Path('/mnt')
>>> script_path = '/var/tmp/user-command.sh'
>>> target / script_path
PosixPath('/var/tmp/user-command.sh')
```

This fails to produce the intended `/mnt/var/tmp/user-command.sh`.

`script_path` as a relative path (without the `/` prefix):

```python
>>> from pathlib import Path
>>> target = Path('/mnt')
>>> script_path = 'var/tmp/user-command.sh'
>>> target / script_path
PosixPath('/mnt/var/tmp/user-command.sh')
```
