### PR TITLE
Handle active swap on existing partitions

### DIFF
--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -13,6 +13,7 @@ from archinstall.lib.disk.utils import (
 	get_lsblk_info,
 	linux_root_guid,
 	mount,
+	swapoff,
 	udev_sync,
 	umount,
 )
@@ -513,6 +514,11 @@ class DeviceHandler:
 			# un-mount for existing encrypted partitions
 			if partition.fs_type == FilesystemType.CRYPTO_LUKS:
 				Luks2(partition.path).lock()
+			elif partition.fs_type == FilesystemType.LINUX_SWAP:
+				# Swap is not mounted at a folder, so there is nothing to
+				# unmount. It has to be switched off, or the partition stays
+				# busy and the disk cannot be repartitioned.
+				swapoff(partition.path)
 			else:
 				umount(partition.path, recursive=True)
 

--- a/archinstall/lib/disk/device_handler.py
+++ b/archinstall/lib/disk/device_handler.py
@@ -515,9 +515,6 @@ class DeviceHandler:
 			if partition.fs_type == FilesystemType.CRYPTO_LUKS:
 				Luks2(partition.path).lock()
 			elif partition.fs_type == FilesystemType.LINUX_SWAP:
-				# Swap is not mounted at a folder, so there is nothing to
-				# unmount. It has to be switched off, or the partition stays
-				# busy and the disk cannot be repartitioned.
 				swapoff(partition.path)
 			else:
 				umount(partition.path, recursive=True)

--- a/archinstall/lib/disk/utils.py
+++ b/archinstall/lib/disk/utils.py
@@ -198,6 +198,34 @@ def swapon(path: Path) -> None:
 		raise DiskError(f'Could not enable swap {path}:\n{err.message}')
 
 
+def _active_swap_areas() -> set[Path]:
+	# Ask swapon what is being used as swap right now. That can be a partition,
+	# an encrypted or LVM device, or an ordinary file, so these are not always
+	# devices. The paths are resolved because swap can be switched on through a
+	# link such as /dev/disk/by-uuid/..., while swapon reports what it points at.
+	try:
+		output = SysCommand(['swapon', '--show=NAME', '--noheadings', '--raw']).decode()
+	except SysCallError as err:
+		raise DiskError(f'Could not read the active swap areas:\n{err.message}')
+
+	return {Path(line).resolve() for line in output.splitlines() if line}
+
+
+def swapoff(path: Path) -> None:
+	# swapoff fails if it is pointed at something that is not currently being
+	# used as swap, so check first. That also makes this safe to call on a
+	# partition whose swap is already off: it simply does nothing.
+	if path.resolve() not in _active_swap_areas():
+		return
+
+	debug(f'Disabling swap: {path}')
+
+	try:
+		SysCommand(['swapoff', str(path)])
+	except SysCallError as err:
+		raise DiskError(f'Could not disable swap {path}:\n{err.message}')
+
+
 def linux_root_guid(arch: str | None) -> PartitionGUID:
 	if arch == 'aarch64':
 		return PartitionGUID.LINUX_ROOT_AARCH64

--- a/archinstall/lib/disk/utils.py
+++ b/archinstall/lib/disk/utils.py
@@ -1,3 +1,5 @@
+from codecs import escape_decode
+from os import fsdecode
 from pathlib import Path
 from subprocess import CalledProcessError
 
@@ -198,25 +200,13 @@ def swapon(path: Path) -> None:
 		raise DiskError(f'Could not enable swap {path}:\n{err.message}')
 
 
-def _active_swap_areas() -> set[Path]:
-	# swapon includes swap files; lsblk only handles block devices.
-	try:
-		output = SysCommand(['swapon', '--show=NAME', '--noheadings', '--raw']).decode()
-	except SysCallError as err:
-		raise DiskError(f'Could not read the active swap areas:\n{err.message}')
-
-	return {Path(line).resolve() for line in output.splitlines() if line}
-
-
 def swapoff(path: Path) -> None:
-	# swapoff rejects inactive areas; resolve aliases before checking.
-	if path.resolve() not in _active_swap_areas():
-		return
-
-	debug(f'Disabling swap: {path}')
-
 	try:
