### PR TITLE
Unset default permissions for testing and linting workflows

### DIFF
--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -1,5 +1,6 @@
 on: [ push, pull_request ]
 name: Bandit security checkup
+permissions: {}
 jobs:
     bandit:
         runs-on: ubuntu-latest

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -1,5 +1,6 @@
 on: [ push, pull_request ]
 name: flake8 linting
+permissions: {}
 jobs:
     flake8:
         runs-on: ubuntu-latest

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,5 +1,6 @@
 on: [ push, pull_request ]
 name: mypy type checking
+permissions: {}
 jobs:
     mypy:
         runs-on: ubuntu-latest

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,5 +1,6 @@
 on: [ push, pull_request ]
 name: Pylint linting
+permissions: {}
 jobs:
     pylint:
         runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,5 +1,6 @@
 on: [ push, pull_request ]
 name: pytest test validation
+permissions: {}
 jobs:
     pytest:
         runs-on: ubuntu-latest

--- a/.github/workflows/ruff-format.yaml
+++ b/.github/workflows/ruff-format.yaml
@@ -1,5 +1,6 @@
 on: [ push, pull_request ]
 name: ruff check formatting
+permissions: {}
 jobs:
   ruff_format_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruff-lint.yaml
+++ b/.github/workflows/ruff-lint.yaml
@@ -1,5 +1,6 @@
 on: [ push, pull_request ]
 name: ruff check linting
+permissions: {}
 jobs:
     ruff:
         runs-on: ubuntu-latest

--- a/.github/workflows/translation-check.yaml
+++ b/.github/workflows/translation-check.yaml
@@ -10,6 +10,7 @@ on:
             - 'archinstall/**/*.py'
             - 'archinstall/locales/**'
             - '.github/workflows/translation-check.yaml'
+permissions: {}
 jobs:
     translations:
         name: Validate translations


### PR DESCRIPTION
## PR Description:

This commit addresses some excessive-permissions warnings from zizmor:
- https://docs.zizmor.sh/audits/#excessive-permissions

I didn't change all of the workflows, like python-build.yml, because I wanted to test on a smaller subset first.