### PR TITLE
Remove reintroduced __future__ import

### DIFF
--- a/archinstall/tui/menu_item.py
+++ b/archinstall/tui/menu_item.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from enum import Enum, StrEnum, auto


### PR DESCRIPTION
These have been removed from all files in the repo, so this was reintroduced.

It seems that this is the result of generated code.
