### PR TITLE
Add an opt-in discard/TRIM option for LUKS encryption

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -282,6 +282,7 @@ class DeviceHandler:
 		enc_password: Password | None,
 		lock_after_create: bool = True,
 		iter_time: int = DEFAULT_ITER_TIME,
+		allow_discards: bool = False,
 	) -> Luks2:
 		luks_handler = Luks2(
 			dev_path,
@@ -293,7 +294,7 @@ class DeviceHandler:
 
 		udev_sync()
 
-		luks_handler.unlock(key_file=key_file)
+		luks_handler.unlock(key_file=key_file, allow_discards=allow_discards)
 
 		if not luks_handler.mapper_dev:
 			raise DiskError('Failed to unlock luks device')
@@ -324,7 +325,7 @@ class DeviceHandler:
 
 		udev_sync()
 
-		luks_handler.unlock(key_file=key_file)
+		luks_handler.unlock(key_file=key_file, allow_discards=enc_conf.allow_discards)
 
 		if not luks_handler.mapper_dev:
 			raise DiskError('Failed to unlock luks device')

--- a/archinstall/lib/disk/disk_menu.py
+++ b/archinstall/lib/disk/disk_menu.py
@@ -284,6 +284,9 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskMenuConfig]):
 			if enc_type != EncryptionType.NO_ENCRYPTION:
 				output += tr('Iteration time') + f': {enc_config.iter_time or DEFAULT_ITER_TIME}ms\n'
 
+				if enc_config.allow_discards:
+					output += tr('Discard/TRIM support') + f': {tr("Enabled")}\n'
+
 			if enc_config.partitions:
 				output += f'Partitions: {len(enc_config.partitions)} selected\n'
 			elif enc_config.lvm_volumes:

--- a/archinstall/lib/disk/encryption_menu.py
+++ b/archinstall/lib/disk/encryption_menu.py
@@ -3,7 +3,7 @@ from typing import override
 
 from archinstall.lib.disk.fido import Fido2
 from archinstall.lib.menu.abstract_menu import AbstractSubMenu
-from archinstall.lib.menu.helpers import Input, Selection, Table
+from archinstall.lib.menu.helpers import Confirmation, Input, Selection, Table
 from archinstall.lib.menu.menu_helper import MenuHelper
 from archinstall.lib.menu.util import get_password
 from archinstall.lib.models.device import (
@@ -96,12 +96,40 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				preview_action=self._prev_hsm,
 				key='hsm_device',
 			),
+			MenuItem(
+				text=tr('Discard/TRIM support'),
+				action=self._select_allow_discards,
+				value=self._enc_config.allow_discards,
+				dependencies=[self._check_dep_enc_type],
+				preview_action=self._prev_allow_discards,
+				key='allow_discards',
+			),
 		]
 
 	async def _select_lvm_vols(self, preset: list[LvmVolume]) -> list[LvmVolume]:
 		if self._lvm_config:
 			return await select_lvm_vols_to_encrypt(self._lvm_config, preset=preset)
 		return []
+
+	async def _select_allow_discards(self, preset: bool) -> bool:
+		prompt = (
+			tr('TRIM lets an SSD reclaim blocks the filesystem has freed, which keeps write performance up as it fills.')
+			+ '\n\n'
+			+ tr('On an encrypted device it also reveals which blocks are in use, which can give away the filesystem type and how full the disk is.')
+			+ '\n\n'
+			+ tr('Would you like to enable it?')
+			+ '\n'
+		)
+
+		result = await Confirmation(header=prompt, allow_skip=True, preset=preset).show()
+
+		match result.type_:
+			case ResultType.Skip:
+				return preset
+			case ResultType.Selection:
+				return result.item() == MenuItem.yes()
+			case ResultType.Reset:
+				raise ValueError('Unhandled result type')
 
 	def _check_dep_enc_type(self) -> bool:
 		enc_type: EncryptionType | None = self._item_group.find_by_key('encryption_type').value
