### PR TITLE
Install rtkit when using PulseAudio or PipeWire

### DIFF
--- a/archinstall/applications/audio.py
+++ b/archinstall/applications/audio.py
@@ -72,6 +72,9 @@ class AudioApp:
 		if SysInfo.requires_alsa_fw():
 			install_session.add_additional_packages('alsa-firmware')
 
+		# Common dependency for realtime scheduling support
+		install_session.add_additional_packages('rtkit');
+
 		match audio_config.audio:
 			case Audio.PIPEWIRE:
 				install_session.add_additional_packages(self.pipewire_packages)


### PR DESCRIPTION
## PR Description:

Install `rtkit` whenever either the PulseAudio or PipeWire audio profile is selected.

`rtkit` is optional for both backends, but it enables realtime scheduling through RealtimeKit when available. 

Installing it avoids runtime warnings such as:

```text
pipewire: mod.rt: RTKit error: org.freedesktop.DBus.Error.ServiceUnknown
wireplumber: mod.rt: RTKit error: org.freedesktop.DBus.Error.ServiceUnknown
pipewire-pulse: mod.rt: RTKit error: org.freedesktop.DBus.Error.ServiceUnknown
```

The package is added once in the common audio installation flow, avoiding duplication between the PulseAudio and PipeWire package lists.

## Tests and Checks

- [x] I have tested the code!

Tested in a virtual machine:
`rtkit` is installed correctly, starts on demand as expected, and the RTKit-related errors are no longer present.