### PR TITLE
Fix archiso workflow

### DIFF
--- a/test_tooling/mkarchiso/build_iso.sh
+++ b/test_tooling/mkarchiso/build_iso.sh
@@ -40,7 +40,7 @@ pacman --noconfirm -S archiso
 
 cp -r /usr/share/archiso/configs/releng/* /tmp/archlive
 
-sed -i /archinstall/d "$packages_file"
+sed -i -e /archinstall/d -e /broadcom-wl/d "$packages_file"
 
 # Add packages to the archiso profile packages
 for package in "${packages[@]}"; do


### PR DESCRIPTION
This is a temporary fix to address https://github.com/archlinux/archinstall/pull/4744#issuecomment-5478368460

If this is merged it should be reverted if either:

- a new release of `archiso` is made and in the repos that has `broadcom-wl` removed from `configs/releng/packages.x86_64`
- `broadcom-wl` is added back to the repos