@@ -151,6 +179,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				lvm_volumes=enc_lvm_vols,
 				hsm_device=enc_config.hsm_device,
 				iter_time=iter_time or DEFAULT_ITER_TIME,
+				allow_discards=enc_config.allow_discards,
 			)
 
 		return None
@@ -166,6 +195,9 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		if (iter_time := self._prev_iter_time(item)) is not None:
 			output += f'\n{iter_time}'
+
+		if (allow_discards := self._prev_allow_discards(item)) is not None:
+			output += f'\n{allow_discards}'
 
 		if (fido_device := self._prev_hsm(item)) is not None:
 			output += f'\n{fido_device}'
@@ -229,6 +261,16 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 			if iter_time and enc_type != EncryptionType.NO_ENCRYPTION:
 				return f'{tr("Iteration time")}: {iter_time}ms'
+
+		return None
+
+	def _prev_allow_discards(self, item: MenuItem) -> str | None:
+		enc_type = self._item_group.find_by_key('encryption_type').value
+
+		if enc_type and enc_type != EncryptionType.NO_ENCRYPTION:
+			output = f'{tr("Discard/TRIM support")}: '
+			output += tr('Enabled') if item.value else tr('Disabled')
+			return output
 
 		return None
 

--- a/archinstall/lib/disk/filesystem.py
+++ b/archinstall/lib/disk/filesystem.py
@@ -277,6 +277,7 @@ class FilesystemHandler:
 					enc_config.encryption_password,
 					lock_after_create,
 					iter_time=enc_config.iter_time,
+					allow_discards=enc_config.allow_discards,
 				)
 
 				enc_vols[vol] = luks_handler
@@ -308,6 +309,7 @@ class FilesystemHandler:
 						enc_config.encryption_password,
 						lock_after_create=lock_after_create,
 						iter_time=enc_config.iter_time,
+						allow_discards=enc_config.allow_discards,
 					)
 
 					enc_mods[part_mod] = luks_handler

--- a/archinstall/lib/disk/luks.py
+++ b/archinstall/lib/disk/luks.py
@@ -124,13 +124,17 @@ class Luks2:
 	def is_unlocked(self) -> bool:
 		return (mapper_dev := self.mapper_dev) is not None and mapper_dev.is_symlink()
 
-	def unlock(self, key_file: Path | None = None) -> None:
+	def unlock(self, key_file: Path | None = None, allow_discards: bool = False) -> None:
 		"""
 		Unlocks the luks device, an optional key file location for unlocking can be specified,
 		otherwise a default location for the key file will be used.
 
 		:param key_file: An alternative key file
 		:type key_file: Path
+
+		:param allow_discards: Pass discard requests through to the underlying device. Stored as a
+			persistent flag in the luks2 header, which cryptsetup replaces rather than merges.
+		:type allow_discards: bool
 		"""
 		debug(f'Unlocking luks2 device: {self.luks_dev_path}')
 
@@ -148,6 +152,10 @@ class Luks2:
 			'--type',
 			'luks2',
 		]
+
+		if allow_discards:
+			# --persistent stores the flag in the luks2 header so later unlocks inherit it
+			cmd += ['--allow-discards', '--persistent']
 
 		try:
 			result = run(cmd, input_data=passphrase)

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -1465,6 +1465,7 @@ class _DiskEncryptionSerialization(TypedDict):
 	lvm_volumes: list[str]
 	hsm_device: NotRequired[_Fido2DeviceSerialization]
 	iter_time: NotRequired[int]
+	allow_discards: NotRequired[bool]
 
 
 @dataclass
@@ -1475,6 +1476,7 @@ class DiskEncryption:
 	lvm_volumes: list[LvmVolume] = field(default_factory=list)
 	hsm_device: Fido2Device | None = None
 	iter_time: int = DEFAULT_ITER_TIME
+	allow_discards: bool = False
 
 	def __post_init__(self) -> None:
 		if self.encryption_type in [EncryptionType.LUKS, EncryptionType.LVM_ON_LUKS] and not self.partitions:
