### PR TITLE
fix(disk): use fmask=0177 for EFI partition mount options

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -381,7 +381,7 @@ class Installer:
 			options = part_mod.mount_options
 
 			if part_mod.is_efi():
-				options = list(dict.fromkeys(options + ['fmask=0077', 'dmask=0077']))
+				options = list(dict.fromkeys(options + ['fmask=0177', 'dmask=0077']))
 
 			mount(part_mod.dev_path, target, options=options)
 		elif part_mod.fs_type == FilesystemType.BTRFS:


### PR DESCRIPTION
Fixes #4714

### Context & Rationale
When setting default mount options for the EFI system partition, `fmask=0077` was previously used. Updating this to `fmask=0177` ensures files on the ESP are not created with execute permissions, while keeping `dmask=0077` for directories. This aligns with systemd's default behavior for ESP mount options (`fmask=0177,dmask=0077`) and satisfies `bootctl` requirements.

### Changes
- Changed `fmask=0077` to `fmask=0177` in `archinstall/lib/installer.py` when setting EFI partition mount options.