### PR TITLE
Remove the Pylint dangerous-default-value exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,6 @@ disable = [
     "attribute-defined-outside-init",
     "broad-exception-caught",
     "cell-var-from-loop",
-    "dangerous-default-value",
     "fixme",
     "protected-access",
     "raise-missing-from",


### PR DESCRIPTION
## PR Description:

All of the violations were fixed by commit aaa0ee01.