@@ -1501,6 +1503,9 @@ class DiskEncryption:
 
 		if self.iter_time != DEFAULT_ITER_TIME:  # Only include if not default
 			obj['iter_time'] = self.iter_time
+
+		if self.allow_discards:
+			obj['allow_discards'] = self.allow_discards
 
 		return obj
 
@@ -1558,6 +1563,8 @@ class DiskEncryption:
 
 		if iter_time := disk_encryption.get('iter_time', None):
 			enc.iter_time = iter_time
+
+		enc.allow_discards = disk_encryption.get('allow_discards', False) is True
 
 		return enc
 

--- a/archinstall/locales/base.pot
+++ b/archinstall/locales/base.pot
@@ -344,6 +344,9 @@ msgstr ""
 msgid "Iteration time"
 msgstr ""
 
+msgid "Discard/TRIM support"
+msgstr ""
+
 msgid ""
 "No disks were detected. A disk is required to be able to install Arch Linux"
 msgstr ""
@@ -404,6 +407,16 @@ msgid "LVM volumes"
 msgstr ""
 
 msgid "HSM"
+msgstr ""
+
+msgid ""
+"TRIM lets an SSD reclaim blocks the filesystem has freed, which keeps write "
+"performance up as it fills."
+msgstr ""
+
+msgid ""
+"On an encrypted device it also reveals which blocks are in use, which can "
+"give away the filesystem type and how full the disk is."
 msgstr ""
 
 msgid "Partitions to be encrypted"

--- a/docs/cli_parameters/config/disk_encryption.rst
+++ b/docs/cli_parameters/config/disk_encryption.rst
@@ -12,8 +12,13 @@ Disk encryption consists of a top level entry in the user configuration.
             "encryption_type": "luks",
             "partitions": [
                 "d712357f-97cc-40f8-a095-24ff244d4539"
-            ]
+            ],
+            "allow_discards": false
         }
    }
 
 The ``UID`` in the ``partitions`` list is an internal reference to the ``obj_id`` in the :ref:`disk config` entries.
+
+``allow_discards`` passes TRIM requests through to the underlying device, which is what lets an SSD reclaim blocks the filesystem has freed. The flag is written into the LUKS2 header when the device is created, so it applies to every later unlock without any extra kernel parameter.
+
+It is off by default: on an encrypted device the pattern of used and unused blocks becomes visible to anyone who can read the disk, which can give away the filesystem type and how full it is.

--- a/tests/test_disk_encryption.py
+++ b/tests/test_disk_encryption.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+from archinstall.lib.models.device import (
+	DiskEncryption,
+	DiskLayoutConfiguration,
+	DiskLayoutType,
+	EncryptionType,
+	FilesystemType,
+	LvmConfiguration,
+	LvmLayoutType,
+	LvmVolume,
+	LvmVolumeGroup,
+	ModificationStatus,
+	SectorSize,
+	Size,
+	Unit,
+)
+from archinstall.lib.models.users import Password
+
+
+def _disk_config() -> tuple[DiskLayoutConfiguration, str]:
+	volume = LvmVolume(
+		status=ModificationStatus.CREATE,
+		name='root',
+		fs_type=FilesystemType.EXT4,
+		length=Size(20, Unit.GiB, SectorSize.default()),
+		mountpoint=Path('/'),
+	)
+
+	disk_config = DiskLayoutConfiguration(
+		config_type=DiskLayoutType.Default,
+		lvm_config=LvmConfiguration(
+			config_type=LvmLayoutType.Default,
+			vol_groups=[LvmVolumeGroup(name='ArchinstallVg', pvs=[], volumes=[volume])],
+		),
+	)
+
+	return disk_config, volume.obj_id
+
+
+def test_allow_discards_defaults_to_off() -> None:
+	disk_config, vol_id = _disk_config()
+
+	enc = DiskEncryption.parse_arg(
+		disk_config,
+		{
+			'encryption_type': EncryptionType.LUKS_ON_LVM.value,
+			'partitions': [],
+			'lvm_volumes': [vol_id],
+		},
+		Password(enc_password='password_hash'),
+	)
+
+	assert enc is not None
+	assert enc.allow_discards is False
+	assert 'allow_discards' not in enc.json()
+
+
+def test_allow_discards_round_trip() -> None:
+	disk_config, vol_id = _disk_config()
+
+	enc = DiskEncryption.parse_arg(
+		disk_config,
+		{
+			'encryption_type': EncryptionType.LUKS_ON_LVM.value,
+			'partitions': [],
+			'lvm_volumes': [vol_id],
+			'allow_discards': True,
+		},
+		Password(enc_password='password_hash'),
+	)
+
+	assert enc is not None
+	assert enc.allow_discards is True
+	assert enc.json()['allow_discards'] is True


