### PR TITLE
Use staticmethod for get_type_from_code

### DIFF
--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -753,13 +753,13 @@ class PartitionType(StrEnum):
 	PRIMARY = auto()
 	_UNKNOWN = 'unknown'
 
-	@classmethod
-	def get_type_from_code(cls, code: int) -> Self:
+	@staticmethod
+	def get_type_from_code(code: int) -> PartitionType:
 		if code == parted.PARTITION_NORMAL:
-			return cls.PRIMARY
+			return PartitionType.PRIMARY
 		else:
 			debug(f'Partition code not supported: {code}')
-			return cls._UNKNOWN
+			return PartitionType._UNKNOWN
 
 	def get_partition_code(self) -> int | None:
 		if self == PartitionType.PRIMARY:


### PR DESCRIPTION
Addresses the following:

pyright

```
  archinstall/lib/models/device.py:759:11 - error: Type "Literal[PartitionType.PRIMARY]" is not assignable to return type "Self@PartitionType"
    Type "Literal[PartitionType.PRIMARY]" is not assignable to type "Self@PartitionType" (reportReturnType)
  archinstall/lib/models/device.py:762:11 - error: Type "Literal[PartitionType._UNKNOWN]" is not assignable to return type "Self@PartitionType"
    Type "Literal[PartitionType._UNKNOWN]" is not assignable to type "Self@PartitionType" (reportReturnType)
```

pyrefly

```
ERROR Returned type `Literal[PartitionType.PRIMARY]` is not assignable to declared return type `Self@PartitionType` [bad-return]
   --> archinstall/lib/models/device.py:759:11
    |
757 |     def get_type_from_code(cls, code: int) -> Self:
    |                                               ---- declared return type
758 |         if code == parted.PARTITION_NORMAL:
759 |             return cls.PRIMARY
    |                    ^^^^^^^^^^^
    |
ERROR Returned type `Literal[PartitionType._UNKNOWN]` is not assignable to declared return type `Self@PartitionType` [bad-return]
   --> archinstall/lib/models/device.py:762:11
    |
757 |     def get_type_from_code(cls, code: int) -> Self:
    |                                               ---- declared return type
758 |         if code == parted.PARTITION_NORMAL:
759 |             return cls.PRIMARY
760 |         else:
761 |             debug(f'Partition code not supported: {code}')
762 |             return cls._UNKNOWN
    |                    ^^^^^^^^^^^^
    |
```

ty

```
error[invalid-return-type]: Return type does not match returned value
   --> archinstall/lib/models/device.py:757:44
    |
757 |     def get_type_from_code(cls, code: int) -> Self:
    |                                               ---- Expected `Self@get_type_from_code` because of return type
758 |         if code == parted.PARTITION_NORMAL:
759 |             return cls.PRIMARY
    |                    ^^^^^^^^^^^ expected `Self@get_type_from_code`, found `Literal[PartitionType.PRIMARY]`
    |

error[invalid-return-type]: Return type does not match returned value
   --> archinstall/lib/models/device.py:757:44
    |
757 |     def get_type_from_code(cls, code: int) -> Self:
    |                                               ---- Expected `Self@get_type_from_code` because of return type
758 |         if code == parted.PARTITION_NORMAL:
759 |             return cls.PRIMARY
760 |         else:
761 |             debug(f'Partition code not supported: {code}')
762 |             return cls._UNKNOWN
    |                    ^^^^^^^^^^^^ expected `Self@get_type_from_code`, found `Literal[PartitionType._UNKNOWN]`
    |
```
