### PR TITLE
fix(applications): add ghostscript to print service packages

### DIFF
--- a/archinstall/applications/print_service.py
+++ b/archinstall/applications/print_service.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 class PrintServiceApp:
 	@property
 	def packages(self) -> list[str]:
-		return ['cups', 'system-config-printer', 'cups-pk-helper']
+		return ['cups', 'system-config-printer', 'cups-pk-helper', 'ghostscript']
 
 	@property
 	def services(self) -> list[str]:

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -1,0 +1,7 @@
+from archinstall.applications.print_service import PrintServiceApp
+
+
+def test_print_service_includes_ghostscript() -> None:
+	# cups only ships the PDF/PostScript rendering filter through ghostscript,
+	# so driverless (IPP Everywhere) printing fails without it.
+	assert 'ghostscript' in PrintServiceApp().packages

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -1,7 +1,0 @@
-from archinstall.applications.print_service import PrintServiceApp
-
-
-def test_print_service_includes_ghostscript() -> None:
-	# cups only ships the PDF/PostScript rendering filter through ghostscript,
-	# so driverless (IPP Everywhere) printing fails without it.
-	assert 'ghostscript' in PrintServiceApp().packages


### PR DESCRIPTION
Closes #4595

Selecting the print service installs `cups`, `system-config-printer` and `cups-pk-helper`, but not `ghostscript`. cups needs ghostscript for the PDF/PostScript rendering filter, so driverless (IPP Everywhere) jobs fail out of the box with `cfFilterGhostscript: Unable to launch Ghostscript: gs: No such file or directory`.

Adds `ghostscript` to `PrintServiceApp.packages` plus a regression test (fails without the change, passes with it).
