### PR TITLE
Revert "Fix archiso workflow (#4748)"

### DIFF
--- a/test_tooling/mkarchiso/build_iso.sh
+++ b/test_tooling/mkarchiso/build_iso.sh
@@ -40,7 +40,7 @@ pacman --noconfirm -S archiso
 
 cp -r /usr/share/archiso/configs/releng/* /tmp/archlive
 
-sed -i -e /archinstall/d -e /broadcom-wl/d "$packages_file"
+sed -i /archinstall/d "$packages_file"
 
 # Add packages to the archiso profile packages
 for package in "${packages[@]}"; do


### PR DESCRIPTION
This reverts commit cd078bc6da60971ebbbf4d6824968a4207c92866.

The archiso merge request has a link that shows the package was dropped.

https://gitlab.archlinux.org/archlinux/archiso/-/merge_requests/471