-		SysCommand(['swapoff', str(path)])
+		output = SysCommand(['swapon', '--show=NAME', '--noheadings', '--raw']).output()
+		# --raw escapes filename bytes as \xNN.
+		active = {Path(fsdecode(escape_decode(line)[0])).resolve() for line in output.splitlines()}
+		if path.resolve() in active:
+			SysCommand(['swapoff', str(path)])
 	except SysCallError as err:
 		raise DiskError(f'Could not disable swap {path}:\n{err.message}')
 

--- a/archinstall/lib/disk/utils.py
+++ b/archinstall/lib/disk/utils.py
@@ -199,10 +199,7 @@ def swapon(path: Path) -> None:
 
 
 def _active_swap_areas() -> set[Path]:
-	# Ask swapon what is being used as swap right now. That can be a partition,
-	# an encrypted or LVM device, or an ordinary file, so these are not always
-	# devices. The paths are resolved because swap can be switched on through a
-	# link such as /dev/disk/by-uuid/..., while swapon reports what it points at.
+	# swapon includes swap files; lsblk only handles block devices.
 	try:
 		output = SysCommand(['swapon', '--show=NAME', '--noheadings', '--raw']).decode()
 	except SysCallError as err:
@@ -212,9 +209,7 @@ def _active_swap_areas() -> set[Path]:
 
 
 def swapoff(path: Path) -> None:
-	# swapoff fails if it is pointed at something that is not currently being
-	# used as swap, so check first. That also makes this safe to call on a
-	# partition whose swap is already off: it simply does nothing.
+	# swapoff rejects inactive areas; resolve aliases before checking.
 	if path.resolve() not in _active_swap_areas():
 		return
 

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -19,6 +19,9 @@ from archinstall.lib.translationhandler import tr
 ENC_IDENTIFIER = 'ainst'
 DEFAULT_ITER_TIME = 10000
 
+# What lsblk prints instead of a mountpoint when a partition is in use as swap
+SWAP_MOUNTPOINT = '[SWAP]'
+
 
 class DiskLayoutType(Enum):
 	Default = 'default_layout'
@@ -1631,11 +1634,20 @@ class LsblkInfo(BaseModel):
 			return Size(value, Unit.B, sector_size)
 		return value
 
+	@field_validator('mountpoint', mode='before')
+	@classmethod
+	def remove_swap_mountpoint(cls, value: Any) -> Any:
+		# '[SWAP]' is lsblk saying the partition is in use as swap. It is not a
+		# folder anything is mounted at, so it must not become one.
+		if value == SWAP_MOUNTPOINT:
+			return None
+		return value
+
 	@field_validator('mountpoints', 'fsroots', mode='before')
 	@classmethod
-	def remove_none(cls, value: Any) -> Any:
+	def remove_non_paths(cls, value: Any) -> Any:
 		if isinstance(value, list):
-			return [item for item in value if item is not None]
+			return [item for item in value if item is not None and item != SWAP_MOUNTPOINT]
 		return value
 
 	@field_serializer('size', when_used='json')

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -1637,8 +1637,6 @@ class LsblkInfo(BaseModel):
 	@field_validator('mountpoint', mode='before')
 	@classmethod
 	def remove_swap_mountpoint(cls, value: Any) -> Any:
-		# '[SWAP]' is lsblk saying the partition is in use as swap. It is not a
-		# folder anything is mounted at, so it must not become one.
 		if value == SWAP_MOUNTPOINT:
 			return None
 		return value

--- a/archinstall/lib/models/device.py
+++ b/archinstall/lib/models/device.py
@@ -19,9 +19,6 @@ from archinstall.lib.translationhandler import tr
 ENC_IDENTIFIER = 'ainst'
 DEFAULT_ITER_TIME = 10000
 
-# What lsblk prints instead of a mountpoint when a partition is in use as swap
-SWAP_MOUNTPOINT = '[SWAP]'
-
 
 class DiskLayoutType(Enum):
 	Default = 'default_layout'
@@ -1634,18 +1631,20 @@ class LsblkInfo(BaseModel):
 			return Size(value, Unit.B, sector_size)
 		return value
 
