### PR TITLE
Fix GRUB boot-directory path when ESP has custom mountpoint (#4701)

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1350,15 +1350,9 @@ class Installer:
 
 			self.pacman.strap('efibootmgr')  # TODO: Do we need? Yes, but remove from minimal_installation() instead?
 
-			boot_dir_arg = []
-			if boot_partition.mountpoint and boot_partition.mountpoint != boot_dir:
-				boot_dir_arg.append(f'--boot-directory={boot_partition.mountpoint}')
-				boot_dir = boot_partition.mountpoint
-
 			add_options = [
 				f'--target={"arm64" if platform.machine() == "aarch64" else platform.machine()}-efi',
 				f'--efi-directory={efi_partition.mountpoint}',
-				*boot_dir_arg,
 				'--bootloader-id=GRUB',
 			]
 


### PR DESCRIPTION
When a user specifies a custom ESP mountpoint (e.g., /efi or /boot/efi), the installer incorrectly passed --boot-directory=<custom_esp_path> to grub-install. This caused GRUB modules and configuration to be installed on the ESP partition instead of /boot/grub.

The issue was in _add_grub_bootloader() where the code checked if boot_partition.mountpoint differed from /boot and then set --boot-directory to the boot partition's mountpoint. This is incorrect because:

1. GRUB's --boot-directory flag specifies where to find GRUB modules and configuration (should always be /boot for Linux)
2. GRUB's --efi-directory flag specifies where to install EFI binaries (the ESP mountpoint - this was correctly set)
3. The boot partition mountpoint could be the ESP mountpoint (e.g., /efi) which is not where GRUB modules belong

The fix removes the --boot-directory argument entirely, allowing GRUB to use its default of /boot. This ensures:
- GRUB modules are installed to /boot/grub as expected
- grub-mkconfig writes grub.cfg to /boot/grub/grub.cfg
- BTRFS snapshots that include /boot will contain the GRUB configuration
- System maintenance tasks work correctly with GRUB at the standard path

Fixes #4701

- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
