### PR TITLE
chore(installer): remove wait `reflector.service`

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -182,7 +182,6 @@ class Installer:
 	def _verify_service_stop(self, offline: bool, skip_ntp: bool, skip_wkd: bool) -> None:
 		"""
 		Certain services might be running that affects the system during installation.
-		One such service is "reflector.service" which updates /etc/pacman.d/mirrorlist
 		We need to wait for it before we continue since we opted in to use a custom mirror/region.
 		"""
 
@@ -202,17 +201,6 @@ class Installer:
 				time.sleep(1)
 		else:
 			info(tr('Skipping waiting for automatic time sync (this can cause issues if time is out of sync during installation)'))
-
-		if not offline:
-			info('Waiting for automatic mirror selection (reflector) to complete.')
-			for _ in range(60):
-				if self._service_state('reflector') in ('dead', 'failed', 'exited'):
-					break
-				time.sleep(1)
-			else:
-				warn('Reflector did not complete within 60 seconds, continuing anyway...')
-		else:
-			info('Skipped reflector...')
 
 		# info('Waiting for pacman-init.service to complete.')
 		# while self._service_state('pacman-init') not in ('dead', 'failed', 'exited'):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -179,10 +179,10 @@ class Installer:
 		if mod not in self._modules:
 			self._modules.append(mod)
 
-	def _verify_service_stop(self, offline: bool, skip_ntp: bool, skip_wkd: bool) -> None:
+	def _verify_service_stop(self, skip_ntp: bool, skip_wkd: bool) -> None:
 		"""
 		Certain services might be running that affects the system during installation.
-		We need to wait for it before we continue since we opted in to use a custom mirror/region.
+		We need to wait for them, to make sure ISO has no boot defects before install.
 		"""
 
 		if not skip_ntp:
@@ -244,7 +244,7 @@ class Installer:
 		skip_wkd: bool = False,
 	) -> None:
 		# self._verify_boot_part()
-		self._verify_service_stop(offline, skip_ntp, skip_wkd)
+		self._verify_service_stop(skip_ntp, skip_wkd)
 
 	def mount_ordered_layout(self) -> None:
 		debug('Mounting ordered layout')


### PR DESCRIPTION
Releng `archiso` no longer ships this service

`offline` remains used for other operations

Additional details in commits.