### PR TITLE
Use staticmethod for Bootloader.get_default

### DIFF
--- a/archinstall/lib/models/bootloader.py
+++ b/archinstall/lib/models/bootloader.py
@@ -36,14 +36,14 @@ class Bootloader(Enum):
 	def json(self) -> str:
 		return self.value
 
-	@classmethod
-	def get_default(cls, uefi: bool, skip_boot: bool = False) -> Self:
+	@staticmethod
+	def get_default(uefi: bool, skip_boot: bool = False) -> Bootloader:
 		if skip_boot:
-			return cls.NO_BOOTLOADER
+			return Bootloader.NO_BOOTLOADER
 		elif uefi:
-			return cls.Systemd
+			return Bootloader.Systemd
 		else:
-			return cls.Grub
+			return Bootloader.Grub
 
 	@classmethod
 	def from_arg(cls, bootloader: str, skip_boot: bool) -> Self:


### PR DESCRIPTION
Addresses the following:

pyright

```
  archinstall/lib/models/bootloader.py:42:11 - error: Type "Literal[Bootloader.NO_BOOTLOADER]" is not assignable to return type "Self@Bootloader"
    Type "Literal[Bootloader.NO_BOOTLOADER]" is not assignable to type "Self@Bootloader" (reportReturnType)
  archinstall/lib/models/bootloader.py:44:11 - error: Type "Literal[Bootloader.Systemd]" is not assignable to return type "Self@Bootloader"
    Type "Literal[Bootloader.Systemd]" is not assignable to type "Self@Bootloader" (reportReturnType)
  archinstall/lib/models/bootloader.py:46:11 - error: Type "Literal[Bootloader.Grub]" is not assignable to return type "Self@Bootloader"
    Type "Literal[Bootloader.Grub]" is not assignable to type "Self@Bootloader" (reportReturnType)
```

pyrefly

```
ERROR Returned type `Literal[Bootloader.NO_BOOTLOADER]` is not assignable to declared return type `Self@Bootloader` [bad-return]
  --> archinstall/lib/models/bootloader.py:42:11
   |
40 |     def get_default(cls, uefi: bool, skip_boot: bool = False) -> Self:
   |                                                                  ---- declared return type
41 |         if skip_boot:
42 |             return cls.NO_BOOTLOADER
   |                    ^^^^^^^^^^^^^^^^^
   |
ERROR Returned type `Literal[Bootloader.Systemd]` is not assignable to declared return type `Self@Bootloader` [bad-return]
  --> archinstall/lib/models/bootloader.py:44:11
   |
40 |     def get_default(cls, uefi: bool, skip_boot: bool = False) -> Self:
   |                                                                  ---- declared return type
41 |         if skip_boot:
42 |             return cls.NO_BOOTLOADER
43 |         elif uefi:
44 |             return cls.Systemd
   |                    ^^^^^^^^^^^
   |
ERROR Returned type `Literal[Bootloader.Grub]` is not assignable to declared return type `Self@Bootloader`
[bad-return]
  --> archinstall/lib/models/bootloader.py:46:11
   |
40 |     def get_default(cls, uefi: bool, skip_boot: bool = False) -> Self:
   |                                                                  ---- declared return type
41 |         if skip_boot:
42 |             return cls.NO_BOOTLOADER
43 |         elif uefi:
44 |             return cls.Systemd
45 |         else:
46 |             return cls.Grub
   |                    ^^^^^^^^
   |
```

ty

```
error[invalid-return-type]: Return type does not match returned value
  --> archinstall/lib/models/bootloader.py:40:63
   |
40 |     def get_default(cls, uefi: bool, skip_boot: bool = False) -> Self:
   |                                                                  ---- Expected `Self@get_default` because of return type
41 |         if skip_boot:
42 |             return cls.NO_BOOTLOADER
   |                    ^^^^^^^^^^^^^^^^^ expected `Self@get_default`, found `Literal[Bootloader.NO_BOOTLOADER]`
   |

error[invalid-return-type]: Return type does not match returned value
  --> archinstall/lib/models/bootloader.py:40:63
   |
40 |     def get_default(cls, uefi: bool, skip_boot: bool = False) -> Self:
   |                                                                  ---- Expected `Self@get_default` because of return type
41 |         if skip_boot:
42 |             return cls.NO_BOOTLOADER
43 |         elif uefi:
44 |             return cls.Systemd
   |                    ^^^^^^^^^^^ expected `Self@get_default`, found `Literal[Bootloader.Systemd]`
   |

error[invalid-return-type]: Return type does not match returned value
  --> archinstall/lib/models/bootloader.py:46:11
   |
46 |             return cls.Grub
   |                    ^^^^^^^^ expected `Self@get_default`, found `Literal[Bootloader.Grub]`
   |
  ::: archinstall/lib/models/bootloader.py:40:63
   |
40 |     def get_default(cls, uefi: bool, skip_boot: bool = False) -> Self:
   |                                                                  ---- Expected `Self@get_default` because of return type
   |
```
