### PR TITLE
Add an optional swap file for hibernation

### DIFF
--- a/archinstall/lib/args.py
+++ b/archinstall/lib/args.py
@@ -19,7 +19,7 @@ from pydantic.dataclasses import dataclass as p_dataclass
 from archinstall.lib.crypt import decrypt, encrypt
 from archinstall.lib.log import debug, error, logger, warn
 from archinstall.lib.menu.util import get_password
-from archinstall.lib.models.application import ApplicationConfiguration, ZramConfiguration
+from archinstall.lib.models.application import ApplicationConfiguration, SwapConfiguration
 from archinstall.lib.models.authentication import AuthenticationConfiguration
 from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
 from archinstall.lib.models.config import SubConfig
@@ -163,7 +163,7 @@ class ArchConfig:
 	bootloader_config: BootloaderConfiguration | None = None
 	app_config: ApplicationConfiguration | None = None
 	auth_config: AuthenticationConfiguration | None = None
-	swap: ZramConfiguration | None = None
+	swap: SwapConfiguration | None = None
 	hostname: str = 'archlinux'
 	kernels: list[str] = field(default_factory=lambda: [DEFAULT_KERNEL.value])
 	ntp: bool = True
@@ -338,7 +338,7 @@ class ArchConfig:
 
 		swap_arg = args_config.get('swap')
 		if swap_arg is not None:
-			arch_config.swap = ZramConfiguration.parse_arg(swap_arg)
+			arch_config.swap = SwapConfiguration.parse_arg(swap_arg)
 
 		if timezone := args_config.get('timezone', 'UTC'):
 			arch_config.timezone = timezone