### PR DESCRIPTION
`enable_periodic_trim()` enables `fstrim.timer` on every install that isn't btrfs, but nothing in the tree ever sets `allow-discards`. dm-crypt drops discard requests by default, so on an encrypted root the timer fires every week and trims nothing. That's #897, open since 2022.

btrfs has the same problem from the other side: `fstrim.timer` is skipped there (#1837) because btrfs discards on its own since kernel 6.2, and those discards get dropped by dm-crypt too, with no timer to make up for it.

### Why the LUKS2 header and not a kernel parameter

The issue links the wiki, and the first thing you see there is `cryptdevice=...:allow-discards`. That's the [LUKS1 and plain dm-crypt](https://wiki.archlinux.org/title/Dm-crypt/Specialties#LUKS1_and_plain_dm-crypt) section. archinstall only ever creates LUKS2, `--type luks2` is hardcoded in `luks.py`, and for LUKS2 the wiki says:

> For a LUKS2 device, TRIM support can be enabled by using the `--allow-discards --persistent` options when opening it. The `allow-discards` flag will be written into the LUKS2 header and the option will be automatically used whenever the LUKS2 device is opened.

So the flag goes in once, when the device is created, and every later unlock picks it up: the `encrypt` hook, `sd-encrypt`, `/etc/crypttab`, `LVM_ON_LUKS` and `LUKS_ON_LVM`. Nothing to add to `_get_kernel_params_partition` or `_get_kernel_params_lvm`.

The wiki also notes that `--persistent` replaces the existing flags instead of adding to them. That doesn't bite here: this only runs right after `luksFormat`, on a header that has no other flags yet, and `_encrypt_partitions` only touches partitions that don't exist yet.

### The menu

A new entry at the bottom of the encryption menu, off by default:

<img width="654" height="124" alt="luks-menu" src="https://github.com/user-attachments/assets/99394635-cbe4-4510-b187-618302422bc3" />

Turning it on goes through a confirmation that says what you get and what you give up:

<img width="1060" height="174" alt="luks-confirm" src="https://github.com/user-attachments/assets/02820eba-a5ad-48fc-8c8c-6f43001a9a32" />

dm-crypt refuses discards for a reason. On an encrypted device the pattern of used and unused blocks becomes visible to anyone who can read the disk, which gives away the filesystem type and roughly how full it is. That's a real tradeoff, so it should be a choice rather than a default. In a config file it's `"allow_discards": true` under `disk_encryption`.

### Testing

`ruff`, `flake8`, `mypy --strict` and `pylint` are clean on each commit on its own, and `locales_generator.sh check` passes. `tests/test_disk_encryption.py` is new, there were no encryption tests before.

I also ran it end to end in QEMU, ext4 over LUKS2 with systemd-boot and the busybox `encrypt` hook, on a virtio disk with `discard=unmap`. The flag lands in the header, the mapping the initramfs opens has `allow_discards`, `fstrim -v /` actually trims, and `/proc/cmdline` and `/etc/crypttab` stay clean. `systemd-cryptsetup` reads the same header flag, which covers the `sd-encrypt` path. With the option off, none of it happens.

`issue_discards` in `lvm.conf` and the `discard` mount option in fstab are separate layers with their own tradeoffs, so I left those alone.

Closes #897