### PR TITLE
Don't persist git credentials during testing and linting workflows

### DIFF
--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -7,6 +7,8 @@ jobs:
             image: archlinux/archlinux:latest
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                persist-credentials: false
             - run: pacman --noconfirm -Syu bandit
             - name: Security checkup with Bandit
               run: bandit -r archinstall || exit 0

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -7,6 +7,8 @@ jobs:
             image: archlinux/archlinux:latest
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                persist-credentials: false
             - name: Prepare arch
               run: |
                 pacman-key --init

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -7,6 +7,8 @@ jobs:
             image: archlinux/archlinux:latest
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                persist-credentials: false
             - name: Prepare arch
               run: |
                 pacman-key --init

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -7,6 +7,8 @@ jobs:
             image: archlinux/archlinux:latest
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                persist-credentials: false
             - name: Prepare arch
               run: |
                 pacman-key --init

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,6 +8,8 @@ jobs:
             options: --privileged
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                persist-credentials: false
             - name: Prepare arch
               run: |
                 pacman-key --init

--- a/.github/workflows/ruff-format.yaml
+++ b/.github/workflows/ruff-format.yaml
@@ -5,5 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0
       - run: ruff format --diff

--- a/.github/workflows/ruff-lint.yaml
+++ b/.github/workflows/ruff-lint.yaml
@@ -5,4 +5,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                persist-credentials: false
             - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0

--- a/.github/workflows/translation-check.yaml
+++ b/.github/workflows/translation-check.yaml
@@ -16,6 +16,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                persist-credentials: false
             - name: Install gettext
               run: sudo apt-get update && sudo apt-get install -y gettext
             - name: Run translation checks


### PR DESCRIPTION
## PR Description:

This commit addresses some low-severity "artipacked" warnings from zizmor:
- https://docs.zizmor.sh/audits/#artipacked

I didn't change all of the workflows, like python-build.yml, because I wanted to test on a smaller subset first.