### PR TITLE
Refactor default PartitionTable

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -17,6 +17,7 @@ from archinstall.lib.disk.utils import (
 	umount,
 )
 from archinstall.lib.exceptions import DiskError, SysCallError, UnknownFilesystemFormat
+from archinstall.lib.hardware import SysInfo
 from archinstall.lib.log import debug, error, info, log
 from archinstall.lib.models.device import (
 	DEFAULT_ITER_TIME,
@@ -45,7 +46,7 @@ class DeviceHandler:
 
 	def __init__(self) -> None:
 		self._devices: dict[Path, BDevice] = {}
-		self._partition_table = PartitionTable.default()
+		self._partition_table = PartitionTable.GPT if SysInfo.has_uefi() else PartitionTable.MBR
 		self.load_devices()
 
 	@property

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -11,7 +11,6 @@ import parted
 from parted import Disk, Geometry, Partition
 from pydantic import BaseModel, Field, ValidationInfo, field_serializer, field_validator
 
-from archinstall.lib.hardware import SysInfo
 from archinstall.lib.log import debug
 from archinstall.lib.models.config import SubConfig
 from archinstall.lib.models.users import Password
@@ -256,10 +255,6 @@ class PartitionTable(Enum):
 
 	def is_mbr(self) -> bool:
 		return self == PartitionTable.MBR
-
-	@classmethod
-	def default(cls) -> Self:
-		return cls.GPT if SysInfo.has_uefi() else cls.MBR
 
 
 class Units(Enum):


### PR DESCRIPTION
Addresses the following:

pyright

```
  archinstall/lib/models/device.py:262:10 - error: Type "Literal[PartitionTable.GPT, PartitionTable.MBR]" is not assignable to return type "Self@PartitionTable"
    Type "Literal[PartitionTable.GPT, PartitionTable.MBR]" is not assignable to type "Self@PartitionTable" (reportReturnType)
```

ty

```
error[invalid-return-type]: Return type does not match returned value
   --> archinstall/lib/models/device.py:261:22
    |
261 |     def default(cls) -> Self:
    |                         ---- Expected `Self@default` because of return type
262 |         return cls.GPT if SysInfo.has_uefi() else cls.MBR
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Self@default`, found `PartitionTable`
    |
```