-	@field_validator('mountpoint', mode='before')
+	@field_validator('mountpoint', 'mountpoints', mode='before')
 	@classmethod
-	def remove_swap_mountpoint(cls, value: Any) -> Any:
-		if value == SWAP_MOUNTPOINT:
+	def remove_swap_mountpoints(cls, value: Any) -> Any:
+		if value == '[SWAP]':
 			return None
+		if isinstance(value, list):
+			return [item for item in value if item != '[SWAP]']
 		return value
 
 	@field_validator('mountpoints', 'fsroots', mode='before')
 	@classmethod
-	def remove_non_paths(cls, value: Any) -> Any:
+	def remove_none(cls, value: Any) -> Any:
 		if isinstance(value, list):
-			return [item for item in value if item is not None and item != SWAP_MOUNTPOINT]
+			return [item for item in value if item is not None]
 		return value
 
 	@field_serializer('size', when_used='json')

--- a/tests/test_lsblk_swap.py
+++ b/tests/test_lsblk_swap.py
@@ -1,6 +1,11 @@
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+from archinstall.lib.disk import utils
+from archinstall.lib.exceptions import DiskError, SysCallError
 from archinstall.lib.models.device import LsblkInfo
 
 # One entry from `lsblk --json --bytes`, using the columns archinstall asks for.
@@ -28,8 +33,27 @@ SAMPLE_PARTITION: dict[str, Any] = {
 	'fsroots': [],
 }
 
+SWAPON_QUERY = ['swapon', '--show=NAME', '--noheadings', '--raw']
+SWAPON_OUTPUT = '/dev/sda2\n/swapfile\n'
+
+
 def _lsblk_info(**overrides: Any) -> LsblkInfo:
 	return LsblkInfo.model_validate(SAMPLE_PARTITION | overrides)
+
+
+def _fake_syscommand(commands: list[list[str]], swapon_output: str = SWAPON_OUTPUT) -> Callable[[list[str]], Any]:
+	class _Result:
+		def __init__(self, output: str) -> None:
+			self._output = output
+
+		def decode(self) -> str:
+			return self._output
+
+	def _run(cmd: list[str]) -> _Result:
+		commands.append(cmd)
+		return _Result(swapon_output if cmd[0] == 'swapon' else '')
+
+	return _run
 
 
 def test_active_swap_mountpoint_is_not_parsed_as_a_path() -> None:
@@ -65,3 +89,66 @@ def test_a_mountpoint_containing_brackets_is_kept() -> None:
 
 	assert info.mountpoint == Path('/mnt/[backup]')
 	assert info.mountpoints == [Path('/mnt/[backup]')]
+
+
+def test_swapoff_does_nothing_when_the_path_is_not_active(monkeypatch: pytest.MonkeyPatch) -> None:
+	commands: list[list[str]] = []
+	monkeypatch.setattr(utils, 'SysCommand', _fake_syscommand(commands))
+
+	utils.swapoff(Path('/dev/sdb1'))
+
+	# The list of active swap is checked, and nothing is switched off.
+	assert commands == [SWAPON_QUERY]
+
+
+def test_swapoff_disables_an_active_swap_area(monkeypatch: pytest.MonkeyPatch) -> None:
+	commands: list[list[str]] = []
+	monkeypatch.setattr(utils, 'SysCommand', _fake_syscommand(commands))
+
+	utils.swapoff(Path('/dev/sda2'))
+
+	assert commands == [SWAPON_QUERY, ['swapoff', '/dev/sda2']]
+
+
+def test_swapoff_matches_an_active_area_reached_through_a_symlink(
+	monkeypatch: pytest.MonkeyPatch,
+	tmp_path: Path,
+) -> None:
+	# Swap can be switched on through a link like /dev/disk/by-uuid/... while
+	# swapon reports the device it points at, so both have to be compared in the
+	# same form.
+	device = tmp_path / 'sda2'
+	device.touch()
+	link = tmp_path / 'by-uuid'
+	link.symlink_to(device)
+
+	commands: list[list[str]] = []
+	monkeypatch.setattr(utils, 'SysCommand', _fake_syscommand(commands, f'{device}\n'))
+
+	utils.swapoff(link)
+
+	assert commands == [SWAPON_QUERY, ['swapoff', str(link)]]
+
+
+def test_a_failed_swap_query_is_raised_as_a_disk_error(monkeypatch: pytest.MonkeyPatch) -> None:
+	# If we cannot find out what is in use, we cannot know it is safe to skip,
+	# so this has to fail rather than quietly do nothing.
+	def _run(cmd: list[str]) -> Any:
+		raise SysCallError('swapon failed', exit_code=1)
+
+	monkeypatch.setattr(utils, 'SysCommand', _run)
+
+	with pytest.raises(DiskError):
+		utils.swapoff(Path('/dev/sda2'))
+
+
+def test_swapoff_failure_is_raised_as_a_disk_error(monkeypatch: pytest.MonkeyPatch) -> None:
+	def _run(cmd: list[str]) -> Any:
+		if cmd[0] == 'swapoff':
+			raise SysCallError('swapoff failed', exit_code=255)
+		return _fake_syscommand([])(cmd)
+
+	monkeypatch.setattr(utils, 'SysCommand', _run)
+
+	with pytest.raises(DiskError):
+		utils.swapoff(Path('/dev/sda2'))