--- a/archinstall/lib/general/system_menu.py
+++ b/archinstall/lib/general/system_menu.py
@@ -103,25 +103,37 @@ async def select_driver(options: list[GfxDriver] = [], preset: GfxDriver | None 
 
 
 async def select_swap(preset: SwapConfiguration = SwapConfiguration()) -> SwapConfiguration:
-	prompt = tr('Would you like to use swap on zram?') + '\n'
+	def option(zram: bool, swapfile: bool) -> SwapConfiguration:
+		return SwapConfiguration(
+			zram=ZramConfiguration(enabled=zram, algorithm=preset.zram.algorithm),
+			swapfile=swapfile,
+		)
 
-	group = MenuItemGroup.yes_no()
-	group.set_default_by_value(True)
-	group.set_focus_by_value(preset.zram.enabled)
+	items = [
+		MenuItem(tr('zram'), value=option(True, False)),
+		MenuItem(tr('Swap file (enables hibernation)'), value=option(False, True)),
+		MenuItem(tr('zram and swap file'), value=option(True, True)),
+		MenuItem(tr('No swap'), value=option(False, False)),
+	]
 
-	result = await Confirmation(
-		header=prompt,
+	group = MenuItemGroup(items, sort_items=False)
+	group.set_default_by_value(option(True, False))
+	group.set_focus_by_value(option(preset.zram.enabled, preset.swapfile))
+
+	result = await Selection[SwapConfiguration](
+		group,
+		header=tr('Would you like to use swap?') + '\n',
 		allow_skip=True,
-		preset=preset.zram.enabled,
 	).show()
 
 	match result.type_:
 		case ResultType.Skip:
 			return preset
 		case ResultType.Selection:
-			enabled = result.item() == MenuItem.yes()
-			if not enabled:
-				return SwapConfiguration(zram=ZramConfiguration(enabled=False), swapfile=preset.swapfile)
+			selection = result.get_value()
+
+			if not selection.zram.enabled:
+				return selection
 
 			# Ask for compression algorithm
 			algo_group = MenuItemGroup.from_enum(ZramAlgorithm, sort_items=False)
@@ -144,6 +156,6 @@ async def select_swap(preset: SwapConfiguration = SwapConfiguration()) -> SwapCo
 				case _:
 					assert_never(algo_result.type_)
 
-			return SwapConfiguration(zram=ZramConfiguration(enabled=True, algorithm=algo), swapfile=preset.swapfile)
+			return SwapConfiguration(zram=ZramConfiguration(enabled=True, algorithm=algo), swapfile=selection.swapfile)
 		case ResultType.Reset:
 			raise ValueError('Unhandled result type')

--- a/archinstall/lib/general/system_menu.py
+++ b/archinstall/lib/general/system_menu.py
@@ -2,7 +2,7 @@ from typing import assert_never
 
 from archinstall.lib.hardware import GfxDriver, SysInfo
 from archinstall.lib.menu.helpers import Confirmation, Selection
-from archinstall.lib.models.application import ZramAlgorithm, ZramConfiguration
+from archinstall.lib.models.application import SwapConfiguration, ZramAlgorithm, ZramConfiguration
 from archinstall.lib.models.package_types import DEFAULT_KERNEL, Kernel
 from archinstall.lib.translationhandler import tr
 from archinstall.tui.menu_item import MenuItem, MenuItemGroup
@@ -102,17 +102,17 @@ async def select_driver(options: list[GfxDriver] = [], preset: GfxDriver | None 
 			return result.get_value()
 
 
-async def select_swap(preset: ZramConfiguration = ZramConfiguration(enabled=True)) -> ZramConfiguration:
+async def select_swap(preset: SwapConfiguration = SwapConfiguration()) -> SwapConfiguration:
 	prompt = tr('Would you like to use swap on zram?') + '\n'
 
 	group = MenuItemGroup.yes_no()
 	group.set_default_by_value(True)
-	group.set_focus_by_value(preset.enabled)
+	group.set_focus_by_value(preset.zram.enabled)
 
 	result = await Confirmation(
 		header=prompt,
 		allow_skip=True,
-		preset=preset.enabled,
+		preset=preset.zram.enabled,
 	).show()
 
 	match result.type_:
@@ -121,12 +121,12 @@ async def select_swap(preset: ZramConfiguration = ZramConfiguration(enabled=True
 		case ResultType.Selection:
 			enabled = result.item() == MenuItem.yes()
 			if not enabled:
-				return ZramConfiguration(enabled=False)
+				return SwapConfiguration(zram=ZramConfiguration(enabled=False), swapfile=preset.swapfile)
 
 			# Ask for compression algorithm
 			algo_group = MenuItemGroup.from_enum(ZramAlgorithm, sort_items=False)
 			algo_group.set_default_by_value(ZramAlgorithm.ZSTD)
-			algo_group.set_focus_by_value(preset.algorithm)
+			algo_group.set_focus_by_value(preset.zram.algorithm)
 
 			algo_result = await Selection[ZramAlgorithm](
 				algo_group,
@@ -136,7 +136,7 @@ async def select_swap(preset: ZramConfiguration = ZramConfiguration(enabled=True
 
 			match algo_result.type_:
 				case ResultType.Skip:
-					algo = preset.algorithm
+					algo = preset.zram.algorithm
 				case ResultType.Selection:
 					algo = algo_result.get_value()
 				case ResultType.Reset:
@@ -144,6 +144,6 @@ async def select_swap(preset: ZramConfiguration = ZramConfiguration(enabled=True
 				case _:
 					assert_never(algo_result.type_)
 
-			return ZramConfiguration(enabled=True, algorithm=algo)
+			return SwapConfiguration(zram=ZramConfiguration(enabled=True, algorithm=algo), swapfile=preset.swapfile)
 		case ResultType.Reset:
 			raise ValueError('Unhandled result type')

--- a/archinstall/lib/global_menu.py
+++ b/archinstall/lib/global_menu.py
@@ -15,7 +15,7 @@ from archinstall.lib.locale.locale_menu import LocaleMenu
 from archinstall.lib.menu.abstract_menu import AbstractMenu, SpecialMenuKey
 from archinstall.lib.mirror.mirror_handler import MirrorListHandler
 from archinstall.lib.mirror.mirror_menu import MirrorMenu
-from archinstall.lib.models.application import ApplicationConfiguration, ZramConfiguration
+from archinstall.lib.models.application import ApplicationConfiguration, SwapConfiguration
 from archinstall.lib.models.authentication import AuthenticationConfiguration
 from archinstall.lib.models.bootloader import Bootloader, BootloaderConfiguration
 from archinstall.lib.models.device import DiskLayoutConfiguration, DiskLayoutType, PartitionModification
@@ -90,7 +90,7 @@ class GlobalMenu(AbstractMenu[None]):
 			),
 			MenuItem(
 				text=tr('Swap'),
-				value=ZramConfiguration(enabled=True),
+				value=SwapConfiguration(),
 				action=select_swap,
 				preview_action=self._prev_swap,
 				key='swap',
@@ -408,9 +408,12 @@ class GlobalMenu(AbstractMenu[None]):
 	def _prev_swap(self, item: MenuItem) -> str | None:
 		if item.value is not None:
 			output = f'{tr("Swap on zram")}: '
-			output += tr('Enabled') if item.value.enabled else tr('Disabled')
-			if item.value.enabled:
-				output += f'\n{tr("Compression algorithm")}: {item.value.algorithm.value}'
+			output += tr('Enabled') if item.value.zram.enabled else tr('Disabled')
+			if item.value.zram.enabled:
+				output += f'\n{tr("Compression algorithm")}: {item.value.zram.algorithm.value}'
+
+			output += f'\n{tr("Swap file")}: '
+			output += tr('Enabled') if item.value.swapfile else tr('Disabled')
 			return output
 		return None
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -579,22 +579,24 @@ class Installer:
 		if size is None:
 			size = _swapfile_size()
 
+		path = Path(f'{self.target}{file}')
+
 		# bail out before writing anything: the base install still has to fit next to the swap
 		# file, and running the root partition out of space halfway through pacstrap is a lot
-		# harder to make sense of than a message here
-		stat = os.statvfs(self.target)
+		# harder to make sense of than a message here. the swap file can be handed a path on a
+		# mount of its own, so measure the filesystem it lands on and not the target root
+		mount = next(parent for parent in path.parents if parent.exists())
+		stat = os.statvfs(mount)
 		available = Size(stat.f_bavail * stat.f_frsize, Unit.B, SectorSize.default())
 		required = size + __base_install_headroom__
 
 		if available < required:
 			raise DiskError(
-				f'Not enough space for a {size.format_highest()} swap file on {self.target}: '
+				f'Not enough space for a {size.format_highest()} swap file on {mount}: '
 				f'{required.format_highest()} is needed to leave room for the base install, {available.format_highest()} is available',
 			)
 
 		info(f'Creating a {size.format_highest()} swap file: {file}')
-
-		path = Path(f'{self.target}{file}')
 
 		if btrfs:
 			self._create_btrfs_swapfile(path, size)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1,3 +1,4 @@
+import math
 import os
 import platform
 import re
@@ -26,7 +27,7 @@ from archinstall.lib.disk.utils import (
 	swapon,
 )
 from archinstall.lib.exceptions import DiskError, HardwareIncompatibilityError, RequirementError, ServiceException, SysCallError
-from archinstall.lib.hardware import SysInfo
+from archinstall.lib.hardware import SysInfo, read_meminfo
 from archinstall.lib.linux_path import LPath
 from archinstall.lib.locale.utils import verify_keyboard_layout, verify_x11_keyboard_layout
 from archinstall.lib.log import debug, error, info, log, logger, warn
@@ -70,6 +71,11 @@ __packages__ = ['base', 'sudo', 'linux-firmware', 'mkinitcpio'] + [k.value for k
 
 # Additional packages that are installed if the user is running the Live ISO with accessibility tools enabled
 __accessibility_packages__ = ['brltty', 'espeakup', 'alsa-utils']
+
+# Rough floor for what the base install needs next to a swap file. linux-firmware alone is north of
+# a gigabyte and pacstrap keeps the packages it downloads in the target's cache, so this is a lower
+# bound rather than a full accounting: a profile on top of it will ask for a good deal more.
+__base_install_headroom__ = Size(2, Unit.GiB, SectorSize.default())
 
 
 class Installer:
@@ -526,15 +532,32 @@ class Installer:
 
 		return True
 
-	def add_swapfile(self, size: str = '4G', enable_resume: bool = True, file: str = '/swapfile') -> None:
+	def add_swapfile(self, size: Size | None = None, enable_resume: bool = True, file: str = '/swapfile') -> None:
 		if file[:1] != '/':
 			file = f'/{file}'
 		if len(file.strip()) <= 0 or file == '/':
 			raise ValueError(f'The filename for the swap file has to be a valid path, not: {self.target}{file}')
 
-		SysCommand(f'dd if=/dev/zero of={self.target}{file} bs={size} count=1')
-		SysCommand(f'chmod 0600 {self.target}{file}')
-		SysCommand(f'mkswap {self.target}{file}')
+		if size is None:
+			size = _swapfile_size()
+
+		# bail out before writing anything: the base install still has to fit next to the swap
+		# file, and running the root partition out of space halfway through pacstrap is a lot
+		# harder to make sense of than a message here
+		stat = os.statvfs(self.target)
+		available = Size(stat.f_bavail * stat.f_frsize, Unit.B, SectorSize.default())
+		required = size + __base_install_headroom__
+
+		if available < required:
+			raise DiskError(
+				f'Not enough space for a {size.format_highest()} swap file on {self.target}: '
+				f'{required.format_highest()} is needed to leave room for the base install, {available.format_highest()} is available',
+			)
+
+		info(f'Creating a {size.format_highest()} swap file: {file}')
+
+		# mkswap allocates the file, sets it to 0600 and formats it in one go
+		SysCommand(f'mkswap --size {size.convert(Unit.MiB).value}m --file {self.target}{file}')
 
 		self._fstab_entries.append(f'{file} none swap defaults 0 0')
 
@@ -2124,6 +2147,19 @@ class Installer:
 			f'systemctl show --no-pager -p SubState --value {service_name}',
 			environment_vars={'SYSTEMD_COLORS': '0'},
 		).decode()
+
+
+def _swapfile_size() -> Size:
+	"""
+	A hibernation image is a snapshot of the physical memory, so a swap file the size of MemTotal is
+	always large enough to hold one. Whatever zram is holding lives in RAM as well and is therefore
+	already counted there, so an active zram device needs no extra room.
+	"""
+	# /proc/meminfo reports kibibytes even though it labels them kB
+	mem_total = Size(read_meminfo().mem_total, Unit.KiB, SectorSize.default())
+	size = math.ceil(mem_total.convert(Unit.B).value / Unit.MiB.value)
+
+	return Size(size, Unit.MiB, SectorSize.default())
 
 
 def accessibility_tools_in_use() -> bool:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -536,7 +536,10 @@ class Installer:
 		# btrfs refuses to snapshot a subvolume that holds an active swap file, so the swap file
 		# gets a subvolume of its own and the root one stays snapshottable
 		if path.parent.exists():
-			warn(f'{path.parent} already exists, the swap file cannot be given a subvolume of its own and will block snapshots of the one it lands in')
+			warn(
+				f'{path.parent} already exists and will not be created as a subvolume; unless it is one already, '
+				'the swap file will block snapshots of the subvolume it lands in',
+			)
 		else:
 			SysCommand(f'btrfs subvolume create {path.parent}')
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -608,7 +608,7 @@ class Installer:
 			resume_uuid = SysCommand(f'findmnt -no UUID -T {path}').decode()
 			resume_offset = self._swapfile_offset(path, btrfs)
 
-			self._hooks.append('resume')
+			self._prepare_resume()
 			self._kernel_params.append(f'resume=UUID={resume_uuid}')
 			self._kernel_params.append(f'resume_offset={resume_offset}')
 
@@ -951,6 +951,18 @@ class Installer:
 		else:
 			if 'encrypt' not in self._hooks:
 				self._hooks.insert(self._hooks.index(before), 'encrypt')
+
+	def _prepare_resume(self, before: str = 'fsck') -> None:
+		if self._disk_encryption.hsm_device:
+			# the initramfs keeps the systemd hook in this case, which already ships
+			# systemd-hibernate-resume and the generator that reads resume= off the kernel
+			# command line, so the busybox hook would have nothing left to do
+			return
+
+		if 'resume' not in self._hooks:
+			# has to run once the resume device is there, so after udev and after whichever
+			# of encrypt and lvm2 the layout pulled in
+			self._hooks.insert(self._hooks.index(before), 'resume')
 
 	def minimal_installation(
 		self,

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -532,7 +532,45 @@ class Installer:
 
 		return True
 
-	def add_swapfile(self, size: Size | None = None, enable_resume: bool = True, file: str = '/swapfile') -> None:
+	def _create_btrfs_swapfile(self, path: Path, size: Size) -> None:
+		# btrfs refuses to snapshot a subvolume that holds an active swap file, so the swap file
+		# gets a subvolume of its own and the root one stays snapshottable
+		if path.parent.exists():
+			warn(f'{path.parent} already exists, the swap file cannot be given a subvolume of its own and will block snapshots of the one it lands in')
+		else:
+			SysCommand(f'btrfs subvolume create {path.parent}')
+
+		# mkswapfile preallocates the file, marks it NODATACOW as swapon requires, sets it to
+		# 0600 and runs mkswap on it, all in one go
+		SysCommand(f'btrfs filesystem mkswapfile --size {size.convert(Unit.MiB).value}m --uuid clear {path}')
+
+	def _swapfile_offset(self, path: Path, btrfs: bool) -> str:
+		if btrfs:
+			# the physical offset filefrag reports is not the one the kernel resumes from on
+			# btrfs, map-swapfile is the supported way to get it
+			return SysCommand(f'btrfs inspect-internal map-swapfile -r {path}').decode()
+
+		return (
+			SysCommand(
+				f'filefrag -v {path}',
+			)
+			.decode()
+			.split('0:', 1)[1]
+			.split(':', 1)[1]
+			.split('..', 1)[0]
+			.strip()
+		)
+
+	def add_swapfile(self, size: Size | None = None, enable_resume: bool = True, file: str | None = None) -> None:
+		# the layout cannot answer this on its own, a pre-mounted configuration carries no
+		# partition modifications at all, so ask the mount the swap file is going to live on
+		btrfs = SysCommand(f'findmnt -no FSTYPE -T {self.target}').decode() == FilesystemType.BTRFS.value
+
+		if file is None:
+			# btrfs cannot snapshot a subvolume that holds an active swap file, so the swap file
+			# is given a subvolume of its own and the root one stays snapshottable
+			file = '/swap/swapfile' if btrfs else '/swapfile'
+
 		if file[:1] != '/':
 			file = f'/{file}'
 		if len(file.strip()) <= 0 or file == '/':
@@ -556,23 +594,19 @@ class Installer:
 
 		info(f'Creating a {size.format_highest()} swap file: {file}')
 
-		# mkswap allocates the file, sets it to 0600 and formats it in one go
-		SysCommand(f'mkswap --size {size.convert(Unit.MiB).value}m --file {self.target}{file}')
+		path = Path(f'{self.target}{file}')
+
+		if btrfs:
+			self._create_btrfs_swapfile(path, size)
+		else:
+			# mkswap allocates the file, sets it to 0600 and formats it in one go
+			SysCommand(f'mkswap --size {size.convert(Unit.MiB).value}m --file {path}')
 
 		self._fstab_entries.append(f'{file} none swap defaults 0 0')
 
 		if enable_resume:
-			resume_uuid = SysCommand(f'findmnt -no UUID -T {self.target}{file}').decode()
-			resume_offset = (
-				SysCommand(
-					f'filefrag -v {self.target}{file}',
-				)
-				.decode()
-				.split('0:', 1)[1]
-				.split(':', 1)[1]
-				.split('..', 1)[0]
-				.strip()
-			)
+			resume_uuid = SysCommand(f'findmnt -no UUID -T {path}').decode()
+			resume_offset = self._swapfile_offset(path, btrfs)
 
 			self._hooks.append('resume')
 			self._kernel_params.append(f'resume=UUID={resume_uuid}')

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -588,14 +588,14 @@ class Installer:
 		# file, and running the root partition out of space halfway through pacstrap is a lot
 		# harder to make sense of than a message here. the swap file can be handed a path on a
 		# mount of its own, so measure the filesystem it lands on and not the target root
-		mount = next(parent for parent in path.parents if parent.exists())
-		stat = os.statvfs(mount)
+		fs_path = next(parent for parent in path.parents if parent.exists())
+		stat = os.statvfs(fs_path)
 		available = Size(stat.f_bavail * stat.f_frsize, Unit.B, SectorSize.default())
 		required = size + __base_install_headroom__
 
 		if available < required:
 			raise DiskError(
-				f'Not enough space for a {size.format_highest()} swap file on {mount}: '
+				f'Not enough space for a {size.format_highest()} swap file on {fs_path}: '
 				f'{required.format_highest()} is needed to leave room for the base install, {available.format_highest()} is available',
 			)
 

--- a/archinstall/lib/models/application.py
+++ b/archinstall/lib/models/application.py
@@ -202,6 +202,43 @@ class ZramConfiguration(SubConfig):
 		return None
 
 
+@dataclass(frozen=True)
+class SwapConfiguration(SubConfig):
+	zram: ZramConfiguration = ZramConfiguration(enabled=True)
+	swapfile: bool = False
+
+	@classmethod
+	def parse_arg(cls, arg: bool | dict[str, Any]) -> Self:
+		# the option used to hold the zram configuration on its own, so a bare bool
+		# and a dict of zram keys both still have to parse as that
+		if isinstance(arg, bool):
+			return cls(zram=ZramConfiguration.parse_arg(arg))
+
+		if 'zram' in arg or 'swapfile' in arg:
+			return cls(
+				zram=ZramConfiguration.parse_arg(arg.get('zram', False)),
+				swapfile=arg.get('swapfile', False),
+			)
+
+		return cls(zram=ZramConfiguration.parse_arg(arg))
+
+	@override
+	def json(self) -> dict[str, Any]:
+		return {
+			'zram': self.zram.json(),
+			'swapfile': self.swapfile,
+		}
+
+	@override
+	def summary(self) -> list[str] | None:
+		out = self.zram.summary() or []
+
+		if self.swapfile:
+			out.append(tr('Swap file enabled'))
+
+		return out or None
+
+
 @dataclass
 class ApplicationConfiguration(SubConfig):
 	bluetooth_config: BluetoothConfiguration | None = None

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -599,7 +599,19 @@ msgid ""
 "the Nvidia proprietary driver.\n"
 msgstr ""
 
-msgid "Would you like to use swap on zram?"
+msgid "zram"
+msgstr ""
+
+msgid "Swap file (enables hibernation)"
+msgstr ""
+
+msgid "zram and swap file"
+msgstr ""
+
+msgid "No swap"
+msgstr ""
+
+msgid "Would you like to use swap?"
 msgstr ""
 
 msgid "Select zram compression algorithm:"
@@ -650,6 +662,9 @@ msgid "Swap on zram"
 msgstr ""
 
 msgid "Compression algorithm"
+msgstr ""
+
+msgid "Swap file"
 msgstr ""
 
 msgid "Parallel Downloads"
@@ -856,6 +871,9 @@ msgstr ""
 
 #, python-brace-format
 msgid "Zram algorithm {}"
+msgstr ""
+
+msgid "Swap file enabled"
 msgstr ""
 
 msgid "Bluetooth enabled"

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -111,8 +111,8 @@ def perform_installation(
 		if mirror_config := config.mirror_config:
 			installation.set_mirrors(mirror_list_handler, mirror_config, on_target=True)
 
-		if config.swap and config.swap.enabled:
-			installation.setup_swap(algo=config.swap.algorithm)
+		if config.swap and config.swap.zram.enabled:
+			installation.setup_swap(algo=config.swap.zram.algorithm)
 
 		if config.bootloader_config and config.bootloader_config.bootloader != Bootloader.NO_BOOTLOADER:
 			installation.add_bootloader(

--- a/archinstall/scripts/guided.py
+++ b/archinstall/scripts/guided.py
@@ -100,6 +100,11 @@ def perform_installation(
 		if mirror_config := config.mirror_config:
 			installation.set_mirrors(mirror_list_handler, mirror_config, on_target=False)
 
+		# the swap file has to exist before the initramfs is generated, otherwise the resume
+		# hook and the kernel parameters it needs would not make it in
+		if config.swap and config.swap.swapfile:
+			installation.add_swapfile()
+
 		installation.minimal_installation(
 			optional_repositories=optional_repositories,
 			mkinitcpio=run_mkinitcpio,
@@ -111,6 +116,8 @@ def perform_installation(
 		if mirror_config := config.mirror_config:
 			installation.set_mirrors(mirror_list_handler, mirror_config, on_target=True)
 
+		# unlike the swap file above, this one runs after the base install because it
+		# pacstraps zram-generator into the target
 		if config.swap and config.swap.zram.enabled:
 			installation.setup_swap(algo=config.swap.zram.algorithm)
 

--- a/docs/cli_parameters/config/config_options.csv
+++ b/docs/cli_parameters/config/config_options.csv
@@ -20,5 +20,5 @@ parallel downloads,0-∞,sets a given number of parallel downloads to be used by
 profile_config,*`read more under the profiles section`*,Installs a given profile if defined,No
 script,`guided <https://github.com/archlinux/archinstall/blob/master/archinstall/scripts/guided.py>`__! *(default)*!, `minimal <https://github.com/archlinux/archinstall/blob/master/archinstall/scripts/minimal.py>`__!, `only_hdd <https://github.com/archlinux/archinstall/blob/master/archinstall/scripts/only_hdd.py>`_!, When used to autorun an installation!, this sets which script to autorun with,No
 silent,``true``!, ``false``,disables or enables user questions using the TUI,No
-swap,``true``!, ``false``,enables or disables swap,No
+swap,``zram``!, ``swapfile``,enables swap on zram and/or a swap file. The swap file is sized after the installed memory and is what makes hibernation possible. A bare ``true`` or ``false`` still toggles zram on its own,No
 timezone,`timezone <https://wiki.archlinux.org/title/System_time#Time_zone>`_,sets a timezone for the installed system,No

--- a/docs/cli_parameters/config/config_options.csv
+++ b/docs/cli_parameters/config/config_options.csv
@@ -20,5 +20,5 @@ parallel downloads,0-∞,sets a given number of parallel downloads to be used by
 profile_config,*`read more under the profiles section`*,Installs a given profile if defined,No
 script,`guided <https://github.com/archlinux/archinstall/blob/master/archinstall/scripts/guided.py>`__! *(default)*!, `minimal <https://github.com/archlinux/archinstall/blob/master/archinstall/scripts/minimal.py>`__!, `only_hdd <https://github.com/archlinux/archinstall/blob/master/archinstall/scripts/only_hdd.py>`_!, When used to autorun an installation!, this sets which script to autorun with,No
 silent,``true``!, ``false``,disables or enables user questions using the TUI,No
-swap,``zram``!, ``swapfile``,enables swap on zram and/or a swap file. The swap file is sized after the installed memory and is what makes hibernation possible. A bare ``true`` or ``false`` still toggles zram on its own,No
+swap,{ zram: ``true``/``false``/{ enabled!, algorithm }!, swapfile: ``true``/``false`` },enables swap on zram and/or a swap file. The swap file is sized after the installed memory and is what makes hibernation possible. A bare ``true`` or ``false`` still toggles zram on its own,No
 timezone,`timezone <https://wiki.archlinux.org/title/System_time#Time_zone>`_,sets a timezone for the installed system,No

--- a/examples/config-sample.json
+++ b/examples/config-sample.json
@@ -171,8 +171,11 @@
   "script": "guided",
   "silent": false,
   "swap": {
-    "enabled": true,
-    "algorithm": "zstd"
+    "zram": {
+      "enabled": true,
+      "algorithm": "zstd"
+    },
+    "swapfile": false
   },
   "timezone": "UTC",
   "version": "2.8.6"

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -14,6 +14,7 @@ from archinstall.lib.models.application import (
 	AudioConfiguration,
 	BluetoothConfiguration,
 	PrintServiceConfiguration,
+	SwapConfiguration,
 	ZramConfiguration,
 )
 from archinstall.lib.models.authentication import AuthenticationConfiguration, U2FLoginConfiguration, U2FLoginMethod
@@ -239,7 +240,7 @@ def test_config_file_parsing(
 		ntp=True,
 		packages=['firefox'],
 		pacman_config=PacmanConfiguration(parallel_downloads=66),
-		swap=ZramConfiguration(enabled=False),
+		swap=SwapConfiguration(zram=ZramConfiguration(enabled=False)),
 		timezone='UTC',
 		services=['service_1', 'service_2'],
 		custom_commands=["echo 'Hello, World!'"],

--- a/tests/test_swap_config.py
+++ b/tests/test_swap_config.py
@@ -1,0 +1,84 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pytest import MonkeyPatch
+
+from archinstall.lib.args import ArchConfigHandler
+from archinstall.lib.hardware import MemInfo
+from archinstall.lib.installer import _swapfile_size
+from archinstall.lib.models.application import SwapConfiguration, ZramAlgorithm, ZramConfiguration
+from archinstall.lib.models.device import SectorSize, Size, Unit
+
+
+@pytest.mark.parametrize(
+	'arg, expected',
+	[
+		# the option held nothing but the zram configuration before the swap file was
+		# added, so every shape it used to accept has to keep parsing the same way
+		(True, SwapConfiguration(zram=ZramConfiguration(enabled=True))),
+		(False, SwapConfiguration(zram=ZramConfiguration(enabled=False))),
+		({'enabled': False}, SwapConfiguration(zram=ZramConfiguration(enabled=False))),
+		(
+			{'enabled': True, 'algorithm': 'lz4'},
+			SwapConfiguration(zram=ZramConfiguration(enabled=True, algorithm=ZramAlgorithm.LZ4)),
+		),
+		# and the current shape
+		({'zram': True}, SwapConfiguration(zram=ZramConfiguration(enabled=True))),
+		({'swapfile': True}, SwapConfiguration(zram=ZramConfiguration(enabled=False), swapfile=True)),
+		(
+			{'zram': {'enabled': True, 'algorithm': 'lz4'}, 'swapfile': True},
+			SwapConfiguration(zram=ZramConfiguration(enabled=True, algorithm=ZramAlgorithm.LZ4), swapfile=True),
+		),
+	],
+)
+def test_swap_config_parsing(arg: bool | dict[str, Any], expected: SwapConfiguration) -> None:
+	assert SwapConfiguration.parse_arg(arg) == expected
+
+
+@pytest.mark.parametrize(
+	'config',
+	[
+		SwapConfiguration(),
+		SwapConfiguration(zram=ZramConfiguration(enabled=False)),
+		SwapConfiguration(zram=ZramConfiguration(enabled=False), swapfile=True),
+		SwapConfiguration(zram=ZramConfiguration(enabled=True, algorithm=ZramAlgorithm.LZ4), swapfile=True),
+	],
+)
+def test_swap_config_round_trip(config: SwapConfiguration) -> None:
+	assert SwapConfiguration.parse_arg(config.json()) == config
+
+
+def test_swap_config_from_config_file(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+	config_file = tmp_path / 'config.json'
+	config_file.write_text(json.dumps({'swap': {'zram': {'enabled': True, 'algorithm': 'lz4'}, 'swapfile': True}}))
+
+	monkeypatch.setattr('sys.argv', ['archinstall', '--config', str(config_file)])
+
+	assert ArchConfigHandler().config.swap == SwapConfiguration(
+		zram=ZramConfiguration(enabled=True, algorithm=ZramAlgorithm.LZ4),
+		swapfile=True,
+	)
+
+
+@pytest.mark.parametrize(
+	'mem_total, expected_mib',
+	[
+		(8125656, 7936),
+		(1024 * 1024, 1024),
+		(1024 * 1024 + 1, 1025),
+	],
+)
+def test_swapfile_size(monkeypatch: MonkeyPatch, mem_total: int, expected_mib: int) -> None:
+	monkeypatch.setattr(
+		'archinstall.lib.installer.read_meminfo',
+		lambda: MemInfo(mem_total=mem_total, mem_free=0, mem_available=0),
+	)
+
+	size = _swapfile_size()
+
+	assert size == Size(expected_mib, Unit.MiB, SectorSize.default())
+	# a hibernation image can be as large as the memory it came from, so rounding the
+	# size down would leave the last of it with nowhere to go
+	assert size >= Size(mem_total, Unit.KiB, SectorSize.default())


### PR DESCRIPTION
archinstall only sets up zram today, and zram cannot hold a hibernation image: the compressed pages live in the RAM you are trying to write out. So hibernation is a manual job after the install — create the file, find the offset, add two kernel parameters, add the `resume` hook, rebuild the initramfs. #994 has been asking for this since 2022, and #2371 and #2450 are the same request.

`Installer.add_swapfile()` has also been sitting in the tree unused since #1558 in March 2023. This wires it up and fixes what would have broken if anything had called it.

### The menu

<img width="1280" height="800" alt="swap-menu" src="https://github.com/user-attachments/assets/3143183b-d153-4e2e-9c5c-8a638b5cf2f7" />

zram and the swap file can be on together, which is probably what most people want. zram stays at priority 100 and does the day-to-day swapping; the file sits at -1 so a hibernation image has somewhere to go.

<img width="1280" height="800" alt="swap-menu2" src="https://github.com/user-attachments/assets/0b8e52f9-1d0a-40d2-ab57-5c22ef2bf306" />

### The parts worth reviewing

The file is sized at `MemTotal` and created before `minimal_installation()`, so the hook and the kernel parameters are in place before the initramfs is built.

On btrfs it gets a subvolume of its own at `/swap`. btrfs will not snapshot a subvolume that holds an active swap file, and turning on hibernation should not make `/` unsnapshottable as a side effect.

The offset comes from `btrfs inspect-internal map-swapfile -r`, not `filefrag`. On btrfs the two disagree (140544 vs 72960 on my test VM) and `filefrag`'s number will not resume. It fails silently, the machine just cold-boots, so it is easy to get wrong.

`swap` used to hold the zram configuration directly. Both old shapes still parse (`true` and `{"enabled": ..., "algorithm": ...}`); the new one is `{"zram": {...}, "swapfile": true}`. `tests/test_swap_config.py` covers all of them plus a round trip through `ArchConfigHandler`.

`add_swapfile()`'s signature changed. Nothing in the tree calls it, but a plugin might.

Two things I deliberately left alone: `only_hd.py` enables the swap menu item without ever acting on it, which is pre-existing and equally true of zram, and `schema.json` has no `swap` key and is currently invalid JSON anyway.

### Testing

49 tests pass, `ruff` and `mypy --strict` are clean on each commit individually, and `locales_generator.sh check` passes. Hibernation is verified end to end in QEMU on btrfs with systemd-boot and UKI — the full round trip is in the first comment below.

Closes #994
Closes #2371
Refs #2450, #4169
