### PR TITLE
fix: Stop hardcoding dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-    "pyparted==3.13.0",
-    "pydantic==2.13.4",
-    "cryptography==50.0.0",
-    "textual==8.2.8",
-    "markdown-it-py==4.2.0",
-    "linkify-it-py==2.1.0",
+    "pyparted>=3.13.0",
+    "pydantic>=2.13.4",
+    "cryptography>=50.0.0",
+    "textual>=8.2.8",
+    "markdown-it-py>=4.2.0",
+    "linkify-it-py>=2.1.0",
 ]
 
 [project.urls]
@@ -32,14 +32,14 @@ Documentation = "https://archinstall.readthedocs.io/"
 Source = "https://github.com/archlinux/archinstall"
 
 [project.optional-dependencies]
-log = ["systemd_python==236"]
+log = ["systemd_python>=236"]
 dev = [
-    "mypy==2.3.0",
-    "flake8==7.3.0",
-    "pre-commit==4.6.1",
-    "ruff==0.16.2",
-    "pylint==4.0.7",
-    "pytest==9.1.1",
+    "mypy>=2.3.0",
+    "flake8>=7.3.0",
+    "pre-commit>=4.6.1",
+    "ruff>=0.16.2",
+    "pylint>=4.0.7",
+    "pytest>=9.1.1",
     "hypothesis>=6.152.4",
 ]
 doc = ["sphinx"]

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "description": "Track runtime Python deps via Arch Linux repos instead of PyPI",
       "managerFilePatterns": ["**/pyproject.toml"],
       "matchStrings": [
-        "\"(?<depName>pyparted|pydantic|cryptography|textual|markdown-it-py|linkify-it-py)==(?<currentValue>[^\"]+)\""
+        "\"(?<depName>pyparted|pydantic|cryptography|textual|markdown-it-py|linkify-it-py)>=(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "arch/python-{{{depName}}}",
       "datasourceTemplate": "repology",
@@ -26,7 +26,7 @@
       "description": "Track systemd_python via Arch Linux repos (different package name)",
       "managerFilePatterns": ["**/pyproject.toml"],
       "matchStrings": [
-        "\"systemd_python==(?<currentValue>[^\"]+)\""
+        "\"systemd_python>=(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "arch/python-systemd",
       "datasourceTemplate": "repology",


### PR DESCRIPTION
Fixes #4694

## PR Description:

Stop hardcoding versions of packages and allow new versions too, fixes `pip check` failing.

## Tests and Checks
- [ ] I have tested the code!<br>