--- a/tests/test_lsblk_swap.py
+++ b/tests/test_lsblk_swap.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from typing import Any
+
+from archinstall.lib.models.device import LsblkInfo
+
+# One entry from `lsblk --json --bytes`, using the columns archinstall asks for.
+SAMPLE_PARTITION: dict[str, Any] = {
+	'name': 'sda2',
+	'path': '/dev/sda2',
+	'pkname': 'sda',
+	'log-sec': 512,
+	'size': 4294967296,
+	'pttype': 'gpt',
+	'ptuuid': '5f1e1b8a',
+	'rota': True,
+	'tran': 'sata',
+	'partn': 2,
+	'partuuid': '0d2a1f7c',
+	'parttype': '0657fd6d-a4ab-43c4-84e5-0933c84b4f4f',
+	'uuid': 'e3c9b4a1',
+	'fstype': 'swap',
+	'fsver': '1',
+	'fsavail': None,
+	'fsuse%': None,
+	'type': 'part',
+	'mountpoint': None,
+	'mountpoints': [None],
+	'fsroots': [],
+}
+
+def _lsblk_info(**overrides: Any) -> LsblkInfo:
+	return LsblkInfo.model_validate(SAMPLE_PARTITION | overrides)
+
+
+def test_active_swap_mountpoint_is_not_parsed_as_a_path() -> None:
+	info = _lsblk_info(mountpoint='[SWAP]', mountpoints=['[SWAP]'])
+
+	assert info.mountpoint is None
+	assert info.mountpoints == []
+
+
+def test_sentinel_is_removed_from_each_field_independently() -> None:
+	assert _lsblk_info(mountpoint='[SWAP]', mountpoints=[None]).mountpoint is None
+	assert _lsblk_info(mountpoint=None, mountpoints=['[SWAP]']).mountpoints == []
+
+
+def test_inactive_swap_has_no_mountpoints() -> None:
+	info = _lsblk_info()
+
+	assert info.mountpoint is None
+	assert info.mountpoints == []
+
+
+def test_regular_mountpoints_are_untouched() -> None:
+	info = _lsblk_info(fstype='ext4', mountpoint='/home', mountpoints=['/home'])
+
+	assert info.mountpoint == Path('/home')
+	assert info.mountpoints == [Path('/home')]
+
+
+def test_a_mountpoint_containing_brackets_is_kept() -> None:
+	# Only that exact string is dropped. '[SWAP]' is the only thing lsblk ever
+	# puts in brackets, and a real folder is allowed brackets in its name.
+	info = _lsblk_info(fstype='ext4', mountpoint='/mnt/[backup]', mountpoints=['/mnt/[backup]'])
+
+	assert info.mountpoint == Path('/mnt/[backup]')
+	assert info.mountpoints == [Path('/mnt/[backup]')]

