### PR TITLE
Fix pre-commit mypy hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
     rev: v2.3.1
     hooks:
     - id: mypy
+      pass_filenames: false
       args: [
         '--config-file=pyproject.toml'
       ]


### PR DESCRIPTION
Addresses https://github.com/archlinux/archinstall/pull/4735#issuecomment-5468162240

Do not pass filenames to mypy because they will override the `files` config option in `pyproject.toml`.

Reference:

https://pre-commit.com/#hooks-pass_filenames
