### PR TITLE
Add a cooldown period of 3 days for dev dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,7 +55,8 @@
         "pytest",
         "pylint"
       ],
-      "automerge": true
+      "automerge": true,
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Disable PyPI updates for runtime deps tracked via Arch repos",


### PR DESCRIPTION
## PR Description:

This may help prevent some supply chain attacks.

Earlier discussion: https://github.com/archlinux/archinstall/pull/4662#issuecomment-5334266380