--- a/tests/test_lsblk_swap.py
+++ b/tests/test_lsblk_swap.py
@@ -8,7 +8,6 @@ from archinstall.lib.disk import utils
 from archinstall.lib.exceptions import DiskError, SysCallError
 from archinstall.lib.models.device import LsblkInfo
 
-# One entry from `lsblk --json --bytes`, using the columns archinstall asks for.
 SAMPLE_PARTITION: dict[str, Any] = {
 	'name': 'sda2',
 	'path': '/dev/sda2',
@@ -83,8 +82,6 @@ def test_regular_mountpoints_are_untouched() -> None:
 
 
 def test_a_mountpoint_containing_brackets_is_kept() -> None:
-	# Only that exact string is dropped. '[SWAP]' is the only thing lsblk ever
-	# puts in brackets, and a real folder is allowed brackets in its name.
 	info = _lsblk_info(fstype='ext4', mountpoint='/mnt/[backup]', mountpoints=['/mnt/[backup]'])
 
 	assert info.mountpoint == Path('/mnt/[backup]')
@@ -97,7 +94,6 @@ def test_swapoff_does_nothing_when_the_path_is_not_active(monkeypatch: pytest.Mo
 
 	utils.swapoff(Path('/dev/sdb1'))
 
-	# The list of active swap is checked, and nothing is switched off.
 	assert commands == [SWAPON_QUERY]
 
 
@@ -114,9 +110,6 @@ def test_swapoff_matches_an_active_area_reached_through_a_symlink(
 	monkeypatch: pytest.MonkeyPatch,
 	tmp_path: Path,
 ) -> None:
-	# Swap can be switched on through a link like /dev/disk/by-uuid/... while
-	# swapon reports the device it points at, so both have to be compared in the
-	# same form.
 	device = tmp_path / 'sda2'
 	device.touch()
 	link = tmp_path / 'by-uuid'
@@ -131,8 +124,6 @@ def test_swapoff_matches_an_active_area_reached_through_a_symlink(
 
 
 def test_a_failed_swap_query_is_raised_as_a_disk_error(monkeypatch: pytest.MonkeyPatch) -> None:
-	# If we cannot find out what is in use, we cannot know it is safe to skip,
-	# so this has to fail rather than quietly do nothing.
 	def _run(cmd: list[str]) -> Any:
 		raise SysCallError('swapon failed', exit_code=1)
 

--- a/tests/test_lsblk_swap.py
+++ b/tests/test_lsblk_swap.py
@@ -1,12 +1,14 @@
-from collections.abc import Callable
+from os import fsdecode, fsencode
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock, call
 
 import pytest
 
 from archinstall.lib.disk import utils
 from archinstall.lib.exceptions import DiskError, SysCallError
-from archinstall.lib.models.device import LsblkInfo
+from archinstall.lib.log import logger
+from archinstall.lib.models.device import FilesystemType, LsblkInfo
 
 SAMPLE_PARTITION: dict[str, Any] = {
 	'name': 'sda2',
@@ -33,113 +35,100 @@ SAMPLE_PARTITION: dict[str, Any] = {
 }
 
 SWAPON_QUERY = ['swapon', '--show=NAME', '--noheadings', '--raw']
-SWAPON_OUTPUT = '/dev/sda2\n/swapfile\n'
 
 
-def _lsblk_info(**overrides: Any) -> LsblkInfo:
-	return LsblkInfo.model_validate(SAMPLE_PARTITION | overrides)
+@pytest.mark.parametrize(
+	('mountpoint', 'mountpoints', 'expected'),
+	[
+		('[SWAP]', ['[SWAP]'], (None, [])),
+		('[SWAP]', [None], (None, [])),
+		(None, ['[SWAP]'], (None, [])),
+		(None, [None], (None, [])),
+		('/home', ['/home', None], (Path('/home'), [Path('/home')])),
+		('/mnt/[SWAP]', ['/mnt/[SWAP]'], (Path('/mnt/[SWAP]'), [Path('/mnt/[SWAP]')])),
+	],
+)
+def test_swap_mountpoints(mountpoint: str | None, mountpoints: list[str | None], expected: tuple[Path | None, list[Path]]) -> None:
+	info = LsblkInfo.model_validate(SAMPLE_PARTITION | {'mountpoint': mountpoint, 'mountpoints': mountpoints})
+	assert (info.mountpoint, info.mountpoints) == expected
 
 
-def _fake_syscommand(commands: list[list[str]], swapon_output: str = SWAPON_OUTPUT) -> Callable[[list[str]], Any]:
-	class _Result:
-		def __init__(self, output: str) -> None:
-			self._output = output
-
-		def decode(self) -> str:
-			return self._output
-
-	def _run(cmd: list[str]) -> _Result:
-		commands.append(cmd)
-		return _Result(swapon_output if cmd[0] == 'swapon' else '')
-
-	return _run
-
-
-def test_active_swap_mountpoint_is_not_parsed_as_a_path() -> None:
-	info = _lsblk_info(mountpoint='[SWAP]', mountpoints=['[SWAP]'])
-
-	assert info.mountpoint is None
-	assert info.mountpoints == []
-
-
-def test_sentinel_is_removed_from_each_field_independently() -> None:
-	assert _lsblk_info(mountpoint='[SWAP]', mountpoints=[None]).mountpoint is None
-	assert _lsblk_info(mountpoint=None, mountpoints=['[SWAP]']).mountpoints == []
-
-
-def test_inactive_swap_has_no_mountpoints() -> None:
-	info = _lsblk_info()
-
-	assert info.mountpoint is None
-	assert info.mountpoints == []
-
-
-def test_regular_mountpoints_are_untouched() -> None:
-	info = _lsblk_info(fstype='ext4', mountpoint='/home', mountpoints=['/home'])
-
-	assert info.mountpoint == Path('/home')
-	assert info.mountpoints == [Path('/home')]
-
-
-def test_a_mountpoint_containing_brackets_is_kept() -> None:
-	info = _lsblk_info(fstype='ext4', mountpoint='/mnt/[backup]', mountpoints=['/mnt/[backup]'])
-
-	assert info.mountpoint == Path('/mnt/[backup]')
-	assert info.mountpoints == [Path('/mnt/[backup]')]
-
-
-def test_swapoff_does_nothing_when_the_path_is_not_active(monkeypatch: pytest.MonkeyPatch) -> None:
-	commands: list[list[str]] = []
-	monkeypatch.setattr(utils, 'SysCommand', _fake_syscommand(commands))
-
-	utils.swapoff(Path('/dev/sdb1'))
-
-	assert commands == [SWAPON_QUERY]
-
-
-def test_swapoff_disables_an_active_swap_area(monkeypatch: pytest.MonkeyPatch) -> None:
-	commands: list[list[str]] = []
-	monkeypatch.setattr(utils, 'SysCommand', _fake_syscommand(commands))
+@pytest.mark.parametrize('active', [False, True])
+def test_swapoff_only_disables_active_swap(monkeypatch: pytest.MonkeyPatch, active: bool) -> None:
+	command = Mock()
+	command.return_value.output.return_value = b'/dev/sda2\n' if active else b'/dev/sdb1\n'
+	monkeypatch.setattr(utils, 'SysCommand', command)
 
 	utils.swapoff(Path('/dev/sda2'))
 
-	assert commands == [SWAPON_QUERY, ['swapoff', '/dev/sda2']]
+	expected = [call(SWAPON_QUERY)]
+	if active:
+		expected.append(call(['swapoff', '/dev/sda2']))
+	assert command.call_args_list == expected
 
 
-def test_swapoff_matches_an_active_area_reached_through_a_symlink(
-	monkeypatch: pytest.MonkeyPatch,
-	tmp_path: Path,
-) -> None:
-	device = tmp_path / 'sda2'
+@pytest.mark.parametrize(
+	('name', 'encoded'),
+	[
+		('sda2', b'sda2'),
+		('swap file', b'swap\\x20file'),
+		('swap\nfile', b'swap\\x0afile'),
+		('swap\\x20file', b'swap\\x5cx20file'),
+		('swäp', 'swäp'.encode()),
+		(fsdecode(b'swap-\xff'), b'swap-\\xff'),
+	],
+)
+def test_swapoff_matches_escaped_paths_and_aliases(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, name: str, encoded: bytes) -> None:
+	device = tmp_path / name
 	device.touch()
-	link = tmp_path / 'by-uuid'
-	link.symlink_to(device)
+	alias = tmp_path / 'by-uuid'
+	alias.symlink_to(device)
+	command = Mock()
+	command.return_value.output.return_value = fsencode(tmp_path) + b'/' + encoded + b'\n'
+	monkeypatch.setattr(utils, 'SysCommand', command)
 
-	commands: list[list[str]] = []
-	monkeypatch.setattr(utils, 'SysCommand', _fake_syscommand(commands, f'{device}\n'))
+	utils.swapoff(alias)
 
-	utils.swapoff(link)
-
-	assert commands == [SWAPON_QUERY, ['swapoff', str(link)]]
+	assert command.call_args_list == [call(SWAPON_QUERY), call(['swapoff', str(alias)])]
 
 
-def test_a_failed_swap_query_is_raised_as_a_disk_error(monkeypatch: pytest.MonkeyPatch) -> None:
-	def _run(cmd: list[str]) -> Any:
-		raise SysCallError('swapon failed', exit_code=1)
+@pytest.mark.parametrize('query_fails', [False, True])
+def test_swapoff_errors(monkeypatch: pytest.MonkeyPatch, query_fails: bool) -> None:
+	result = Mock()
+	result.output.return_value = b'/dev/sda2\n'
+	error = SysCallError('command failed', exit_code=1)
+	command = Mock(side_effect=[error] if query_fails else [result, error])
+	monkeypatch.setattr(utils, 'SysCommand', command)
 
-	monkeypatch.setattr(utils, 'SysCommand', _run)
-
-	with pytest.raises(DiskError):
+	with pytest.raises(DiskError, match='Could not disable swap /dev/sda2:'):
 		utils.swapoff(Path('/dev/sda2'))
 
+	expected = [call(SWAPON_QUERY)]
+	if not query_fails:
+		expected.append(call(['swapoff', '/dev/sda2']))
+	assert command.call_args_list == expected
 
-def test_swapoff_failure_is_raised_as_a_disk_error(monkeypatch: pytest.MonkeyPatch) -> None:
-	def _run(cmd: list[str]) -> Any:
-		if cmd[0] == 'swapoff':
-			raise SysCallError('swapoff failed', exit_code=255)
-		return _fake_syscommand([])(cmd)
 
-	monkeypatch.setattr(utils, 'SysCommand', _run)
+def test_existing_partitions_disable_swap_and_unmount_filesystems(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+	monkeypatch.setattr(logger, '_path', tmp_path)
+	from archinstall.lib.disk.device_handler import DeviceHandler
 
-	with pytest.raises(DiskError):
-		utils.swapoff(Path('/dev/sda2'))
+	handler = DeviceHandler.__new__(DeviceHandler)
+	handler._devices = {
+		Path('/dev/sda'): Mock(
+			partition_infos=[
+				Mock(path=Path('/dev/sda1'), fs_type=FilesystemType.EXT4),
+				Mock(path=Path('/dev/sda2'), fs_type=FilesystemType.LINUX_SWAP),
+			]
+		),
+	}
+	command = Mock()
+	command.return_value.output.return_value = b'/dev/sda2\n'
+	monkeypatch.setattr(utils, 'SysCommand', command)
+	unmount = Mock()
+	monkeypatch.setattr('archinstall.lib.disk.device_handler.umount', unmount)
+
+	handler.umount_all_existing(Path('/dev/sda'))
+
+	unmount.assert_called_once_with(Path('/dev/sda1'), recursive=True)
+	assert command.call_args_list == [call(SWAPON_QUERY), call(['swapoff', '/dev/sda2'])]


### PR DESCRIPTION
The installer is trying to unmount a directory called `[SWAP]`. That isn't a real mountpoint; it's how `lsblk` marks active swap.

This filters that marker out and turns off active swap partitions on the selected disk before repartitioning.

Fixes #4235.
