### PR TITLE
feat(#4466): support optdepends of linux-firmware 

### DIFF
--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -88,6 +88,7 @@ class ArchConfigType(StrEnum):
 	ENCRYPTION_PASSWORD = 'encryption_password'
 	HOSTNAME = 'hostname'
 	KERNELS = 'kernels'
+	FIRMWARE_OPTDEPS = 'firmware_optdeps'
 	NTP = 'ntp'
 	TIMEZONE = 'timezone'
 	SERVICES = 'services'
@@ -166,6 +167,7 @@ class ArchConfig:
 	swap: ZramConfiguration | None = None
 	hostname: str = 'archlinux'
 	kernels: list[str] = field(default_factory=lambda: [DEFAULT_KERNEL.value])
+	firmware_optdeps: list[str] = field(default_factory=list)
 	ntp: bool = True
 	packages: list[str] = field(default_factory=list)
 	pacman_config: PacmanConfiguration = field(default_factory=PacmanConfiguration)
@@ -211,6 +213,7 @@ class ArchConfig:
 		return {
 			ArchConfigType.HOSTNAME: self.hostname,
 			ArchConfigType.KERNELS: self.kernels,
+			ArchConfigType.FIRMWARE_OPTDEPS: self.firmware_optdeps,
 			ArchConfigType.NTP: self.ntp,
 			ArchConfigType.TIMEZONE: self.timezone,
 			ArchConfigType.SERVICES: self.services,
@@ -325,6 +328,9 @@ class ArchConfig:
 
 		if kernels := args_config.get('kernels', []):
 			arch_config.kernels = kernels
+
+		if firmware_optdeps := args_config.get('firmware_optdeps', []):
+			arch_config.firmware_optdeps = firmware_optdeps
 
 		arch_config.ntp = args_config.get('ntp', True)
 

--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -126,6 +126,8 @@ class ArchConfigType(StrEnum):
 				return tr('Hostname')
 			case ArchConfigType.KERNELS:
 				return tr('Kernels')
+			case ArchConfigType.FIRMWARE_OPTDEPS:
+				return tr('Optional firmware')
 			case ArchConfigType.NTP:
 				return tr('Automatic time sync (NTP)')
 			case ArchConfigType.TIMEZONE:

--- a/archinstall/lib/general/system_menu.py
+++ b/archinstall/lib/general/system_menu.py
@@ -3,7 +3,7 @@ from typing import assert_never
 from archinstall.lib.hardware import GfxDriver, SysInfo
 from archinstall.lib.menu.helpers import Confirmation, Selection
 from archinstall.lib.models.application import ZramAlgorithm, ZramConfiguration
-from archinstall.lib.models.package_types import DEFAULT_KERNEL, Kernel
+from archinstall.lib.models.package_types import DEFAULT_KERNEL, FirmwareOptdep, Kernel
 from archinstall.lib.translationhandler import tr
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
 from archinstall.tui.result import ResultType
@@ -23,6 +23,32 @@ async def select_kernel(preset: list[Kernel] = []) -> list[Kernel]:
 	result = await Selection[Kernel](
 		group,
 		header=tr('Select which kernel(s) to install'),
+		allow_skip=True,
+		allow_reset=True,
+		multi=True,
+	).show()
+
+	match result.type_:
+		case ResultType.Skip:
+			return preset
+		case ResultType.Reset:
+			return []
+		case ResultType.Selection:
+			return result.get_values()
+
+
+async def select_firmware_optdeps(preset: list[FirmwareOptdep] = []) -> list[FirmwareOptdep]:
+	"""
+	Asks the user which of linux-firmware's optional dependencies to install.
+
+	:return: The selected firmware packages
+	:rtype: list[FirmwareOptdep]
+	"""
+	group = MenuItemGroup.from_enum(FirmwareOptdep, sort_items=True, preset=preset)
+
+	result = await Selection[FirmwareOptdep](
+		group,
+		header=tr('Select optional firmware to install (none are pulled in by linux-firmware)'),
 		allow_skip=True,
 		allow_reset=True,
 		multi=True,

--- a/archinstall/lib/general/system_menu.py
+++ b/archinstall/lib/general/system_menu.py
@@ -37,13 +37,14 @@ async def select_kernel(preset: list[Kernel] = []) -> list[Kernel]:
 			return result.get_values()
 
 
-async def select_firmware_optdeps(preset: list[FirmwareOptdep] = []) -> list[FirmwareOptdep]:
+async def select_firmware_optdeps(preset: list[FirmwareOptdep] | None = None) -> list[FirmwareOptdep]:
 	"""
 	Asks the user which of linux-firmware's optional dependencies to install.
 
 	:return: The selected firmware packages
 	:rtype: list[FirmwareOptdep]
 	"""
+	preset = preset or []
 	group = MenuItemGroup.from_enum(FirmwareOptdep, sort_items=True, preset=preset)
 
 	result = await Selection[FirmwareOptdep](

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -9,7 +9,7 @@ from archinstall.lib.bootloader.utils import validate_bootloader_layout
 from archinstall.lib.configuration import save_config
 from archinstall.lib.disk.disk_menu import DiskLayoutConfigurationMenu
 from archinstall.lib.general.general_menu import select_hostname, select_ntp, select_timezone
-from archinstall.lib.general.system_menu import select_kernel, select_swap
+from archinstall.lib.general.system_menu import select_firmware_optdeps, select_kernel, select_swap
 from archinstall.lib.hardware import SysInfo
 from archinstall.lib.locale.locale_menu import LocaleMenu
 from archinstall.lib.menu.abstract_menu import AbstractMenu, SpecialMenuKey
@@ -109,6 +109,13 @@ class GlobalMenu(AbstractMenu[None]):
 				preview_action=self._prev_kernel,
 				mandatory=True,
 				key='kernels',
+			),
+			MenuItem(
+				text=tr('Optional firmware'),
+				value=[],
+				action=select_firmware_optdeps,
+				preview_action=self._prev_firmware_optdeps,
+				key='firmware_optdeps',
 			),
 			MenuItem(
 				text=tr('Hostname'),
@@ -436,6 +443,12 @@ class GlobalMenu(AbstractMenu[None]):
 		if item.value:
 			kernel = ', '.join(item.value)
 			return f'{tr("Kernel")}: {kernel}'
+		return None
+
+	def _prev_firmware_optdeps(self, item: MenuItem) -> str | None:
+		if item.value:
+			firmware = ', '.join(item.value)
+			return f'{tr("Optional firmware")}: {firmware}'
 		return None
 
 	def _prev_bootloader_config(self, item: MenuItem) -> str | None:

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -448,7 +448,7 @@ class GlobalMenu(AbstractMenu[None]):
 	def _prev_firmware_optdeps(self, item: MenuItem) -> str | None:
 		if item.value:
 			firmware = ', '.join(item.value)
-			return f'{tr("Optional firmware")}: {firmware}'
+			return f'{tr("Additional firmware")}: {firmware}'
 		return None
 
 	def _prev_bootloader_config(self, item: MenuItem) -> str | None:

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -111,7 +111,7 @@ class GlobalMenu(AbstractMenu[None]):
 				key='kernels',
 			),
 			MenuItem(
-				text=tr('Optional firmware'),
+				text=tr('Additional firmware'),
 				value=[],
 				action=select_firmware_optdeps,
 				preview_action=self._prev_firmware_optdeps,

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -79,7 +79,7 @@ class Installer:
 		disk_config: DiskLayoutConfiguration,
 		base_packages: list[str] = [],
 		kernels: list[str] | None = None,
-		firmware: list[str] | None = None,
+		firmware: list[str] = [],
 		silent: bool = False,
 	):
 		"""
@@ -103,7 +103,7 @@ class Installer:
 			self._base_packages.append(kernel)
 
 		# Optional firmware is strapped with base so the blobs are in place before the initramfs is generated
-		self._base_packages.extend(firmware or [])
+		self._base_packages.extend(firmware)
 
 		# If using accessibility tools in the live environment, append those to the packages list
 		if accessibility_tools_in_use():

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -77,9 +77,9 @@ class Installer:
 		self,
 		target: Path,
 		disk_config: DiskLayoutConfiguration,
-		base_packages: list[str] = [],
+		base_packages: list[str] | None = None,
 		kernels: list[str] | None = None,
-		firmware: list[str] = [],
+		firmware: list[str] | None = None,
 		silent: bool = False,
 	):
 		"""
@@ -103,7 +103,7 @@ class Installer:
 			self._base_packages.append(kernel)
 
 		# Optional firmware is strapped with base so the blobs are in place before the initramfs is generated
-		self._base_packages.extend(firmware)
+		self._base_packages.extend(firmware or [])
 
 		# If using accessibility tools in the live environment, append those to the packages list
 		if accessibility_tools_in_use():

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -79,6 +79,7 @@ class Installer:
 		disk_config: DiskLayoutConfiguration,
 		base_packages: list[str] = [],
 		kernels: list[str] | None = None,
+		firmware: list[str] | None = None,
 		silent: bool = False,
 	):
 		"""
@@ -100,6 +101,10 @@ class Installer:
 
 		for kernel in self.kernels:
 			self._base_packages.append(kernel)
+
+		# linux-firmware pulls in its hard deps only, so the optional ones are
+		# strapped alongside base or their blobs never reach the target
+		self._base_packages.extend(firmware or [])
 
 		# If using accessibility tools in the live environment, append those to the packages list
 		if accessibility_tools_in_use():

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -102,8 +102,7 @@ class Installer:
 		for kernel in self.kernels:
 			self._base_packages.append(kernel)
 
-		# linux-firmware pulls in its hard deps only, so the optional ones are
-		# strapped alongside base or their blobs never reach the target
+		# Optional firmware is strapped with base so the blobs are in place before the initramfs is generated
 		self._base_packages.extend(firmware or [])
 
 		# If using accessibility tools in the live environment, append those to the packages list

--- a/archinstall/lib/models/package_types.py
+++ b/archinstall/lib/models/package_types.py
@@ -10,3 +10,20 @@ class Kernel(StrEnum):
 
 
 DEFAULT_KERNEL: Final = Kernel.LINUX
+
+
+class FirmwareOptdep(StrEnum):
+	"""linux-firmware's optional dependencies.
+
+	The metapackage pulls in its hard deps only, so these blobs never reach the
+	target: hardware that needs one (a Marvell wifi card, a Mellanox NIC) comes
+	up without firmware and there is nothing in the installer that says so.
+	Mirrors `pacman -Si linux-firmware` optdepends.
+	"""
+
+	LIQUIDIO = 'linux-firmware-liquidio'
+	MARVELL = 'linux-firmware-marvell'
+	MELLANOX = 'linux-firmware-mellanox'
+	NFP = 'linux-firmware-nfp'
+	QCOM = 'linux-firmware-qcom'
+	QLOGIC = 'linux-firmware-qlogic'

--- a/archinstall/lib/models/package_types.py
+++ b/archinstall/lib/models/package_types.py
@@ -13,12 +13,11 @@ DEFAULT_KERNEL: Final = Kernel.LINUX
 
 
 class FirmwareOptdep(StrEnum):
-	"""linux-firmware's optional dependencies.
+	"""
+	The optional dependencies of linux-firmware (pacman -Si linux-firmware).
 
-	The metapackage pulls in its hard deps only, so these blobs never reach the
-	target: hardware that needs one (a Marvell wifi card, a Mellanox NIC) comes
-	up without firmware and there is nothing in the installer that says so.
-	Mirrors `pacman -Si linux-firmware` optdepends.
+	The metapackage installs its hard dependencies only, so these blobs are
+	never present on the target unless they are requested explicitly.
 	"""
 
 	LIQUIDIO = 'linux-firmware-liquidio'

--- a/archinstall/lib/models/package_types.py
+++ b/archinstall/lib/models/package_types.py
@@ -14,7 +14,7 @@ DEFAULT_KERNEL: Final = Kernel.LINUX
 
 class FirmwareOptdep(StrEnum):
 	"""
-	The optional dependencies of linux-firmware (pacman -Si linux-firmware).
+	The optional dependencies of linux-firmware.
 
 	The metapackage installs its hard dependencies only, so these blobs are
 	never present on the target unless they are requested explicitly.

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -80,6 +80,7 @@ def perform_installation(
 		mountpoint,
 		disk_config,
 		kernels=config.kernels,
+		firmware=config.firmware_optdeps,
 		silent=arch_config_handler.args.silent,
 	) as installation:
 		# Mount all the drives to the desired mountpoint


### PR DESCRIPTION
Follow up to discussion #4466 

<img width="881" height="332" alt="Screenshot_20260812_140313" src="https://github.com/user-attachments/assets/869e0b5f-7c74-40e4-af8d-b63c52ba6188" />

Instead of adding PCIDs detection or touching any existing logic; simply expose the optional set for user to select. _Goal was to reduce maintain burden as this simply needs to track new `optdepends`_

This is then strapped at `_base_packages` as an `.extend()` before the `mkinitcpio -P` call.  
Since it's fully optional, to me it should not be gated behind `--advanced`, we initialize as empty `[]` and extend selections. 

This would notably make some Marvell Wifi card users happy (i,e surface type devices) and QCOM being quite common nowadays. The others, I've had little experience with.

https://wiki.archlinux.org/title/Linux_firmware#Installation
