### PR TITLE
Fix examples/config-sample.json and cover the example configs with a test

### DIFF
--- a/examples/config-sample.json
+++ b/examples/config-sample.json
@@ -17,12 +17,16 @@
         "partitions": [
           {
             "btrfs": [],
+            "dev_path": null,
             "flags": [
               "boot"
             ],
             "fs_type": "fat32",
             "size": {
-              "sector_size": null,
+              "sector_size": {
+                "unit": "B",
+                "value": 512
+              },
               "unit": "MiB",
               "value": 512
             },
@@ -30,7 +34,10 @@
             "mountpoint": "/boot",
             "obj_id": "2c3fa2d5-2c79-4fab-86ec-22d0ea1543c0",
             "start": {
-              "sector_size": null,
+              "sector_size": {
+                "unit": "B",
+                "value": 512
+              },
               "unit": "MiB",
               "value": 1
             },
@@ -39,10 +46,14 @@
           },
           {
             "btrfs": [],
+            "dev_path": null,
             "flags": [],
             "fs_type": "ext4",
             "size": {
-              "sector_size": null,
+              "sector_size": {
+                "unit": "B",
+                "value": 512
+              },
               "unit": "GiB",
               "value": 20
             },
@@ -50,7 +61,10 @@
             "mountpoint": "/",
             "obj_id": "3e7018a0-363b-4d05-ab83-8e82d13db208",
             "start": {
-              "sector_size": null,
+              "sector_size": {
+                "unit": "B",
+                "value": 512
+              },
               "unit": "MiB",
               "value": 513
             },
@@ -59,20 +73,27 @@
           },
           {
             "btrfs": [],
+            "dev_path": null,
             "flags": [],
             "fs_type": "ext4",
             "size": {
-              "sector_size": null,
-              "unit": "Percent",
-              "value": 100
+              "sector_size": {
+                "unit": "B",
+                "value": 512
+              },
+              "unit": "GiB",
+              "value": 10
             },
             "mount_options": [],
             "mountpoint": "/home",
             "obj_id": "ce58b139-f041-4a06-94da-1f8bad775d3f",
             "start": {
-              "sector_size": null,
-              "unit": "GiB",
-              "value": 20
+              "sector_size": {
+                "unit": "B",
+                "value": 512
+              },
+              "unit": "MiB",
+              "value": 20993
             },
             "status": "create",
             "type": "primary"
@@ -138,7 +159,7 @@
     "parallel_downloads": 5
   },
   "profile_config": {
-    "gfx_driver": "All open-source (default)",
+    "gfx_driver": "All open-source",
     "greeter": "sddm",
     "profile": {
       "details": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,16 @@ def config_fixture() -> Path:
 
 
 @pytest.fixture(scope='session')
+def example_config_fixture() -> Path:
+	return Path(__file__).parent.parent / 'examples' / 'config-sample.json'
+
+
+@pytest.fixture(scope='session')
+def example_creds_fixture() -> Path:
+	return Path(__file__).parent.parent / 'examples' / 'creds-sample.json'
+
+
+@pytest.fixture(scope='session')
 def btrfs_config_fixture() -> Path:
 	return Path(__file__).parent / 'data' / 'test_config_btrfs.json'
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,3 +1,4 @@
+import json
 import os
 from importlib.metadata import version
 from pathlib import Path
@@ -17,7 +18,7 @@ from archinstall.lib.models.application import (
 )
 from archinstall.lib.models.authentication import AuthenticationConfiguration, U2FLoginConfiguration, U2FLoginMethod
 from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
-from archinstall.lib.models.device import DiskLayoutConfiguration, DiskLayoutType
+from archinstall.lib.models.device import DiskLayoutConfiguration, DiskLayoutType, Size
 from archinstall.lib.models.locale import LocaleConfiguration
 from archinstall.lib.models.mirrors import CustomRepository, CustomServer, MirrorConfiguration, MirrorRegion, SignCheck, SignOption
 from archinstall.lib.models.network import NetworkConfiguration, Nic, NicType
@@ -388,3 +389,50 @@ def test_encrypted_creds_with_env_var(
 			groups=[],
 		),
 	]
+
+
+def test_example_config_parsing(
+	monkeypatch: MonkeyPatch,
+	example_config_fixture: Path,
+	example_creds_fixture: Path,
+) -> None:
+	monkeypatch.setattr(
+		'sys.argv',
+		[
+			'archinstall',
+			'--config',
+			str(example_config_fixture),
+			'--creds',
+			str(example_creds_fixture),
+		],
+	)
+
+	handler = ArchConfigHandler()
+	arch_config = handler.config
+
+	assert arch_config.disk_config is not None
+	assert arch_config.profile_config is not None
+	assert arch_config.auth_config is not None
+	assert arch_config.auth_config.users
+
+
+def test_example_config_partitions(example_config_fixture: Path) -> None:
+	# partition entries are only parsed when the configured device is present on
+	# the machine, which is never the case in CI, so read them here directly
+	config = json.loads(example_config_fixture.read_text())
+
+	for device in config['disk_config']['device_modifications']:
+		previous_end = None
+
+		for partition in device['partitions']:
+			assert 'dev_path' in partition
+
+			start = Size.parse_args(partition['start'])
+			end = start + Size.parse_args(partition['size'])
+
+			assert start.is_valid_start()
+
+			if previous_end is not None:
+				assert start >= previous_end
+
+			previous_end = end

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -420,11 +420,18 @@ def test_example_config_partitions(example_config_fixture: Path) -> None:
 	# partition entries are only parsed when the configured device is present on
 	# the machine, which is never the case in CI, so read them here directly
 	config = json.loads(example_config_fixture.read_text())
+	device_modifications = config['disk_config']['device_modifications']
 
-	for device in config['disk_config']['device_modifications']:
+	assert device_modifications
+
+	for device in device_modifications:
+		partitions = device['partitions']
+
+		assert partitions
+
 		previous_end = None
 
-		for partition in device['partitions']:
+		for partition in partitions:
 			assert 'dev_path' in partition
 
 			start = Size.parse_args(partition['start'])


### PR DESCRIPTION
`examples/config-sample.json` cannot be parsed by the current config format. Running
`archinstall --config examples/config-sample.json` on a machine that actually has the configured
device raises before the installer starts.

Five separate problems, all in the sample rather than in the parser:

1. **Every partition is missing `dev_path`.** `DiskLayoutConfiguration.parse_arg` indexes it
   directly (`partition['dev_path']`), so it raises `KeyError: 'dev_path'`.
2. **`"sector_size": null` in every `size` and `start`.** `Size.parse_args` hands it to
   `SectorSize.parse_args`, which indexes `arg['value']`, so it raises
   `TypeError: 'NoneType' object is not subscriptable`.
3. **`/home` uses `"unit": "Percent"`**, which is not a member of `Unit`, so it raises
   `KeyError: 'Percent'`.
4. **`/` and `/home` overlap.** `/` starts at 513 MiB and is 20 GiB long, so it ends at 20993 MiB,
   but `/home` starts at 20 GiB (20480 MiB), so it raises `ValueError: Partitions overlap`.
5. **`"gfx_driver": "All open-source (default)"`** no longer matches any `GfxDriver` value; the
   enum is `All open-source`.

Fixes: `dev_path` is set to `null` on each partition, every `sector_size` becomes an explicit 512 B
object, `/home` becomes a fixed 10 GiB starting at 20993 MiB, and `gfx_driver` is corrected. The
layout the sample describes is otherwise unchanged, apart from `/home` no longer claiming a
percentage the format does not support.

### Test

The reason this went unnoticed is that partition entries are only parsed when the configured device
is present on the machine: `device_handler.get_device()` returns `None` and the entry is skipped
with a silent `continue`, so no CI runner ever reaches that code. The added coverage works around
that:

- `test_example_config_parsing` runs `examples/config-sample.json` and `examples/creds-sample.json`
  through `ArchConfigHandler`, which catches everything outside the disk section (item 5 above, and
  any future drift in the other sections).
- `test_example_config_partitions` reads the partition entries straight from the JSON and asserts
  the invariants the parser would enforce: `dev_path` present, sizes parseable through
  `Size.parse_args`, first partition at no less than 1 MiB, and no overlap between consecutive
  partitions (items 1 to 4).

Reverting either change to the sample makes the corresponding test fail.
