### PR TITLE
fix: only prompt for credentials encryption when creds will be saved

### DIFF
--- a/archinstall/lib/configuration.py
+++ b/archinstall/lib/configuration.py
@@ -109,24 +109,26 @@ async def save_config(config: ArchConfig) -> None:
 
 	debug(f'Saving configuration files to {dest_path.absolute()}')
 
-	header = tr('Do you want to encrypt the user_credentials.json file?')
-
-	enc_result = await Confirmation(
-		header=header,
-		allow_skip=False,
-		preset=False,
-	).show()
-
 	enc_password: str | None = None
-	if enc_result.type_ == ResultType.Selection:
-		if enc_result.get_value():
-			password = await get_password(
-				header=tr('Credentials file encryption password'),
-				allow_skip=True,
-			)
 
-			if password:
-				enc_password = password.plaintext
+	if save_option in ('user_creds', 'all'):
+		header = tr('Do you want to encrypt the user_credentials.json file?')
+
+		enc_result = await Confirmation(
+			header=header,
+			allow_skip=False,
+			preset=False,
+		).show()
+
+		if enc_result.type_ == ResultType.Selection:
+			if enc_result.get_value():
+				password = await get_password(
+					header=tr('Credentials file encryption password'),
+					allow_skip=True,
+				)
+
+				if password:
+					enc_password = password.plaintext
 
 	match save_option:
 		case 'user_config':


### PR DESCRIPTION
    
    The encryption prompt for user_credentials.json was shown unconditionally
    in save_config, even when the user selected 'Save user configuration'.
    That option only writes user_configuration.json, so the credentials file
    was never created despite the misleading prompt. Gate the encryption
    prompt behind 'user_creds' and 'all' save options.